### PR TITLE
refactor: change session variable

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -110,7 +110,7 @@ class Email2FA implements ActionInterface
     /**
      * Called from `Session::attempt()`.
      */
-    public function afterAttempt(User $user): void
+    public function afterLogin(User $user): void
     {
         $this->createIdentity($user);
     }

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -136,6 +136,32 @@ class Session implements AuthenticatorInterface
     }
 
     /**
+     * If an action has been defined, start it up.
+     *
+     * @param string $type 'register'
+     */
+    public function startUpAction(string $type, User $user): bool
+    {
+        $actionClass = setting('Auth.actions')[$type] ?? null;
+
+        if ($actionClass === null) {
+            return false;
+        }
+
+        $action = Factories::actions($actionClass); // @phpstan-ignore-line
+
+        // E.g., afterRegister()
+        $method = 'after' . ucfirst($type);
+        if (method_exists($action, $method)) {
+            $action->{$method}($user);
+        }
+
+        $this->setSessionUser('auth_action', $actionClass);
+
+        return true;
+    }
+
+    /**
      * Check token in Action
      *
      * @param string $type  Action type. 'email_2fa' or 'email_activate'

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -162,6 +162,17 @@ class Session implements AuthenticatorInterface
     }
 
     /**
+     * Returns an action object.
+     */
+    public function getAction(): ?ActionInterface
+    {
+        /** @var class-string<ActionInterface>|null $actionClass */
+        $actionClass = $this->getSessionUser('auth_action');
+
+        return Factories::actions($actionClass); // @phpstan-ignore-line
+    }
+
+    /**
      * Check token in Action
      *
      * @param string $type  Action type. 'email_2fa' or 'email_activate'

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -533,11 +533,6 @@ class Session implements AuthenticatorInterface
         session()->set(setting('Auth.sessionConfig')['field'], $sessionUserInfo);
     }
 
-    private function setSessionUserInfo(array $sessionUserInfo): void
-    {
-        session()->set(setting('Auth.sessionConfig')['field'], $sessionUserInfo);
-    }
-
     /**
      * Logs the given user in.
      */

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -353,7 +353,7 @@ class Session implements AuthenticatorInterface
     {
         // Get identities for action
         $identities = $this->userIdentityModel->getIdentitiesByTypes(
-            $this->user->getAuthId(),
+            $this->user,
             $this->getActionTypes()
         );
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -189,6 +189,7 @@ class Session implements AuthenticatorInterface
 
         // Clean up our session
         $this->removeSessionUser('auth_action');
+        $this->removeSessionUser('auth_action_message');
 
         $this->user = $user;
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -161,6 +161,10 @@ class Session implements AuthenticatorInterface
         /** @var class-string<ActionInterface>|null $actionClass */
         $actionClass = $this->getSessionUser('auth_action');
 
+        if ($actionClass === null) {
+            return null;
+        }
+
         return Factories::actions($actionClass); // @phpstan-ignore-line
     }
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -425,6 +425,9 @@ class Session implements AuthenticatorInterface
         return $this->getSessionUser('auth_action_message') ?? '';
     }
 
+    /**
+     * @return bool true if logged in by remember-me token.
+     */
     private function checkRememberMe(): bool
     {
         // Get remember-me token.

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -352,12 +352,6 @@ class Session implements AuthenticatorInterface
             $this->getActionTypes()
         );
 
-        // If we will have more than one identity, we need to change the logic blow.
-        assert(
-            count($identities) < 2,
-            'More than one identity for actions. user_id: ' . $this->user->getAuthId()
-        );
-
         // Having an action?
         foreach ($identities as $identity) {
             $actionClass = setting('Auth.actions')[$identity->name];

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -108,12 +108,14 @@ class Session implements AuthenticatorInterface
         /** @var User $user */
         $user = $result->extraInfo();
 
-        $this->login($user);
-
-        $this->recordLoginAttempt($credentials, true, $ipAddress, $userAgent, $user->getAuthId());
+        $this->user = $user;
 
         // If an action has been defined for login, start it up.
         $hasAction = $this->startUpAction('login', $user);
+
+        $this->login($user);
+
+        $this->recordLoginAttempt($credentials, true, $ipAddress, $userAgent, $user->getAuthId());
 
         if (! $hasAction) {
             $this->completeLogin($user);

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -171,7 +171,7 @@ class Auth extends BaseConfig
      * These settings only apply if you are using the Session Authenticator
      * for authentication.
      *
-     * - field                  The name of the key the current user ID is stored in session
+     * - field                  The name of the key the current user info is stored in session
      * - allowRemembering       Does the system allow use of "remember-me"
      * - rememberCookieName     The name of the cookie to use for "remember-me"
      * - rememberLength         The length of time, in seconds, to remember a user.
@@ -179,7 +179,7 @@ class Auth extends BaseConfig
      * @var array<string, bool|int|string>
      */
     public array $sessionConfig = [
-        'field'              => 'logged_in',
+        'field'              => 'user',
         'allowRemembering'   => true,
         'rememberCookieName' => 'remember',
         'rememberLength'     => 30 * DAY,

--- a/src/Controllers/ActionController.php
+++ b/src/Controllers/ActionController.php
@@ -28,8 +28,9 @@ class ActionController extends BaseController
     public function _remap(string $method, ...$params)
     {
         // Grab our action instance if one has been set.
+        $sessionUserInfo = session(setting('Auth.sessionConfig')['field']) ?? [];
         /** @var class-string<ActionInterface>|null $actionClass */
-        $actionClass = session('auth_action');
+        $actionClass = $sessionUserInfo['auth_action'] ?? null;
 
         if (! empty($actionClass) && class_exists($actionClass)) {
             $this->action = Factories::actions($actionClass); // @phpstan-ignore-line

--- a/src/Controllers/ActionController.php
+++ b/src/Controllers/ActionController.php
@@ -3,10 +3,10 @@
 namespace CodeIgniter\Shield\Controllers;
 
 use App\Controllers\BaseController;
-use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\Shield\Authentication\Actions\ActionInterface;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 
 /**
  * Class ActionController
@@ -27,14 +27,11 @@ class ActionController extends BaseController
      */
     public function _remap(string $method, ...$params)
     {
-        // Grab our action instance if one has been set.
-        $sessionUserInfo = session(setting('Auth.sessionConfig')['field']) ?? [];
-        /** @var class-string<ActionInterface>|null $actionClass */
-        $actionClass = $sessionUserInfo['auth_action'] ?? null;
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
 
-        if (! empty($actionClass) && class_exists($actionClass)) {
-            $this->action = Factories::actions($actionClass); // @phpstan-ignore-line
-        }
+        // Grab our action instance if one has been set.
+        $this->action = $authenticator->getAction();
 
         if (empty($this->action) || ! $this->action instanceof ActionInterface) {
             throw new PageNotFoundException();

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -3,10 +3,8 @@
 namespace CodeIgniter\Shield\Controllers;
 
 use App\Controllers\BaseController;
-use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\RedirectResponse;
-use CodeIgniter\Shield\Authentication\Actions\ActionInterface;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\UserModel;
@@ -89,10 +87,8 @@ class RegisterController extends BaseController
         $authenticator->login($user);
 
         // If an action has been defined for login, start it up.
-        $actionClass = setting('Auth.actions')['register'] ?? null;
-        if (! empty($actionClass)) {
-            $this->startUpAction($actionClass, $user);
-
+        $hasAction = $authenticator->startUpAction('register', $user);
+        if ($hasAction) {
             return redirect()->to('auth/a/show');
         }
 
@@ -105,25 +101,6 @@ class RegisterController extends BaseController
         // Success!
         return redirect()->to(config('Auth')->registerRedirect())
             ->with('message', lang('Auth.registerSuccess'));
-    }
-
-    /**
-     * @param class-string<ActionInterface> $actionClass
-     */
-    private function startUpAction(string $actionClass, User $user)
-    {
-        // @TODO I want to move this logic to Authenticators\Session,
-        //      and create register() method in Authenticators\Session.
-
-        $action = Factories::actions($actionClass); // @phpstan-ignore-line
-
-        if (method_exists($action, 'afterRegister')) {
-            $action->afterRegister($user);
-        }
-
-        $sessionUserInfo                = session(setting('Auth.sessionConfig')['field']) ?? [];
-        $sessionUserInfo['auth_action'] = $actionClass;
-        session()->set(setting('Auth.sessionConfig')['field'], $sessionUserInfo);
     }
 
     /**

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -121,7 +121,9 @@ class RegisterController extends BaseController
             $action->afterRegister($user);
         }
 
-        session()->set('auth_action', $actionClass);
+        $sessionUserInfo                = session(setting('Auth.sessionConfig')['field']) ?? [];
+        $sessionUserInfo['auth_action'] = $actionClass;
+        session()->set(setting('Auth.sessionConfig')['field'], $sessionUserInfo);
     }
 
     /**

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -117,6 +117,7 @@ class UserIdentityModel extends Model
     {
         return $this->where('user_id', $user->getAuthId())
             ->whereIn('type', $types)
+            ->orderBy($this->primaryKey)
             ->findAll();
     }
 

--- a/tests/Authentication/AuthHelperTest.php
+++ b/tests/Authentication/AuthHelperTest.php
@@ -63,7 +63,7 @@ final class AuthHelperTest extends TestCase
     {
         $user = fake(UserModel::class, ['id' => 1]);
         $this->setPrivateProperty(auth()->getAuthenticator(), 'user', $user);
-        $_SESSION['logged_in'] = $user->id;
+        $_SESSION['user']['id'] = $user->id;
 
         $this->assertTrue(auth()->loggedIn());
         $this->assertSame($user->id, user_id());

--- a/tests/Authentication/ChainFilterTest.php
+++ b/tests/Authentication/ChainFilterTest.php
@@ -63,9 +63,9 @@ final class ChainFilterTest extends TestCase
 
     public function testFilterSuccessSeession()
     {
-        $_SESSION['logged_in'] = $this->user->id;
+        $_SESSION['user']['id'] = $this->user->id;
 
-        $result = $this->withSession(['logged_in' => $this->user->id])
+        $result = $this->withSession(['user' => ['id' => $this->user->id]])
             ->get('protected-route');
 
         $result->assertStatus(200);

--- a/tests/Authentication/MagicLinkTest.php
+++ b/tests/Authentication/MagicLinkTest.php
@@ -115,9 +115,7 @@ final class MagicLinkTest extends TestCase
     public function testMagicLinkVerifySuccess()
     {
         $identities = new UserIdentityModel();
-        /**
-         * @phpstan-var User
-         */
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
         $identities->insert([
@@ -130,7 +128,7 @@ final class MagicLinkTest extends TestCase
         $result = $this->get(route_to('verify-magic-link') . '?token=' . 'abasdasdf');
 
         $result->assertRedirectTo(site_url());
-        $result->assertSessionHas('logged_in', $user->id);
+        $result->assertSessionHas('user', ['id' => $user->id]);
         $this->assertTrue(auth()->loggedIn());
     }
 }

--- a/tests/Authentication/SessionAuthenticatorTest.php
+++ b/tests/Authentication/SessionAuthenticatorTest.php
@@ -53,7 +53,7 @@ final class SessionAuthenticatorTest extends TestCase
 
     public function testLoggedInTrue()
     {
-        $_SESSION['logged_in'] = $this->user->id;
+        $_SESSION['user']['id'] = $this->user->id;
 
         $this->assertTrue($this->auth->loggedIn());
 
@@ -64,7 +64,7 @@ final class SessionAuthenticatorTest extends TestCase
 
     public function testLoggedInWithRememberCookie()
     {
-        unset($_SESSION['logged_in']);
+        unset($_SESSION['user']);
 
         $this->user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret']);
 
@@ -94,7 +94,7 @@ final class SessionAuthenticatorTest extends TestCase
 
         $this->auth->login($this->user);
 
-        $this->assertSame($this->user->id, $_SESSION['logged_in']);
+        $this->assertSame($this->user->id, $_SESSION['user']['id']);
 
         $this->dontSeeInDatabase('auth_remember_tokens', [
             'user_id' => $this->user->id,
@@ -107,7 +107,7 @@ final class SessionAuthenticatorTest extends TestCase
 
         $this->auth->remember()->login($this->user);
 
-        $this->assertSame($this->user->id, $_SESSION['logged_in']);
+        $this->assertSame($this->user->id, $_SESSION['user']['id']);
 
         $this->seeInDatabase('auth_remember_tokens', [
             'user_id' => $this->user->id,
@@ -127,7 +127,7 @@ final class SessionAuthenticatorTest extends TestCase
 
         $this->auth->logout();
 
-        $this->assertArrayNotHasKey('logged_in', $_SESSION);
+        $this->assertArrayNotHasKey('user', $_SESSION);
         $this->dontSeeInDatabase('auth_remember_tokens', ['user_id' => $this->user->id]);
     }
 
@@ -145,7 +145,7 @@ final class SessionAuthenticatorTest extends TestCase
 
         $this->auth->loginById($this->user->id);
 
-        $this->assertSame($this->user->id, $_SESSION['logged_in']);
+        $this->assertSame($this->user->id, $_SESSION['user']['id']);
 
         $this->dontSeeInDatabase('auth_remember_tokens', ['user_id' => $this->user->id]);
     }
@@ -156,7 +156,7 @@ final class SessionAuthenticatorTest extends TestCase
 
         $this->auth->remember()->loginById($this->user->id);
 
-        $this->assertSame($this->user->id, $_SESSION['logged_in']);
+        $this->assertSame($this->user->id, $_SESSION['user']['id']);
 
         $this->seeInDatabase('auth_remember_tokens', ['user_id' => $this->user->id]);
     }
@@ -165,7 +165,7 @@ final class SessionAuthenticatorTest extends TestCase
     {
         $this->user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret']);
         $this->auth->remember()->loginById($this->user->id);
-        $this->assertSame($this->user->id, $_SESSION['logged_in']);
+        $this->assertSame($this->user->id, $_SESSION['user']['id']);
 
         $this->seeInDatabase('auth_remember_tokens', ['user_id' => $this->user->id]);
 
@@ -269,7 +269,7 @@ final class SessionAuthenticatorTest extends TestCase
             'password' => 'secret123',
         ]);
 
-        $this->assertArrayNotHasKey('logged_in', $_SESSION);
+        $this->assertArrayNotHasKey('user', $_SESSION);
 
         $result = $this->auth->attempt([
             'email'    => $this->user->email,
@@ -282,8 +282,8 @@ final class SessionAuthenticatorTest extends TestCase
         $foundUser = $result->extraInfo();
         $this->assertSame($this->user->id, $foundUser->id);
 
-        $this->assertArrayHasKey('logged_in', $_SESSION);
-        $this->assertSame($this->user->id, $_SESSION['logged_in']);
+        $this->assertArrayHasKey('id', $_SESSION['user']);
+        $this->assertSame($this->user->id, $_SESSION['user']['id']);
 
         // A login attempt should have been recorded
         $this->seeInDatabase('auth_logins', [
@@ -299,7 +299,7 @@ final class SessionAuthenticatorTest extends TestCase
             'password' => 'secret123',
         ]);
 
-        $this->assertArrayNotHasKey('logged_in', $_SESSION);
+        $this->assertArrayNotHasKey('user', $_SESSION);
 
         $result = $this->auth->attempt([
             'email'    => 'foo@example.COM',
@@ -312,8 +312,8 @@ final class SessionAuthenticatorTest extends TestCase
         $foundUser = $result->extraInfo();
         $this->assertSame($this->user->id, $foundUser->id);
 
-        $this->assertArrayHasKey('logged_in', $_SESSION);
-        $this->assertSame($this->user->id, $_SESSION['logged_in']);
+        $this->assertArrayHasKey('id', $_SESSION['user']);
+        $this->assertSame($this->user->id, $_SESSION['user']['id']);
 
         // A login attempt should have been recorded
         $this->seeInDatabase('auth_logins', [
@@ -331,7 +331,7 @@ final class SessionAuthenticatorTest extends TestCase
             'password' => 'secret123',
         ]);
 
-        $this->assertArrayNotHasKey('logged_in', $_SESSION);
+        $this->assertArrayNotHasKey('user', $_SESSION);
 
         $result = $this->auth->attempt([
             'username' => 'fooROG',
@@ -344,8 +344,8 @@ final class SessionAuthenticatorTest extends TestCase
         $foundUser = $result->extraInfo();
         $this->assertSame($user->id, $foundUser->id);
 
-        $this->assertArrayHasKey('logged_in', $_SESSION);
-        $this->assertSame($user->id, $_SESSION['logged_in']);
+        $this->assertArrayHasKey('id', $_SESSION['user']);
+        $this->assertSame($user->id, $_SESSION['user']['id']);
 
         // A login attempt should have been recorded
         $this->seeInDatabase('auth_logins', [

--- a/tests/Authentication/SessionFilterTest.php
+++ b/tests/Authentication/SessionFilterTest.php
@@ -58,10 +58,10 @@ final class SessionFilterTest extends DatabaseTestCase
 
     public function testFilterSuccess()
     {
-        $user                  = fake(UserModel::class);
-        $_SESSION['logged_in'] = $user->id;
+        $user                   = fake(UserModel::class);
+        $_SESSION['user']['id'] = $user->id;
 
-        $result = $this->withSession(['logged_in' => $user->id])
+        $result = $this->withSession(['user' => ['id' => $user->id]])
             ->get('protected-route');
 
         $result->assertStatus(200);

--- a/tests/Controllers/ActionsTest.php
+++ b/tests/Controllers/ActionsTest.php
@@ -63,14 +63,22 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmal2FA();
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => Email2FA::class,
-            ])->get('/auth/a/show');
+            ->withSession($this->getSessionUserInfo())
+            ->get('/auth/a/show');
 
         $result->assertStatus(200);
         // Should auto populate in the form
         $result->assertSee($this->user->email);
+    }
+
+    private function getSessionUserInfo(string $class = Email2FA::class): array
+    {
+        return [
+            'user' => [
+                'id'          => $this->user->id,
+                'auth_action' => $class,
+            ],
+        ];
     }
 
     public function testEmail2FAHandleInvalidEmail()
@@ -78,10 +86,8 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmal2FA();
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => Email2FA::class,
-            ])->post('/auth/a/handle', [
+            ->withSession($this->getSessionUserInfo())
+            ->post('/auth/a/handle', [
                 'email' => 'foo@example.com',
             ]);
 
@@ -108,10 +114,8 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmal2FA();
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => Email2FA::class,
-            ])->post('/auth/a/handle', [
+            ->withSession($this->getSessionUserInfo())
+            ->post('/auth/a/handle', [
                 'email' => $this->user->email,
             ]);
 
@@ -127,10 +131,8 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmal2FA();
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => Email2FA::class,
-            ])->post('/auth/a/verify', [
+            ->withSession($this->getSessionUserInfo())
+            ->post('/auth/a/verify', [
                 'token' => '234567',
             ]);
 
@@ -143,10 +145,8 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmal2FA();
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => Email2FA::class,
-            ])->post('/auth/a/verify', [
+            ->withSession($this->getSessionUserInfo())
+            ->post('/auth/a/verify', [
                 'token' => '123456',
             ]);
 
@@ -168,10 +168,7 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmal2FA();
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => Email2FA::class,
-            ])
+            ->withSession($this->getSessionUserInfo())
             ->get('/auth/a/show');
 
         $result->assertOK();
@@ -202,10 +199,7 @@ final class ActionsTest extends TestCase
 
         // Try to visit any other page, skipping the 2FA
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => Email2FA::class,
-            ])
+            ->withSession($this->getSessionUserInfo())
             ->get('/');
 
         $result->assertRedirect();
@@ -230,10 +224,8 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmailActivate();
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => EmailActivator::class,
-            ])->get('/auth/a/show');
+            ->withSession($this->getSessionUserInfo(EmailActivator::class))
+            ->get('/auth/a/show');
 
         $result->assertStatus(200);
 
@@ -257,10 +249,8 @@ final class ActionsTest extends TestCase
         $model->save($this->user);
 
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => EmailActivator::class,
-            ])->post('/auth/a/verify', [
+            ->withSession($this->getSessionUserInfo(EmailActivator::class))
+            ->post('/auth/a/verify', [
                 'token' => '123456',
             ]);
 
@@ -294,10 +284,7 @@ final class ActionsTest extends TestCase
 
         // Try to visit any other page, skipping the 2FA
         $result = $this->actingAs($this->user)
-            ->withSession([
-                'logged_in'   => $this->user->id,
-                'auth_action' => EmailActivator::class,
-            ])
+            ->withSession($this->getSessionUserInfo(EmailActivator::class))
             ->get('/');
 
         $result->assertRedirect();

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -88,7 +88,7 @@ final class LoginTest extends TestCase
         $this->assertCloseEnough($identity->last_used_at->getTimestamp(), Time::now()->getTimestamp());
 
         // Session should have `logged_in` value with user's id
-        $this->assertSame($this->user->id, session('logged_in'));
+        $this->assertSame($this->user->id, session('user')['id']);
     }
 
     public function testLoginActionUsernameSuccess()
@@ -118,21 +118,20 @@ final class LoginTest extends TestCase
         $this->assertCloseEnough($identity->last_used_at->getTimestamp(), Time::now()->getTimestamp());
 
         // Session should have `logged_in` value with user's id
-        $this->assertSame($this->user->id, session('logged_in'));
+        $this->assertSame($this->user->id, session('user')['id']);
     }
 
     public function testLogoutAction()
     {
-
         // log them in
-        session()->set('logged_in', $this->user->id);
+        session()->set('user', ['id' => $this->user->id]);
 
         $result = $this->get('logout');
 
         $result->assertStatus(302);
         $this->assertSame(site_url(config('Auth')->redirects['logout']), $result->getRedirectUrl());
 
-        $this->assertNull(session('logged_in'));
+        $this->assertNull(session('user'));
     }
 
     public function testLoginRedirectsToActionIfDefined()


### PR DESCRIPTION
- change the session variable structure:
  - now uses one key
```php
[
    'user' => [
        'auth_action' => 'CodeIgniter\Shield\Authentication\Actions\Email2FA',
        'auth_action_message' => 'You must complete a two-factor verification.',
        'id' => '1',
    ]
]
```

- if there are more than one identity for actions, use the first one.
- if session has the user info, use it to check the user state.
- add code to set `auth_action` after checking valid remember-me token.
- refactor