### PR TITLE
fix: add missing unique key to `auth_identities`

### DIFF
--- a/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
@@ -46,6 +46,7 @@ class CreateAuthTables extends Migration
             'updated_at'   => ['type' => 'datetime', 'null' => true],
         ]);
         $this->forge->addPrimaryKey('id');
+        $this->forge->addUniqueKey(['type', 'secret']);
         $this->forge->addKey('user_id');
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'CASCADE');
         $this->forge->createTable('auth_identities', true);

--- a/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
@@ -68,7 +68,7 @@ class CreateAuthTables extends Migration
         $this->forge->createTable('auth_logins', true);
 
         /*
-         * Auth Tokens (remember-me) Table
+         * Auth Remember Tokens (remember-me) Table
          * @see https://paragonie.com/blog/2015/04/secure-authentication-php-with-long-term-persistence
          */
         $this->forge->addField([

--- a/tests/Authentication/HasAccessTokensTest.php
+++ b/tests/Authentication/HasAccessTokensTest.php
@@ -46,10 +46,17 @@ final class HasAccessTokensTest extends DatabaseTestCase
         $this->assertSame([], $this->user->accessTokens());
 
         // Give the user a couple of access tokens
-        $token1 = fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'access_token']);
-        $token2 = fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'access_token']);
+        $token1 = fake(
+            UserIdentityModel::class,
+            ['user_id' => $this->user->id, 'type' => 'access_token', 'secret' => 'secretToken1']
+        );
+        $token2 = fake(
+            UserIdentityModel::class,
+            ['user_id' => $this->user->id, 'type' => 'access_token', 'secret' => 'secretToken2']
+        );
 
         $tokens = $this->user->accessTokens();
+
         $this->assertCount(2, $tokens);
         $this->assertSame($token1->id, $tokens[0]->id);
         $this->assertSame($token2->id, $tokens[1]->id);


### PR DESCRIPTION
Access Token or Magic Link Token must be unique.
