### PR TITLE
Refactor: Object Parameters

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -63,7 +63,7 @@ class Email2FA implements ActionInterface
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        $identity = $identityModel->getIdentityByType($user->getAuthId(), $this->type);
+        $identity = $identityModel->getIdentityByType($user, $this->type);
 
         if (empty($identity)) {
             return redirect()->route('auth-action-show')->with('error', lang('Auth.need2FA'));
@@ -126,7 +126,7 @@ class Email2FA implements ActionInterface
         $userIdentityModel = model(UserIdentityModel::class);
 
         // Delete any previous activation identities
-        $userIdentityModel->deleteIdentitiesByType($user->getAuthId(), $this->type);
+        $userIdentityModel->deleteIdentitiesByType($user, $this->type);
 
         // Create an identity for our 2fa hash
         $code = random_string('nozero', 6);

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -112,7 +112,7 @@ class EmailActivator implements ActionInterface
         /** @var UserIdentityModel $userIdentityModel */
         $userIdentityModel = model(UserIdentityModel::class);
 
-        $userIdentityModel->deleteIdentitiesByType($user->getAuthId(), $this->type);
+        $userIdentityModel->deleteIdentitiesByType($user, $this->type);
 
         //  Create an identity for our activation hash
         $code = random_string('nozero', 6);

--- a/src/Authentication/Traits/HasAccessTokens.php
+++ b/src/Authentication/Traits/HasAccessTokens.php
@@ -59,7 +59,7 @@ trait HasAccessTokens
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        return $identityModel->revokeAccessToken($this->id, $rawToken);
+        return $identityModel->revokeAccessToken($this, $rawToken);
     }
 
     /**
@@ -70,7 +70,7 @@ trait HasAccessTokens
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        return $identityModel->revokeAllAccessTokens($this->id);
+        return $identityModel->revokeAllAccessTokens($this);
     }
 
     /**
@@ -83,7 +83,7 @@ trait HasAccessTokens
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        return $identityModel->getAllAccessTokens($this->id);
+        return $identityModel->getAllAccessTokens($this);
     }
 
     /**
@@ -99,7 +99,7 @@ trait HasAccessTokens
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        return $identityModel->getAccessToken($this->id, $rawToken);
+        return $identityModel->getAccessToken($this, $rawToken);
     }
 
     /**
@@ -110,7 +110,7 @@ trait HasAccessTokens
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        return $identityModel->getAccessTokenById($id, $this->id);
+        return $identityModel->getAccessTokenById($id, $this);
     }
 
     /**

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -293,7 +293,7 @@ trait Authorizable
         /** @var GroupModel $groupModel */
         $groupModel = model(GroupModel::class);
 
-        $this->groupCache = $groupModel->getByUserId($this->id);
+        $this->groupCache = $groupModel->getForUser($this);
     }
 
     /**
@@ -309,7 +309,7 @@ trait Authorizable
         /** @var PermissionModel $permissionModel */
         $permissionModel = model(PermissionModel::class);
 
-        $this->permissionsCache = $permissionModel->getByUserId($this->id);
+        $this->permissionsCache = $permissionModel->getForUser($this);
     }
 
     /**
@@ -345,7 +345,7 @@ trait Authorizable
      */
     private function saveGroupsOrPermissions(string $type, $model, array $cache): void
     {
-        $existing = $model->getByUserId($this->id);
+        $existing = $model->getForUser($this);
 
         $new = array_diff($cache, $existing);
 

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -60,7 +60,7 @@ class MagicLinkController extends BaseController
         $identityModel = model(UserIdentityModel::class);
 
         // Delete any previous magic-link identities
-        $identityModel->deleteIdentitiesByType($user->getAuthId(), 'magic-link');
+        $identityModel->deleteIdentitiesByType($user, 'magic-link');
 
         // Generate the code and save it as an identity
         helper('text');

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -63,7 +63,7 @@ class User extends Entity
             /** @var UserIdentityModel $identityModel */
             $identityModel = model(UserIdentityModel::class);
 
-            $this->identities = $identityModel->getIdentities($this->id);
+            $this->identities = $identityModel->getIdentities($this);
         }
     }
 

--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\Model;
+use CodeIgniter\Shield\Entities\User;
 
 class GroupModel extends Model
 {
@@ -20,18 +21,15 @@ class GroupModel extends Model
     protected $validationMessages = [];
     protected $skipValidation     = false;
 
-    /**
-     * @param int|string $userId
-     */
-    public function getByUserId($userId): array
+    public function getForUser(User $user): array
     {
-        $groups = $this->builder()
+        $rows = $this->builder()
             ->select('group')
-            ->where('user_id', $userId)
+            ->where('user_id', $user->getAuthId())
             ->get()
             ->getResultArray();
 
-        return array_column($groups, 'group');
+        return array_column($rows, 'group');
     }
 
     /**

--- a/src/Models/PermissionModel.php
+++ b/src/Models/PermissionModel.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\Model;
+use CodeIgniter\Shield\Entities\User;
 
 class PermissionModel extends Model
 {
@@ -20,18 +21,15 @@ class PermissionModel extends Model
     protected $validationMessages = [];
     protected $skipValidation     = false;
 
-    /**
-     * @param int|string $userId
-     */
-    public function getByUserId($userId): array
+    public function getForUser(User $user): array
     {
-        $permission = $this->builder()
+        $rows = $this->builder()
             ->select('permission')
-            ->where('user_id', $userId)
+            ->where('user_id', $user->getAuthId())
             ->get()
             ->getResultArray();
 
-        return array_column($permission, 'permission');
+        return array_column($rows, 'permission');
     }
 
     /**

--- a/src/Models/RememberModel.php
+++ b/src/Models/RememberModel.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\Model;
+use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
 use DateTime;
 use stdClass;
@@ -23,15 +24,13 @@ class RememberModel extends Model
 
     /**
      * Stores a remember-me token for the user.
-     *
-     * @param int|string $userId
      */
-    public function rememberUser($userId, string $selector, string $hashedValidator, string $expires): void
+    public function rememberUser(User $user, string $selector, string $hashedValidator, string $expires): void
     {
         $expires = new DateTime($expires);
 
         $return = $this->insert([
-            'user_id'         => $userId,
+            'user_id'         => $user->getAuthId(),
             'selector'        => $selector,
             'hashedValidator' => $hashedValidator,
             'expires'         => $expires->format('Y-m-d H:i:s'),
@@ -76,12 +75,10 @@ class RememberModel extends Model
     /**
      * Removes all persistent login tokens (remember-me) for a single user
      * across all devices they may have logged in with.
-     *
-     * @param int|string $userId
      */
-    public function purgeRememberTokens($userId): void
+    public function purgeRememberTokens(User $user): void
     {
-        $return = $this->where(['user_id' => $userId])->delete();
+        $return = $this->where(['user_id' => $user->getAuthId()])->delete();
 
         $this->checkQueryReturn($return);
     }

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -4,6 +4,7 @@ namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\Model;
 use CodeIgniter\Shield\Entities\AccessToken;
+use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Entities\UserIdentity;
 use Faker\Generator;
 
@@ -35,12 +36,9 @@ class UserIdentityModel extends Model
             ->first();
     }
 
-    /**
-     * @param int|string $userId
-     */
-    public function getAccessToken($userId, string $rawToken): ?AccessToken
+    public function getAccessToken(User $user, string $rawToken): ?AccessToken
     {
-        return $this->where('user_id', $userId)
+        return $this->where('user_id', $user->getAuthId())
             ->where('type', 'access_token')
             ->where('secret', hash('sha256', $rawToken))
             ->asObject(AccessToken::class)
@@ -51,11 +49,10 @@ class UserIdentityModel extends Model
      * Given the ID, returns the given access token.
      *
      * @param int|string $id
-     * @param int|string $userId
      */
-    public function getAccessTokenById($id, $userId): ?AccessToken
+    public function getAccessTokenById($id, User $user): ?AccessToken
     {
-        return $this->where('user_id', $userId)
+        return $this->where('user_id', $user->getAuthId())
             ->where('type', 'access_token')
             ->where('id', $id)
             ->asObject(AccessToken::class)
@@ -63,14 +60,12 @@ class UserIdentityModel extends Model
     }
 
     /**
-     * @param int|string $userId
-     *
      * @return AccessToken[]
      */
-    public function getAllAccessTokens($userId): array
+    public function getAllAccessTokens(User $user): array
     {
         return $this
-            ->where('user_id', $userId)
+            ->where('user_id', $user->getAuthId())
             ->where('type', 'access_token')
             ->orderBy($this->primaryKey)
             ->asObject(AccessToken::class)
@@ -89,13 +84,11 @@ class UserIdentityModel extends Model
     }
 
     /**
-     * @param int|string $userId
-     *
      * @return UserIdentity[]
      */
-    public function getIdentities($userId): array
+    public function getIdentities(User $user): array
     {
-        return $this->where('user_id', $userId)->orderBy($this->primaryKey)->findAll();
+        return $this->where('user_id', $user->getAuthId())->orderBy($this->primaryKey)->findAll();
     }
 
     /**
@@ -108,47 +101,38 @@ class UserIdentityModel extends Model
         return $this->whereIn('user_id', $userIds)->orderBy($this->primaryKey)->findAll();
     }
 
-    /**
-     * @param int|string $userId
-     */
-    public function getIdentityByType($userId, string $type): ?UserIdentity
+    public function getIdentityByType(User $user, string $type): ?UserIdentity
     {
-        return $this->where('user_id', $userId)
+        return $this->where('user_id', $user->getAuthId())
             ->where('type', $type)
             ->first();
     }
 
     /**
-     * @param int|string $userId
-     * @param string[]   $types
+     * @param string[] $types
      *
      * @return UserIdentity[]
      */
-    public function getIdentitiesByTypes($userId, array $types): array
+    public function getIdentitiesByTypes(User $user, array $types): array
     {
-        return $this->where('user_id', $userId)
+        return $this->where('user_id', $user->getAuthId())
             ->whereIn('type', $types)
             ->findAll();
     }
 
-    /**
-     * @param int|string $userId
-     */
-    public function deleteIdentitiesByType($userId, string $type): void
+    public function deleteIdentitiesByType(User $user, string $type): void
     {
-        $this->where('user_id', $userId)
+        $this->where('user_id', $user->getAuthId())
             ->where('type', $type)
             ->delete();
     }
 
     /**
      * Delete any access tokens for the given raw token.
-     *
-     * @param int|string $userId
      */
-    public function revokeAccessToken($userId, string $rawToken)
+    public function revokeAccessToken(User $user, string $rawToken)
     {
-        return $this->where('user_id', $userId)
+        return $this->where('user_id', $user->getAuthId())
             ->where('type', 'access_token')
             ->where('secret', hash('sha256', $rawToken))
             ->delete();
@@ -156,12 +140,10 @@ class UserIdentityModel extends Model
 
     /**
      * Revokes all access tokens for this user.
-     *
-     * @param int|string $userId
      */
-    public function revokeAllAccessTokens($userId)
+    public function revokeAllAccessTokens(User $user)
     {
-        return $this->where('user_id', $userId)
+        return $this->where('user_id', $user->getAuthId())
             ->where('type', 'access_token')
             ->delete();
     }

--- a/tests/Authentication/SessionAuthenticatorTest.php
+++ b/tests/Authentication/SessionAuthenticatorTest.php
@@ -74,7 +74,7 @@ final class SessionAuthenticatorTest extends TestCase
         $selector      = 'selector';
         $validator     = 'validator';
         $expires       = date('Y-m-d H:i:s', time() + setting('Auth.sessionConfig')['rememberLength']);
-        $rememberModel->rememberUser($this->user->id, $selector, hash('sha256', $validator), $expires);
+        $rememberModel->rememberUser($this->user, $selector, hash('sha256', $validator), $expires);
 
         // Set Cookie value for remember-me.
         $token               = $selector . ':' . $validator;
@@ -180,7 +180,7 @@ final class SessionAuthenticatorTest extends TestCase
 
         $this->seeInDatabase('auth_remember_tokens', ['user_id' => $this->user->id]);
 
-        $this->auth->forget($this->user->id);
+        $this->auth->forget($this->user);
 
         $this->dontSeeInDatabase('auth_remember_tokens', ['user_id' => $this->user->id]);
     }


### PR DESCRIPTION
Changes classes to prefer whole-object parameters instead of the less-precise `int|string` ID.

Fixes #66.