### PR TITLE
refactor: remove $_SESSION

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -655,15 +655,17 @@ class Session implements AuthenticatorInterface
 
         // Destroy the session data - but ensure a session is still
         // available for flash messages, etc.
-        if (isset($_SESSION)) {
-            foreach (array_keys($_SESSION) as $key) {
-                $_SESSION[$key] = null;
-                unset($_SESSION[$key]);
+        /** @var \CodeIgniter\Session\Session $session */
+        $session     = session();
+        $sessionData = $session->get();
+        if (isset($sessionData)) {
+            foreach (array_keys($sessionData) as $key) {
+                $session->remove($key);
             }
         }
 
         // Regenerate the session ID for a touch of added safety.
-        session()->regenerate(true);
+        $session->regenerate(true);
 
         // Take care of any remember-me functionality
         $this->rememberModel->purgeRememberTokens($this->user);

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -47,7 +47,7 @@ class User extends Entity
     /**
      * Returns the first identity of the given $type for this user.
      *
-     * @param string $type 'email_2fa'|'email_activate'|'email_password'
+     * @param string $type 'email_2fa'|'email_activate'|'email_password'|'magic-link'
      */
     public function getIdentity(string $type): ?UserIdentity
     {


### PR DESCRIPTION
`$session->get()` does not return all `$_SESSION` items (flashdata and tempdata are excluded), 
but I think this change is fine.
