### PR TITLE
fix: lastLogin()

### DIFF
--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -226,11 +226,11 @@ class User extends Entity
     /**
      * Returns the last login information for this user as
      */
-    public function lastLogin(bool $allowFailed = false): ?Login
+    public function lastLogin(): ?Login
     {
         /** @var LoginModel $logins */
         $logins = model(LoginModel::class);
 
-        return $logins->lastLogin($this, $allowFailed);
+        return $logins->lastLogin($this);
     }
 }

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -224,21 +224,13 @@ class User extends Entity
     }
 
     /**
-     * Returns the last login information for this
-     * user as
+     * Returns the last login information for this user as
      */
     public function lastLogin(bool $allowFailed = false): ?Login
     {
+        /** @var LoginModel $logins */
         $logins = model(LoginModel::class);
 
-        if (! $allowFailed) {
-            $logins->where('success', 1)
-                ->where('user_id', $this->attributes['id'] ?? null);
-        }
-
-        return $logins
-            ->where('identifier', $this->getEmail())
-            ->orderBy('date', 'desc')
-            ->first();
+        return $logins->lastLogin($this, $allowFailed);
     }
 }

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -65,7 +65,7 @@ class LoginModel extends Model
     {
         return $this->where('success', 1)
             ->where('user_id', $user->id)
-            ->orderBy('date', 'desc')
+            ->orderBy('id', 'desc')
             ->first();
     }
 

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -66,12 +66,12 @@ class LoginModel extends Model
         if (! $allowFailed) {
             $this->where('success', 1)
                 ->where('user_id', $user->id);
+        } else {
+            $this->where('identifier', $user->email)
+                ->orWhere('identifier', $user->username);
         }
 
-        return $this
-            ->where('identifier', $user->email)
-            ->orderBy('date', 'desc')
-            ->first();
+        return $this->orderBy('date', 'desc')->first();
     }
 
     /**

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -61,17 +61,12 @@ class LoginModel extends Model
     /**
      * Returns the last login information for the user
      */
-    public function lastLogin(User $user, bool $allowFailed = false): ?Login
+    public function lastLogin(User $user): ?Login
     {
-        if (! $allowFailed) {
-            $this->where('success', 1)
-                ->where('user_id', $user->id);
-        } else {
-            $this->where('identifier', $user->email)
-                ->orWhere('identifier', $user->username);
-        }
-
-        return $this->orderBy('date', 'desc')->first();
+        return $this->where('success', 1)
+            ->where('user_id', $user->id)
+            ->orderBy('date', 'desc')
+            ->first();
     }
 
     /**

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -5,6 +5,7 @@ namespace CodeIgniter\Shield\Models;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Model;
 use CodeIgniter\Shield\Entities\Login;
+use CodeIgniter\Shield\Entities\User;
 use Exception;
 use Faker\Generator;
 
@@ -55,6 +56,22 @@ class LoginModel extends Model
         ]);
 
         $this->checkQueryReturn($return);
+    }
+
+    /**
+     * Returns the last login information for the user
+     */
+    public function lastLogin(User $user, bool $allowFailed = false): ?Login
+    {
+        if (! $allowFailed) {
+            $this->where('success', 1)
+                ->where('user_id', $user->id);
+        }
+
+        return $this
+            ->where('identifier', $user->email)
+            ->orderBy('date', 'desc')
+            ->first();
     }
 
     /**

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -76,7 +76,7 @@ final class UserTest extends TestCase
         // No logins found.
         $this->assertNull($this->user->lastLogin());
 
-        $login1 = fake(
+        fake(
             LoginModel::class,
             ['identifier' => $this->user->email, 'user_id' => $this->user->id]
         );
@@ -84,7 +84,7 @@ final class UserTest extends TestCase
             LoginModel::class,
             ['identifier' => $this->user->email, 'user_id' => $this->user->id]
         );
-        $login3 = fake(
+        fake(
             LoginModel::class,
             ['identifier' => $this->user->email, 'user_id' => $this->user->id, 'success' => false]
         );

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -76,11 +76,15 @@ final class UserTest extends TestCase
         // No logins found.
         $this->assertNull($this->user->lastLogin());
 
-        $login = fake(
+        $login1 = fake(
             LoginModel::class,
             ['identifier' => $this->user->email, 'user_id' => $this->user->id]
         );
-        fake(
+        $login2 = fake(
+            LoginModel::class,
+            ['identifier' => $this->user->email, 'user_id' => $this->user->id]
+        );
+        $login3 = fake(
             LoginModel::class,
             ['identifier' => $this->user->email, 'user_id' => $this->user->id, 'success' => false]
         );
@@ -88,7 +92,7 @@ final class UserTest extends TestCase
         $last = $this->user->lastLogin();
 
         $this->assertInstanceOf(Login::class, $last); // @phpstan-ignore-line
-        $this->assertSame($login->id, $last->id);
+        $this->assertSame($login2->id, $last->id);
         $this->assertInstanceOf(Time::class, $last->date);
     }
 


### PR DESCRIPTION
Fixes #155

- returns the last successful login in the `auth_logins` table of the user
- refactor
- ~~When `$allowFailed` is false, returns the last successful login in the `auth_logins` table~~
- ~~When `$allowFailed` is true, finds the last login by email or username in the `auth_logins` table~~
