### PR TITLE
fix: add missing `Auth.registerSuccess` for farsi

### DIFF
--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -38,6 +38,7 @@ return [
     // Registration
     'register'         => 'ثبت نام',
     'registerDisabled' => 'اکنون امکان ثبت نام وجود ندارد.',
+    'registerSuccess'  => 'خوش آمدید!',
 
     // Login
     'login'              => 'ورود',


### PR DESCRIPTION
Hi,
related to PR: #169