### PR TITLE
fix: Session::login() method behavior

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -19,7 +19,7 @@ class Email2FA implements ActionInterface
     private string $type = 'email_2fa';
 
     /**
-     * Displays the "Hey we're going to send you an number to your email"
+     * Displays the "Hey we're going to send you a number to your email"
      * message to the user with a prompt to continue.
      */
     public function show(): string

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -12,6 +12,7 @@ use CodeIgniter\Shield\Authentication\AuthenticationException;
 use CodeIgniter\Shield\Authentication\AuthenticatorInterface;
 use CodeIgniter\Shield\Authentication\Passwords;
 use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Entities\UserIdentity;
 use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Models\LoginModel;
 use CodeIgniter\Shield\Models\RememberModel;
@@ -355,10 +356,7 @@ class Session implements AuthenticatorInterface
     private function setAuthAction()
     {
         // Get identities for action
-        $identities = $this->userIdentityModel->getIdentitiesByTypes(
-            $this->user,
-            $this->getActionTypes()
-        );
+        $identities = $this->getIdentitiesForAction();
 
         // Having an action?
         foreach ($identities as $identity) {
@@ -373,6 +371,19 @@ class Session implements AuthenticatorInterface
                 return;
             }
         }
+    }
+
+    /**
+     * Gets identities for action
+     *
+     * @return UserIdentity[]
+     */
+    private function getIdentitiesForAction(): array
+    {
+        return $this->userIdentityModel->getIdentitiesByTypes(
+            $this->user,
+            $this->getActionTypes()
+        );
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -110,6 +110,9 @@ class Session implements AuthenticatorInterface
 
         $this->user = $user;
 
+        // Update the user's last used date on their password identity.
+        $user->touchIdentity($user->getEmailIdentity());
+
         // If an action has been defined for login, start it up.
         $hasAction = $this->startUpAction('login', $user);
 
@@ -489,9 +492,6 @@ class Session implements AuthenticatorInterface
     private function startLogin(User $user): void
     {
         $this->user = $user;
-
-        // Update the user's last used date on their password identity.
-        $user->touchIdentity($user->getEmailIdentity());
 
         // Regenerate the session ID to help protect against session fixation
         if (ENVIRONMENT !== 'testing') {

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -84,7 +84,7 @@ class RegisterController extends BaseController
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
-        $authenticator->login($user);
+        $authenticator->startLogin($user);
 
         // If an action has been defined for login, start it up.
         $hasAction = $authenticator->startUpAction('register', $user);
@@ -95,8 +95,7 @@ class RegisterController extends BaseController
         // Set the user active
         $authenticator->activateUser($user);
 
-        // a successful login
-        Events::trigger('login', $user);
+        $authenticator->completeLogin($user);
 
         // Success!
         return redirect()->to(config('Auth')->registerRedirect())

--- a/src/Test/AuthenticationTesting.php
+++ b/src/Test/AuthenticationTesting.php
@@ -2,6 +2,7 @@
 
 namespace CodeIgniter\Shield\Test;
 
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 
 /**
@@ -14,14 +15,23 @@ trait AuthenticationTesting
     /**
      * Logs the user for testing purposes.
      *
+     * @param bool $pending Whether pending login state or not.
+     *
      * @return $this
      */
-    public function actingAs(User $user): self
+    public function actingAs(User $user, bool $pending = false): self
     {
         // Ensure the helper is loaded during tests.
         helper('auth');
 
-        auth('session')->login($user);
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        if ($pending) {
+            $authenticator->startLogin($user);
+        } else {
+            $authenticator->login($user);
+        }
 
         return $this;
     }

--- a/tests/Controllers/ActionsTest.php
+++ b/tests/Controllers/ActionsTest.php
@@ -62,7 +62,7 @@ final class ActionsTest extends TestCase
     {
         $this->insertIdentityEmal2FA();
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo())
             ->get('/auth/a/show');
 
@@ -85,7 +85,7 @@ final class ActionsTest extends TestCase
     {
         $this->insertIdentityEmal2FA();
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo())
             ->post('/auth/a/handle', [
                 'email' => 'foo@example.com',
@@ -113,7 +113,7 @@ final class ActionsTest extends TestCase
     {
         $this->insertIdentityEmal2FA();
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo())
             ->post('/auth/a/handle', [
                 'email' => $this->user->email,
@@ -130,7 +130,7 @@ final class ActionsTest extends TestCase
     {
         $this->insertIdentityEmal2FA();
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo())
             ->post('/auth/a/verify', [
                 'token' => '234567',
@@ -144,7 +144,7 @@ final class ActionsTest extends TestCase
     {
         $this->insertIdentityEmal2FA();
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo())
             ->post('/auth/a/verify', [
                 'token' => '123456',
@@ -167,7 +167,7 @@ final class ActionsTest extends TestCase
     {
         $this->insertIdentityEmal2FA();
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo())
             ->get('/auth/a/show');
 
@@ -198,7 +198,7 @@ final class ActionsTest extends TestCase
         ]);
 
         // Try to visit any other page, skipping the 2FA
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo())
             ->get('/');
 
@@ -223,7 +223,7 @@ final class ActionsTest extends TestCase
     {
         $this->insertIdentityEmailActivate();
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo(EmailActivator::class))
             ->get('/auth/a/show');
 
@@ -248,7 +248,7 @@ final class ActionsTest extends TestCase
         $model              = auth()->getProvider();
         $model->save($this->user);
 
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo(EmailActivator::class))
             ->post('/auth/a/verify', [
                 'token' => '123456',
@@ -283,7 +283,7 @@ final class ActionsTest extends TestCase
         $this->insertIdentityEmailActivate();
 
         // Try to visit any other page, skipping the 2FA
-        $result = $this->actingAs($this->user)
+        $result = $this->actingAs($this->user, true)
             ->withSession($this->getSessionUserInfo(EmailActivator::class))
             ->get('/');
 


### PR DESCRIPTION
~~Needs to rebase after merging #145~~

- `Session::login()` will complete authentication, or throws Exception if there is auth action.
  - `Session::login()` fires `login` event.
- add parameter `$pending` to `actingAs()` for pending login.