### PR TITLE
fix: Event triggers

### DIFF
--- a/docs/2 - authentication.md
+++ b/docs/2 - authentication.md
@@ -97,7 +97,7 @@ if($result->isOK()) {
 }
 ```
 
-If the attempt fails a `failedLoginAttempt` event is triggered with the credentials array as 
+If the attempt fails a `failedLogin` event is triggered with the credentials array as 
 the only parameter. Whether or not they pass, a login attempt is recorded in the `auth_logins` table.
 
 If `allowRemembering` is `true` in the `Auth` config file, you can tell the Session authenticator

--- a/docs/5 - events.md
+++ b/docs/5 - events.md
@@ -18,14 +18,14 @@ Events::trigger('didRegister', $user);
 Events::on('didRegister', 'SomeLibrary::handleRegister');
 ```
 
-#### didLogin
+#### login
 
 Fired immediately after a successful login. The only argument is the `User` entity.
 
 ```php
-Events::trigger('didLogin', $user);
+Events::trigger('login', $user);
 
-Events::on('didLogin', 'SomeLibrary::handleLogin');
+Events::on('login', 'SomeLibrary::handleLogin');
 ```
 
 #### failedLogin
@@ -42,6 +42,9 @@ Events::on('failedLogin', function($credentials) {
 });
 
 // Outputs:
-
 ['email' => 'foo@example.com'];
 ```
+
+#### logout
+
+Fired immediately after a successful logout. The only argument is the `User` entity.

--- a/docs/5 - events.md
+++ b/docs/5 - events.md
@@ -8,14 +8,14 @@ When you want to respond to an event that Shield publishes, you will need to add
 
 ## Event List
 
-#### didRegister
+#### register
 
 Triggered when a new user has registered in the system. It's only argument is the `User` entity itself.
 
 ```php
-Events::trigger('didRegister', $user);
+Events::trigger('register', $user);
 
-Events::on('didRegister', 'SomeLibrary::handleRegister');
+Events::on('register', 'SomeLibrary::handleRegister');
 ```
 
 #### login

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -12,14 +12,14 @@ use CodeIgniter\Shield\Models\UserModel;
 /**
  * @method Result    attempt(array $credentials)
  * @method Result    check(array $credentials)
- * @method bool      checkAction(string $token)            [Session]
+ * @method bool      checkAction(string $token, string $type) [Session]
  * @method User|null getUser()
  * @method bool      loggedIn()
  * @method bool      login(User $user)
  * @method void      loginById($userId)
  * @method bool      logout()
  * @method void      recordActiveDate()
- * @method $this     remember(bool $shouldRemember = true) [Session]
+ * @method $this     remember(bool $shouldRemember = true)    [Session]
  */
 class Auth
 {

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -10,6 +10,7 @@ use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\UserModel;
 
 /**
+ * @method void      activateUser(User $user)                 [Session]
  * @method Result    attempt(array $credentials)
  * @method Result    check(array $credentials)
  * @method bool      checkAction(string $token, string $type) [Session]

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -10,19 +10,16 @@ use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\UserModel;
 
 /**
- * AuthenticatorInterface:
- *
  * @method Result    attempt(array $credentials)
  * @method Result    check(array $credentials)
+ * @method bool      checkAction(string $token)            [Session]
  * @method User|null getUser()
  * @method bool      loggedIn()
  * @method bool      login(User $user)
  * @method void      loginById($userId)
  * @method bool      logout()
  * @method void      recordActiveDate()
- *
- * Authenticators\Session:
- * @method $this remember(bool $shouldRemember = true)
+ * @method $this     remember(bool $shouldRemember = true) [Session]
  */
 class Auth
 {

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -97,7 +97,7 @@ class Email2FA implements ActionInterface
         $token = $request->getPost('token');
 
         // Token mismatch? Let them try again...
-        if (! auth()->checkAction($token)) {
+        if (! auth()->checkAction('email_2fa', $token)) {
             session()->setFlashdata('error', lang('Auth.invalid2FAToken'));
 
             return view(setting('Auth.views')['action_email_2fa_verify']);

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -4,6 +4,7 @@ namespace CodeIgniter\Shield\Authentication\Actions;
 
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
 use CodeIgniter\Shield\Models\UserIdentityModel;
 
@@ -96,8 +97,11 @@ class Email2FA implements ActionInterface
     {
         $token = $request->getPost('token');
 
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
         // Token mismatch? Let them try again...
-        if (! auth()->checkAction('email_2fa', $token)) {
+        if (! $authenticator->checkAction('email_2fa', $token)) {
             session()->setFlashdata('error', lang('Auth.invalid2FAToken'));
 
             return view(setting('Auth.views')['action_email_2fa_verify']);

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -2,7 +2,6 @@
 
 namespace CodeIgniter\Shield\Authentication\Actions;
 
-use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
@@ -95,28 +94,14 @@ class Email2FA implements ActionInterface
      */
     public function verify(IncomingRequest $request)
     {
-        $token    = $request->getPost('token');
-        $user     = auth()->user();
-        $identity = $user->getIdentity('email_2fa');
+        $token = $request->getPost('token');
 
         // Token mismatch? Let them try again...
-        if (empty($token) || $token !== $identity->secret) {
+        if (! auth()->checkAction($token)) {
             session()->setFlashdata('error', lang('Auth.invalid2FAToken'));
 
             return view(setting('Auth.views')['action_email_2fa_verify']);
         }
-
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
-        // On success - remove the identity and clean up session
-        $identityModel->deleteIdentitiesByType($user->getAuthId(), 'email_2fa');
-
-        // Clean up our session
-        session()->remove('auth_action');
-
-        // a successful login
-        Events::trigger('login', $user);
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -2,6 +2,7 @@
 
 namespace CodeIgniter\Shield\Authentication\Actions;
 
+use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
@@ -113,6 +114,9 @@ class Email2FA implements ActionInterface
 
         // Clean up our session
         session()->remove('auth_action');
+
+        // a successful login
+        Events::trigger('login', $user);
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -81,30 +81,21 @@ class EmailActivator implements ActionInterface
      */
     public function verify(IncomingRequest $request)
     {
-        $token    = $request->getVar('token');
-        $user     = auth()->user();
-        $identity = $user->getIdentity('email_activate');
+        $token = $request->getVar('token');
 
         // No match - let them try again.
-        if ($identity->secret !== $token) {
+        if (! auth()->checkAction('email_activate', $token)) {
             session()->setFlashdata('error', lang('Auth.invalidActivateToken'));
 
             return view(setting('Auth.views')['action_email_activate_show']);
         }
 
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
-        // Remove the identity
-        $identityModel->delete($identity->id);
+        $user = auth()->user();
 
         // Set the user active now
         $provider     = auth()->getProvider();
         $user->active = true;
         $provider->save($user);
-
-        // Clean up our session
-        unset($_SESSION['auth_action']);
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -5,6 +5,7 @@ namespace CodeIgniter\Shield\Authentication\Actions;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
@@ -84,18 +85,23 @@ class EmailActivator implements ActionInterface
     {
         $token = $request->getVar('token');
 
+        $auth = auth('session');
+
+        /** @var Session $authenticator */
+        $authenticator = $auth->getAuthenticator();
+
         // No match - let them try again.
-        if (! auth()->checkAction('email_activate', $token)) {
+        if (! $authenticator->checkAction('email_activate', $token)) {
             session()->setFlashdata('error', lang('Auth.invalidActivateToken'));
 
             return view(setting('Auth.views')['action_email_activate_show']);
         }
 
         /** @var User $user */
-        $user = auth()->user();
+        $user = $auth->user();
 
         // Set the user active now
-        auth()->activateUser($user);
+        $auth->activateUser($user);
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -5,6 +5,7 @@ namespace CodeIgniter\Shield\Authentication\Actions;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
 use CodeIgniter\Shield\Models\UserIdentityModel;
@@ -90,12 +91,11 @@ class EmailActivator implements ActionInterface
             return view(setting('Auth.views')['action_email_activate_show']);
         }
 
+        /** @var User $user */
         $user = auth()->user();
 
         // Set the user active now
-        $provider     = auth()->getProvider();
-        $user->active = true;
-        $provider->save($user);
+        auth()->activateUser($user);
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());

--- a/src/Authentication/AuthenticatorInterface.php
+++ b/src/Authentication/AuthenticatorInterface.php
@@ -32,7 +32,7 @@ interface AuthenticatorInterface
      *
      * @see https://codeigniter4.github.io/CodeIgniter4/extending/authentication.html
      */
-    public function login(User $user): bool;
+    public function login(User $user): void;
 
     /**
      * Logs a user in based on their ID.

--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -141,11 +141,9 @@ class AccessTokens implements AuthenticatorInterface
     /**
      * Logs the given user in by saving them to the class.
      */
-    public function login(User $user): bool
+    public function login(User $user): void
     {
         $this->user = $user;
-
-        return true;
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -27,14 +27,17 @@ class Session implements AuthenticatorInterface
      */
     protected UserModel $provider;
 
+    /**
+     * The user logged in
+     */
     protected ?User $user = null;
-    protected LoginModel $loginModel;
 
     /**
      * Should the user be remembered?
      */
     protected bool $shouldRemember = false;
 
+    protected LoginModel $loginModel;
     protected RememberModel $rememberModel;
 
     public function __construct(UserModel $provider)

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -78,6 +78,7 @@ class Session implements AuthenticatorInterface
 
             // Fire an event on failure so devs have the chance to
             // let them know someone attempted to login to their account
+            unset($credentials['password']);
             Events::trigger('failedLoginAttempt', $credentials);
 
             return $result;

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -106,6 +106,8 @@ class Session implements AuthenticatorInterface
     }
 
     /**
+     * Check token in Action
+     *
      * @param string $type  Action type. 'email_2fa' or 'email_activate'
      * @param string $token Token to check
      */
@@ -134,6 +136,14 @@ class Session implements AuthenticatorInterface
         Events::trigger('login', $user);
 
         return true;
+    }
+
+    /**
+     * Activate a User
+     */
+    public function activateUser(User $user): void
+    {
+        $this->provider->activate($user);
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -126,7 +126,7 @@ class Session implements AuthenticatorInterface
 
         // Remove the password from credentials so we can
         // check afterword.
-        $givenPassword = $credentials['password'] ?? null;
+        $givenPassword = $credentials['password'];
         unset($credentials['password']);
 
         // Find the existing user

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -79,7 +79,7 @@ class Session implements AuthenticatorInterface
             // Fire an event on failure so devs have the chance to
             // let them know someone attempted to login to their account
             unset($credentials['password']);
-            Events::trigger('failedLoginAttempt', $credentials);
+            Events::trigger('failedLogin', $credentials);
 
             return $result;
         }

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -315,7 +315,7 @@ class Session implements AuthenticatorInterface
     private function startLogin(User $user): void
     {
         // Update the user's last used date on their password identity.
-        $this->user->touchIdentity($this->user->getEmailIdentity());
+        $user->touchIdentity($user->getEmailIdentity());
 
         // Regenerate the session ID to help protect against session fixation
         if (ENVIRONMENT !== 'testing') {
@@ -323,7 +323,7 @@ class Session implements AuthenticatorInterface
         }
 
         // Let the session know we're logged in
-        session()->set(setting('Auth.sessionConfig')['field'], $this->user->getAuthId());
+        session()->set(setting('Auth.sessionConfig')['field'], $user->getAuthId());
 
         /** @var Response $response */
         $response = service('response');

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -105,13 +105,17 @@ class Session implements AuthenticatorInterface
         return $result;
     }
 
-    public function checkAction(string $token): bool
+    /**
+     * @param string $type  Action type. 'email_2fa' or 'email_activate'
+     * @param string $token Token to check
+     */
+    public function checkAction(string $type, string $token): bool
     {
         $user = $this->loggedIn()
             ? $this->getUser()
             : null;
 
-        $identity = $user->getIdentity('email_2fa');
+        $identity = $user->getIdentity($type);
 
         if (empty($token) || $token !== $identity->secret) {
             return false;
@@ -121,7 +125,7 @@ class Session implements AuthenticatorInterface
         $identityModel = model(UserIdentityModel::class);
 
         // On success - remove the identity and clean up session
-        $identityModel->deleteIdentitiesByType($user->getAuthId(), 'email_2fa');
+        $identityModel->deleteIdentitiesByType($user->getAuthId(), $type);
 
         // Clean up our session
         session()->remove('auth_action');

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -95,6 +95,9 @@ class Session implements AuthenticatorInterface
         $actionClass = setting('Auth.actions')['login'] ?? null;
         if (! empty($actionClass)) {
             session()->set('auth_action', $actionClass);
+        } else {
+            // a successful login
+            Events::trigger('login', $user);
         }
 
         return $result;

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -10,6 +10,7 @@ use CodeIgniter\Shield\Authentication\AuthenticationException;
 use CodeIgniter\Shield\Authentication\AuthenticatorInterface;
 use CodeIgniter\Shield\Authentication\Passwords;
 use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Models\LoginModel;
 use CodeIgniter\Shield\Models\RememberModel;
 use CodeIgniter\Shield\Models\UserIdentityModel;
@@ -113,9 +114,11 @@ class Session implements AuthenticatorInterface
      */
     public function checkAction(string $type, string $token): bool
     {
-        $user = $this->loggedIn()
-            ? $this->getUser()
-            : null;
+        $user = $this->loggedIn() ? $this->getUser() : null;
+
+        if ($user === null) {
+            throw new LogicException('Cannot get the User.');
+        }
 
         $identity = $user->getIdentity($type);
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -299,9 +299,6 @@ class Session implements AuthenticatorInterface
         if (random_int(1, 100) <= 20) {
             $this->rememberModel->purgeOldRememberTokens();
         }
-
-        // Trigger login event, in case anyone cares
-        return Events::trigger('login', $user);
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -58,6 +58,8 @@ class Session implements AuthenticatorInterface
     /**
      * Attempts to authenticate a user with the given $credentials.
      * Logs the user in with a successful check.
+     *
+     * @phpstan-param array{email?: string, username?: string, password?: string} $credentials
      */
     public function attempt(array $credentials): Result
     {
@@ -113,6 +115,8 @@ class Session implements AuthenticatorInterface
     /**
      * Checks a user's $credentials to see if they match an
      * existing user.
+     *
+     * @phpstan-param array{email?: string, username?: string, password?: string} $credentials
      */
     public function check(array $credentials): Result
     {

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -260,7 +260,7 @@ class Session implements AuthenticatorInterface
     /**
      * Logs the given user in.
      */
-    public function login(User $user): bool
+    public function login(User $user): void
     {
         $this->user = $user;
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -91,6 +91,12 @@ class Session implements AuthenticatorInterface
 
         $this->recordLoginAttempt($credentials, true, $ipAddress, $userAgent, $user->getAuthId());
 
+        // If an action has been defined for login, start it up.
+        $actionClass = setting('Auth.actions')['login'] ?? null;
+        if (! empty($actionClass)) {
+            session()->set('auth_action', $actionClass);
+        }
+
         return $result;
     }
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -138,6 +138,8 @@ class Session implements AuthenticatorInterface
         // Clean up our session
         session()->remove('auth_action');
 
+        $this->user = $user;
+
         // a successful login
         Events::trigger('login', $user);
 

--- a/src/Authentication/Traits/HasAccessTokens.php
+++ b/src/Authentication/Traits/HasAccessTokens.php
@@ -22,6 +22,9 @@ trait HasAccessTokens
 
     /**
      * Generates a new personal access token for this user.
+     *
+     * @param string   $name   Token name
+     * @param string[] $scopes Permissions the token grants
      */
     public function generateAccessToken(string $name, array $scopes = ['*']): AccessToken
     {

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -3,7 +3,6 @@
 namespace CodeIgniter\Shield\Controllers;
 
 use App\Controllers\BaseController;
-use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 
@@ -37,15 +36,10 @@ class LoginController extends BaseController
         // Attempt to login
         $result = auth('session')->remember($remember)->attempt($credentials);
         if (! $result->isOK()) {
-            unset($credentials['password'], $credentials['password_confirm']);
-            Events::trigger('failedLogin', $credentials);
-
             return redirect()->route('login')->withInput()->with('error', $result->reason());
         }
 
         $user = $result->extraInfo();
-
-        Events::trigger('didLogin', $user);
 
         // If an action has been defined for login, start it up.
         $actionClass = setting('Auth.actions')['login'] ?? null;

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -50,8 +50,6 @@ class LoginController extends BaseController
         // If an action has been defined for login, start it up.
         $actionClass = setting('Auth.actions')['login'] ?? null;
         if (! empty($actionClass)) {
-            session()->set('auth_action', $actionClass);
-
             return redirect()->to(route_to('auth-action-show'))->withCookies();
         }
 

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -78,7 +78,7 @@ class RegisterController extends BaseController
         // Add to default group
         $users->addToDefaultGroup($user);
 
-        Events::trigger('didRegister', $user);
+        Events::trigger('register', $user);
 
         auth()->login($user);
 

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -92,8 +92,7 @@ class RegisterController extends BaseController
         }
 
         // Set the user active
-        $user->active = true;
-        $users->save($user);
+        auth()->activateUser($user);
 
         // a successful login
         Events::trigger('login', $user);

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -95,6 +95,9 @@ class RegisterController extends BaseController
         $user->active = true;
         $users->save($user);
 
+        // a successful login
+        Events::trigger('login', $user);
+
         // Success!
         return redirect()->to(config('Auth')->registerRedirect())
             ->with('message', lang('Auth.registerSuccess'));

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -97,6 +97,8 @@ class User extends Entity
     /**
      * Creates a new identity for this user with an email/password
      * combination.
+     *
+     * @phpstan-param array{email: string, password: string} $credentials
      */
     public function createEmailIdentity(array $credentials): void
     {

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -48,7 +48,7 @@ class User extends Entity
     /**
      * Returns the first identity of the given $type for this user.
      *
-     * @phpstan-param 'email_2fa'|'email_activate'|'email_password' $type
+     * @param string $type 'email_2fa'|'email_activate'|'email_password'
      */
     public function getIdentity(string $type): ?UserIdentity
     {

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -67,6 +67,7 @@ return [
     // Activate
     'emailActivateTitle'   => 'Email Activation',
     'emailActivateSubject' => 'Confirm your Email',
+    'invalidActivateToken' => 'The code was incorrect.',
 
     // Groups
     'unknownGroup' => '{0} is not a valid group.',

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -4,6 +4,7 @@ namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\Model;
 use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Exceptions\RuntimeException;
 use Faker\Generator;
 use InvalidArgumentException;
 
@@ -183,5 +184,28 @@ class UserModel extends Model
             'id'          => $id,
             'remember_me' => trim($token),
         ])->first();
+    }
+
+    /**
+     * Activate a User.
+     */
+    public function activate(User $user): void
+    {
+        $user->active = true;
+
+        $return = $this->save($user);
+
+        $this->checkQueryReturn($return);
+    }
+
+    private function checkQueryReturn(bool $return): void
+    {
+        if ($return === false) {
+            $error   = $this->db->error();
+            $message = 'Query error: ' . $error['code'] . ', '
+                . $error['message'] . ', query: ' . $this->db->getLastQuery();
+
+            throw new RuntimeException($message, $error['code']);
+        }
     }
 }

--- a/src/Views/email_activate_show.php
+++ b/src/Views/email_activate_show.php
@@ -9,6 +9,10 @@
         <div class="card-body">
             <h5 class="card-title mb-5"><?= lang('Auth.emailActivateTitle') ?></h5>
 
+            <?php if (session('error')) : ?>
+                <div class="alert alert-danger"><?= session('error') ?></div>
+            <?php endif ?>
+
             <p>We just sent an email to you with a code to confirm your email address. Copy that code and paste it
                 below.</p>
 

--- a/tests/Authentication/SessionAuthenticatorTest.php
+++ b/tests/Authentication/SessionAuthenticatorTest.php
@@ -89,7 +89,7 @@ final class SessionAuthenticatorTest extends TestCase
     {
         $this->user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret']);
 
-        $this->assertTrue($this->auth->login($this->user));
+        $this->auth->login($this->user);
 
         $this->assertSame($this->user->id, $_SESSION['logged_in']);
 
@@ -102,7 +102,7 @@ final class SessionAuthenticatorTest extends TestCase
     {
         $this->user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret']);
 
-        $this->assertTrue($this->auth->remember()->login($this->user));
+        $this->auth->remember()->login($this->user);
 
         $this->assertSame($this->user->id, $_SESSION['logged_in']);
 

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -5,6 +5,7 @@ namespace Tests\Controllers;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Shield\Authentication\Actions\EmailActivator;
 use CodeIgniter\Shield\Authentication\Passwords\ValidationRules;
+use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Test\FeatureTestTrait;
 use Config\Services;
 use Tests\Support\DatabaseTestCase;
@@ -57,13 +58,15 @@ final class RegisterTest extends DatabaseTestCase
         $this->seeInDatabase('users', [
             'username' => 'JohnDoe',
         ]);
+
         // User has email/password identity
-        $user = model('UserModel')->where('username', 'JohnDoe')->first(); // @phpstan-ignore-line
+        $user = model(UserModel::class)->where('username', 'JohnDoe')->first();
         $this->seeInDatabase('auth_identities', [
             'user_id' => $user->id,
             'type'    => 'email_password',
             'secret'  => 'john.doe@example.com',
         ]);
+
         // User added to default group
         $this->assertTrue($user->inGroup(config('AuthGroups')->defaultGroup));
         $this->assertFalse($user->inGroup('admin'));


### PR DESCRIPTION
Supersedes  #99

- fix Event names: now `failedLogin`, `login`, `logout`, `register`
- `login` is fired only once after login process is completed
- fix error invalidActivateToken does not show
- change return types
- add `Auth::activateUser()` and `UserModel::activate()`
- refactor