### PR TITLE
Add User State in Authenticators\Session

### DIFF
--- a/src/Authentication/Actions/ActionInterface.php
+++ b/src/Authentication/Actions/ActionInterface.php
@@ -39,4 +39,10 @@ interface ActionInterface
      * @return Response|string
      */
     public function verify(IncomingRequest $request);
+
+    /**
+     * Returns the string type of the action class.
+     * E.g., 'email_2fa', 'email_activate'.
+     */
+    public function getType(): string;
 }

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -24,11 +24,14 @@ class Email2FA implements ActionInterface
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
-        $user = $authenticator->getUser();
+        $user = $authenticator->getPendingUser();
+        if ($user === null) {
+            throw new RuntimeException('Cannot get the pending login User.');
+        }
 
         $authenticator->createIdentityEmail2FA();
 
-        return view(setting('Auth.views')['action_email_2fa']);
+        return view(setting('Auth.views')['action_email_2fa'], ['user' => $user]);
     }
 
     /**
@@ -45,14 +48,13 @@ class Email2FA implements ActionInterface
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
-        $user = $authenticator->getUser();
+        $user = $authenticator->getPendingUser();
+        if ($user === null) {
+            throw new RuntimeException('Cannot get the pending login User.');
+        }
 
         if (empty($email) || $email !== $user->getAuthEmail()) {
             return redirect()->route('auth-action-show')->with('error', lang('Auth.invalidEmail'));
-        }
-
-        if ($user === null) {
-            throw new RuntimeException('Cannot get the User.');
         }
 
         /** @var UserIdentityModel $identityModel */

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -26,23 +26,7 @@ class Email2FA implements ActionInterface
 
         $user = $authenticator->getUser();
 
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
-        // Delete any previous activation identities
-        $identityModel->deleteIdentitiesByType($user->getAuthId(), 'email_2fa');
-
-        // Create an identity for our 2fa hash
-        helper('text');
-        $code = random_string('nozero', 6);
-
-        $identityModel->insert([
-            'user_id' => $user->getAuthId(),
-            'type'    => 'email_2fa',
-            'secret'  => $code,
-            'name'    => 'login',
-            'extra'   => lang('Auth.need2FA'),
-        ]);
+        $authenticator->createIdentityEmail2FA();
 
         return view(setting('Auth.views')['action_email_2fa']);
     }

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -21,7 +21,10 @@ class Email2FA implements ActionInterface
      */
     public function show(): string
     {
-        $user = auth()->user();
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        $user = $authenticator->getUser();
 
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
@@ -54,7 +57,11 @@ class Email2FA implements ActionInterface
     public function handle(IncomingRequest $request)
     {
         $email = $request->getPost('email');
-        $user  = auth()->user();
+
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        $user = $authenticator->getUser();
 
         if (empty($email) || $email !== $user->getAuthEmail()) {
             return redirect()->route('auth-action-show')->with('error', lang('Auth.invalidEmail'));

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -20,7 +20,10 @@ class EmailActivator implements ActionInterface
      */
     public function show(): string
     {
-        $user = auth()->user();
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        $user = $authenticator->getUser();
 
         if ($user === null) {
             throw new RuntimeException('Cannot get the User.');
@@ -85,10 +88,8 @@ class EmailActivator implements ActionInterface
     {
         $token = $request->getVar('token');
 
-        $auth = auth('session');
-
         /** @var Session $authenticator */
-        $authenticator = $auth->getAuthenticator();
+        $authenticator = auth('session')->getAuthenticator();
 
         // No match - let them try again.
         if (! $authenticator->checkAction('email_activate', $token)) {
@@ -97,11 +98,10 @@ class EmailActivator implements ActionInterface
             return view(setting('Auth.views')['action_email_activate_show']);
         }
 
-        /** @var User $user */
-        $user = $auth->user();
+        $user = $authenticator->getUser();
 
         // Set the user active now
-        $auth->activateUser($user);
+        $authenticator->activateUser($user);
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -22,10 +22,9 @@ class EmailActivator implements ActionInterface
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
-        $user = $authenticator->getUser();
-
+        $user = $authenticator->getPendingUser();
         if ($user === null) {
-            throw new RuntimeException('Cannot get the User.');
+            throw new RuntimeException('Cannot get the pending login User.');
         }
 
         $userEmail = $user->getAuthEmail();

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -9,7 +9,6 @@ use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
-use CodeIgniter\Shield\Models\UserIdentityModel;
 
 class EmailActivator implements ActionInterface
 {
@@ -36,23 +35,7 @@ class EmailActivator implements ActionInterface
             );
         }
 
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
-        // Delete any previous activation identities
-        $identityModel->deleteIdentitiesByType($user->getAuthId(), 'email_activate');
-
-        //  Create an identity for our activation hash
-        helper('text');
-        $code = random_string('nozero', 6);
-
-        $identityModel->insert([
-            'user_id' => $user->getAuthId(),
-            'type'    => 'email_activate',
-            'secret'  => $code,
-            'name'    => 'register',
-            'extra'   => lang('Auth.needVerification'),
-        ]);
+        $code = $authenticator->createIdentityEmailActivate();
 
         // Send the email
         helper('email');

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -13,6 +13,8 @@ use CodeIgniter\Shield\Models\UserIdentityModel;
 
 class EmailActivator implements ActionInterface
 {
+    private string $type = 'email_activate';
+
     /**
      * Shows the initial screen to the user telling them
      * that an email was just sent to them with a link
@@ -75,7 +77,7 @@ class EmailActivator implements ActionInterface
         $authenticator = auth('session')->getAuthenticator();
 
         // No match - let them try again.
-        if (! $authenticator->checkAction('email_activate', $token)) {
+        if (! $authenticator->checkAction($this->type, $token)) {
             session()->setFlashdata('error', lang('Auth.invalidActivateToken'));
 
             return view(setting('Auth.views')['action_email_activate_show']);
@@ -110,19 +112,24 @@ class EmailActivator implements ActionInterface
         /** @var UserIdentityModel $userIdentityModel */
         $userIdentityModel = model(UserIdentityModel::class);
 
-        $userIdentityModel->deleteIdentitiesByType($user->getAuthId(), 'email_activate');
+        $userIdentityModel->deleteIdentitiesByType($user->getAuthId(), $this->type);
 
         //  Create an identity for our activation hash
         $code = random_string('nozero', 6);
 
         $userIdentityModel->insert([
             'user_id' => $user->getAuthId(),
-            'type'    => 'email_activate',
+            'type'    => $this->type,
             'secret'  => $code,
             'name'    => 'register',
             'extra'   => lang('Auth.needVerification'),
         ]);
 
         return $code;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
     }
 }

--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -234,7 +234,7 @@ class AccessTokens implements AuthenticatorInterface
     {
         if (! $this->user instanceof User) {
             throw new InvalidArgumentException(
-                self::class . '::recordActiveDate() requires logged in user before calling.'
+                __METHOD__ . '() requires logged in user before calling.'
             );
         }
 

--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -48,7 +48,12 @@ class AccessTokens implements AuthenticatorInterface
 
         if (! $result->isOK()) {
             // Always record a login attempt, whether success or not.
-            $this->loginModel->recordLoginAttempt('token: ' . ($credentials['token'] ?? ''), false, $ipAddress, $userAgent);
+            $this->loginModel->recordLoginAttempt(
+                'token: ' . ($credentials['token'] ?? ''),
+                false,
+                $ipAddress,
+                $userAgent
+            );
 
             return $result;
         }
@@ -61,7 +66,13 @@ class AccessTokens implements AuthenticatorInterface
 
         $this->login($user);
 
-        $this->loginModel->recordLoginAttempt('token: ' . ($credentials['token'] ?? ''), true, $ipAddress, $userAgent, $this->user->getAuthId());
+        $this->loginModel->recordLoginAttempt(
+            'token: ' . ($credentials['token'] ?? ''),
+            true,
+            $ipAddress,
+            $userAgent,
+            $this->user->getAuthId()
+        );
 
         return $result;
     }
@@ -99,7 +110,10 @@ class AccessTokens implements AuthenticatorInterface
         }
 
         // Hasn't been used in a long time
-        if ($token->last_used_at && $token->last_used_at->isBefore(Time::now()->subSeconds(config('Auth')->unusedTokenLifetime))) {
+        if (
+            $token->last_used_at
+            && $token->last_used_at->isBefore(Time::now()->subSeconds(config('Auth')->unusedTokenLifetime))
+        ) {
             return new Result([
                 'success' => false,
                 'reason'  => lang('Auth.oldToken'),

--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -26,7 +26,9 @@ class AccessTokens implements AuthenticatorInterface
     public function __construct(UserModel $provider)
     {
         helper('session');
-        $this->provider   = $provider;
+
+        $this->provider = $provider;
+
         $this->loginModel = model(LoginModel::class); // @phpstan-ignore-line
     }
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -452,7 +452,7 @@ class Session implements AuthenticatorInterface
     {
         if (! $this->user instanceof User) {
             throw new InvalidArgumentException(
-                self::class . '::recordActiveDate() requires logged in user before calling.'
+                __METHOD__ . '() requires logged in user before calling.'
             );
         }
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -653,29 +653,4 @@ class Session implements AuthenticatorInterface
 
         $this->setRememberMeCookie($rawToken);
     }
-
-    /**
-     * Create an identity for Email Activation
-     *
-     * @return string The secret code
-     */
-    public function createIdentityEmailActivate(): string
-    {
-        helper('text');
-
-        $this->userIdentityModel->deleteIdentitiesByType($this->user->getAuthId(), 'email_activate');
-
-        //  Create an identity for our activation hash
-        $code = random_string('nozero', 6);
-
-        $this->userIdentityModel->insert([
-            'user_id' => $this->user->getAuthId(),
-            'type'    => 'email_activate',
-            'secret'  => $code,
-            'name'    => 'register',
-            'extra'   => lang('Auth.needVerification'),
-        ]);
-
-        return $code;
-    }
 }

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -344,10 +344,10 @@ class Session implements AuthenticatorInterface
 
         $this->startLogin($user);
 
-        $this->processRemember();
+        $this->issueRememberMeToken();
     }
 
-    private function processRemember()
+    private function issueRememberMeToken()
     {
         if ($this->shouldRemember && setting('Auth.sessionConfig')['allowRemembering']) {
             $this->rememberUser($this->user->getAuthId());

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -266,7 +266,7 @@ class Session implements AuthenticatorInterface
     {
         $this->checkUserState();
 
-        return (bool) ($this->userState === self::STATE_LOGGED_IN);
+        return $this->userState === self::STATE_LOGGED_IN;
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -289,12 +289,12 @@ class Session implements AuthenticatorInterface
 
             // Having an action?
             foreach ($identities as $identity) {
-                $action = setting('Auth.actions')[$identity->name];
+                $actionClass = setting('Auth.actions')[$identity->name];
 
-                if ($action) {
+                if ($actionClass) {
                     $this->userState = self::STATE_PENDING;
 
-                    session()->set('auth_action', $action);
+                    session()->set('auth_action', $actionClass);
                     $this->pendingMessage = $identity->extra;
 
                     return;

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -6,6 +6,7 @@ use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Shield\Authentication\Actions\Email2FA;
 use CodeIgniter\Shield\Authentication\AuthenticationException;
 use CodeIgniter\Shield\Authentication\AuthenticatorInterface;
 use CodeIgniter\Shield\Authentication\Passwords;
@@ -118,6 +119,10 @@ class Session implements AuthenticatorInterface
         // If an action has been defined for login, start it up.
         $actionClass = setting('Auth.actions')['login'] ?? null;
         if (! empty($actionClass)) {
+            if ($actionClass === Email2FA::class) {
+                $this->createIdentityEmail2FA();
+            }
+
             session()->set('auth_action', $actionClass);
         } else {
             $this->completeLogin($user);

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -287,6 +287,12 @@ class Session implements AuthenticatorInterface
                 ['email_2fa', 'email_activate']
             );
 
+            // If we will have more than one identity, we need to change the logic blow.
+            assert(
+                count($identities) < 2,
+                'More than one identity for actions. user_id: ' . $userId
+            );
+
             // Having an action?
             foreach ($identities as $identity) {
                 $actionClass = setting('Auth.actions')[$identity->name];

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -347,6 +347,10 @@ class Session implements AuthenticatorInterface
         return $types;
     }
 
+    /**
+     * Checks if the user is currently in pending login state.
+     * They need to do an auth action.
+     */
     public function isPending(): bool
     {
         $this->checkUserState();
@@ -354,6 +358,10 @@ class Session implements AuthenticatorInterface
         return $this->userState === self::STATE_PENDING;
     }
 
+    /**
+     * Checks if the visitor is anonymous. The user's id is unknown.
+     * They are not logged in, are not in pending login state.
+     */
     public function isAnonymous(): bool
     {
         $this->checkUserState();

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -131,11 +131,8 @@ class Session implements AuthenticatorInterface
             return false;
         }
 
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
         // On success - remove the identity and clean up session
-        $identityModel->deleteIdentitiesByType($user->getAuthId(), $type);
+        $this->userIdentityModel->deleteIdentitiesByType($user->getAuthId(), $type);
 
         // Clean up our session
         session()->remove('auth_action');

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -170,7 +170,7 @@ class Auth extends BaseConfig
      * These settings only apply if you are using the Session Authenticator
      * for authentication.
      *
-     * - field                  The name of the key the logged in user is stored in session
+     * - field                  The name of the key the current user ID is stored in session
      * - allowRemembering       Does the system allow use of "remember-me"
      * - rememberCookieName     The name of the cookie to use for "remember-me"
      * - rememberLength         The length of time, in seconds, to remember a user.

--- a/src/Controllers/ActionController.php
+++ b/src/Controllers/ActionController.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\Shield\Controllers;
 
 use App\Controllers\BaseController;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Shield\Authentication\Actions\ActionInterface;
@@ -31,7 +32,7 @@ class ActionController extends BaseController
         $actionClass = session('auth_action');
 
         if (! empty($actionClass) && class_exists($actionClass)) {
-            $this->action = new $actionClass();
+            $this->action = Factories::actions($actionClass); // @phpstan-ignore-line
         }
 
         if (empty($this->action) || ! $this->action instanceof ActionInterface) {

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\Shield\Controllers;
 
 use App\Controllers\BaseController;
+use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
@@ -90,9 +91,13 @@ class RegisterController extends BaseController
         $actionClass = setting('Auth.actions')['register'] ?? null;
 
         if (! empty($actionClass)) {
-            session()->set('auth_action', $actionClass);
+            $action = Factories::actions($actionClass); // @phpstan-ignore-line
 
-            $authenticator->createIdentityEmailActivate();
+            if (method_exists($action, 'afterRegister')) {
+                $action->afterRegister($user);
+            }
+
+            session()->set('auth_action', $actionClass);
 
             return redirect()->to('auth/a/show');
         }

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -5,6 +5,7 @@ namespace CodeIgniter\Shield\Controllers;
 use App\Controllers\BaseController;
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Validation\Validation;
@@ -80,7 +81,10 @@ class RegisterController extends BaseController
 
         Events::trigger('register', $user);
 
-        auth()->login($user);
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        $authenticator->login($user);
 
         // If an action has been defined for login, start it up.
         $actionClass = setting('Auth.actions')['register'] ?? null;
@@ -88,11 +92,13 @@ class RegisterController extends BaseController
         if (! empty($actionClass)) {
             session()->set('auth_action', $actionClass);
 
+            $authenticator->createIdentityEmailActivate();
+
             return redirect()->to('auth/a/show');
         }
 
         // Set the user active
-        auth()->activateUser($user);
+        $authenticator->activateUser($user);
 
         // a successful login
         Events::trigger('login', $user);

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -6,6 +6,7 @@ use App\Controllers\BaseController;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\Shield\Authentication\Actions\ActionInterface;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\UserModel;
@@ -89,15 +90,8 @@ class RegisterController extends BaseController
 
         // If an action has been defined for login, start it up.
         $actionClass = setting('Auth.actions')['register'] ?? null;
-
         if (! empty($actionClass)) {
-            $action = Factories::actions($actionClass); // @phpstan-ignore-line
-
-            if (method_exists($action, 'afterRegister')) {
-                $action->afterRegister($user);
-            }
-
-            session()->set('auth_action', $actionClass);
+            $this->startUpAction($actionClass, $user);
 
             return redirect()->to('auth/a/show');
         }
@@ -111,6 +105,23 @@ class RegisterController extends BaseController
         // Success!
         return redirect()->to(config('Auth')->registerRedirect())
             ->with('message', lang('Auth.registerSuccess'));
+    }
+
+    /**
+     * @param class-string<ActionInterface> $actionClass
+     */
+    private function startUpAction(string $actionClass, User $user)
+    {
+        // @TODO I want to move this logic to Authenticators\Session,
+        //      and create register() method in Authenticators\Session.
+
+        $action = Factories::actions($actionClass); // @phpstan-ignore-line
+
+        if (method_exists($action, 'afterRegister')) {
+            $action->afterRegister($user);
+        }
+
+        session()->set('auth_action', $actionClass);
     }
 
     /**

--- a/src/Filters/SessionAuth.php
+++ b/src/Filters/SessionAuth.php
@@ -7,6 +7,7 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\UserIdentity;
 use CodeIgniter\Shield\Models\UserIdentityModel;
 
@@ -35,12 +36,15 @@ class SessionAuth implements FilterInterface
     {
         helper(['auth', 'setting']);
 
-        if (! auth('session')->loggedIn()) {
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        if (! $authenticator->loggedIn()) {
             return redirect()->route('login');
         }
 
         if (setting('Auth.recordActiveDate')) {
-            auth('session')->recordActiveDate();
+            $authenticator->recordActiveDate();
         }
 
         /** @var UserIdentityModel $identityModel */
@@ -49,7 +53,7 @@ class SessionAuth implements FilterInterface
         // If user is in middle of an action flow
         // ensure they must finish it first.
         $identities = $identityModel->getIdentitiesByTypes(
-            auth('session')->id(),
+            $authenticator->getUser()->getAuthId(),
             ['email_2fa', 'email_activate']
         );
 

--- a/src/Views/email_2fa_show.php
+++ b/src/Views/email_2fa_show.php
@@ -21,8 +21,9 @@
                 <!-- Email -->
                 <div class="mb-2">
                     <input type="email" class="form-control" name="email"
-                           inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>"
-                           value="<?= old('email', auth()->user()->email ?? null) ?>" required />
+                        inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>"
+                        <?php /** @var \CodeIgniter\Shield\Entities\User $user */ ?>
+                        value="<?= old('email', $user->email) ?>" required />
                 </div>
 
                 <div class="d-grid col-8 mx-auto m-3">

--- a/tests/Authentication/AuthHelperTest.php
+++ b/tests/Authentication/AuthHelperTest.php
@@ -61,8 +61,9 @@ final class AuthHelperTest extends TestCase
 
     public function testUserIdReturnsId()
     {
-        $user = fake(UserModel::class, ['id' => 1], false);
+        $user = fake(UserModel::class, ['id' => 1]);
         $this->setPrivateProperty(auth()->getAuthenticator(), 'user', $user);
+        $_SESSION['logged_in'] = $user->id;
 
         $this->assertTrue(auth()->loggedIn());
         $this->assertSame($user->id, user_id());

--- a/tests/Authentication/SessionAuthenticatorTest.php
+++ b/tests/Authentication/SessionAuthenticatorTest.php
@@ -46,10 +46,13 @@ final class SessionAuthenticatorTest extends TestCase
         $this->db->table('auth_identities')->truncate();
     }
 
-    public function testLoggedIn()
+    public function testLoggedInFalse()
     {
         $this->assertFalse($this->auth->loggedIn());
+    }
 
+    public function testLoggedInTrue()
+    {
         $_SESSION['logged_in'] = $this->user->id;
 
         $this->assertTrue($this->auth->loggedIn());


### PR DESCRIPTION
- add `$userState` in `Session`
- now `Session::loggedIn()` does not return `true` for pending login user.
- now `Session::getUser()` does not return pending login user, so `auth()->user()` also does not return.
- add `Session::getPendingUser()`
- add `Session::isPending()` that returns `true` when a user is in pending login state.
- add `Session::isAnonymous()`
- add `ActionInterface::getType()`
- refactor
