### PR TITLE
test: fix `lang('Auth.errorPasswordEmpty')`

### DIFF
--- a/tests/Authentication/ChainFilterTest.php
+++ b/tests/Authentication/ChainFilterTest.php
@@ -25,7 +25,7 @@ final class ChainFilterTest extends TestCase
 
     protected function setUp(): void
     {
-        Services::reset();
+        Services::reset(true);
 
         parent::setUp();
 

--- a/tests/Authentication/SessionFilterTest.php
+++ b/tests/Authentication/SessionFilterTest.php
@@ -20,7 +20,7 @@ final class SessionFilterTest extends DatabaseTestCase
 
     protected function setUp(): void
     {
-        Services::reset();
+        Services::reset(true);
 
         parent::setUp();
 

--- a/tests/Authentication/TokenFilterTest.php
+++ b/tests/Authentication/TokenFilterTest.php
@@ -22,7 +22,7 @@ final class TokenFilterTest extends DatabaseTestCase
 
     protected function setUp(): void
     {
-        Services::reset();
+        Services::reset(true);
 
         parent::setUp();
 

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -21,7 +21,7 @@ final class RegisterTest extends DatabaseTestCase
 
     protected function setUp(): void
     {
-        Services::reset();
+        Services::reset(true);
 
         parent::setUp();
 

--- a/tests/Unit/PwnedValidatorTest.php
+++ b/tests/Unit/PwnedValidatorTest.php
@@ -25,7 +25,7 @@ final class PwnedValidatorTest extends CIUnitTestCase
     {
         parent::setUp();
 
-        Services::reset();
+        Services::reset(true);
 
         $this->validator = new PwnedValidator(new AuthConfig());
     }


### PR DESCRIPTION
Fixes #88

Probably this will fix it.