### PR TITLE
feat: add `id_type` in logins table

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -16,7 +16,7 @@ use CodeIgniter\Shield\Models\UserIdentityModel;
  */
 class Email2FA implements ActionInterface
 {
-    private string $type = 'email_2fa';
+    private string $type = Session::ID_TYPE_EMAIL_2FA;
 
     /**
      * Displays the "Hey we're going to send you a number to your email"

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -13,7 +13,7 @@ use CodeIgniter\Shield\Models\UserIdentityModel;
 
 class EmailActivator implements ActionInterface
 {
-    private string $type = 'email_activate';
+    private string $type = Session::ID_TYPE_EMAIL_ACTIVATE;
 
     /**
      * Shows the initial screen to the user telling them

--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -51,7 +51,8 @@ class AccessTokens implements AuthenticatorInterface
         if (! $result->isOK()) {
             // Always record a login attempt, whether success or not.
             $this->loginModel->recordLoginAttempt(
-                'token: ' . ($credentials['token'] ?? ''),
+                'token',
+                $credentials['token'] ?? '',
                 false,
                 $ipAddress,
                 $userAgent
@@ -69,7 +70,8 @@ class AccessTokens implements AuthenticatorInterface
         $this->login($user);
 
         $this->loginModel->recordLoginAttempt(
-            'token: ' . ($credentials['token'] ?? ''),
+            'token',
+            $credentials['token'] ?? '',
             true,
             $ipAddress,
             $userAgent,

--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -15,6 +15,8 @@ use InvalidArgumentException;
 
 class AccessTokens implements AuthenticatorInterface
 {
+    public const ID_TYPE_ACCESS_TOKEN = 'access_token';
+
     /**
      * The persistence engine
      */
@@ -51,7 +53,7 @@ class AccessTokens implements AuthenticatorInterface
         if (! $result->isOK()) {
             // Always record a login attempt, whether success or not.
             $this->loginModel->recordLoginAttempt(
-                'token',
+                self::ID_TYPE_ACCESS_TOKEN,
                 $credentials['token'] ?? '',
                 false,
                 $ipAddress,
@@ -70,7 +72,7 @@ class AccessTokens implements AuthenticatorInterface
         $this->login($user);
 
         $this->loginModel->recordLoginAttempt(
-            'token',
+            self::ID_TYPE_ACCESS_TOKEN,
             $credentials['token'] ?? '',
             true,
             $ipAddress,

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -239,7 +239,7 @@ class Session implements AuthenticatorInterface
         string $userAgent,
         $userId = null
     ): void {
-        $idType = ! isset($credentials['email']) && isset($credentials['username'])
+        $idType = (! isset($credentials['email']) && isset($credentials['username']))
             ? 'username'
             : 'email';
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -239,7 +239,13 @@ class Session implements AuthenticatorInterface
         string $userAgent,
         $userId = null
     ): void {
+        $idType = 'email';
+        if (! isset($credentials['email']) && isset($credentials['username'])) {
+            $idType = 'username';
+        }
+
         $this->loginModel->recordLoginAttempt(
+            $idType,
             $credentials['email'] ?? $credentials['username'],
             $success,
             $ipAddress,

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -25,10 +25,20 @@ use stdClass;
 
 class Session implements AuthenticatorInterface
 {
-    private const STATE_UNKNOWN   = 0;
-    private const STATE_ANONYMOUS = 1;
-    private const STATE_PENDING   = 2;
-    private const STATE_LOGGED_IN = 3;
+    /**
+     * @var string Special ID Type.
+     *             `username` is stored in `users` table, so no `auth_identities` record.
+     */
+    public const ID_TYPE_USERNAME = 'username';
+
+    public const ID_TYPE_EMAIL_PASSWORD = 'email_password';
+    public const ID_TYPE_MAGIC_LINK     = 'magic-link';
+    public const ID_TYPE_EMAIL_2FA      = 'email_2fa';
+    public const ID_TYPE_EMAIL_ACTIVATE = 'email_activate';
+    private const STATE_UNKNOWN         = 0;
+    private const STATE_ANONYMOUS       = 1;
+    private const STATE_PENDING         = 2;
+    private const STATE_LOGGED_IN       = 3;
 
     /**
      * The persistence engine
@@ -240,8 +250,8 @@ class Session implements AuthenticatorInterface
         $userId = null
     ): void {
         $idType = (! isset($credentials['email']) && isset($credentials['username']))
-            ? 'username'
-            : 'email';
+            ? self::ID_TYPE_USERNAME
+            : self::ID_TYPE_EMAIL_PASSWORD;
 
         $this->loginModel->recordLoginAttempt(
             $idType,

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -239,10 +239,9 @@ class Session implements AuthenticatorInterface
         string $userAgent,
         $userId = null
     ): void {
-        $idType = 'email';
-        if (! isset($credentials['email']) && isset($credentials['username'])) {
-            $idType = 'username';
-        }
+        $idType = ! isset($credentials['email']) && isset($credentials['username'])
+            ? 'username'
+            : 'email';
 
         $this->loginModel->recordLoginAttempt(
             $idType,

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -62,7 +62,7 @@ class MagicLinkController extends BaseController
         $identityModel = model(UserIdentityModel::class);
 
         // Delete any previous magic-link identities
-        $identityModel->deleteIdentitiesByType($user, 'magic-link');
+        $identityModel->deleteIdentitiesByType($user, Session::ID_TYPE_MAGIC_LINK);
 
         // Generate the code and save it as an identity
         helper('text');
@@ -70,7 +70,7 @@ class MagicLinkController extends BaseController
 
         $identityModel->insert([
             'user_id' => $user->id,
-            'type'    => 'magic-link',
+            'type'    => Session::ID_TYPE_MAGIC_LINK,
             'secret'  => $token,
             'expires' => Time::now()->addSeconds(setting('Auth.magicLinkLifetime'))->toDateTimeString(),
         ]);
@@ -105,7 +105,7 @@ class MagicLinkController extends BaseController
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        $identity = $identityModel->getIdentityBySecret('magic-link', $token);
+        $identity = $identityModel->getIdentityBySecret(Session::ID_TYPE_MAGIC_LINK, $token);
 
         $identifier = $token ?? '';
 
@@ -158,7 +158,7 @@ class MagicLinkController extends BaseController
         $loginModel = model(LoginModel::class);
 
         $loginModel->recordLoginAttempt(
-            'magic-link',
+            Session::ID_TYPE_MAGIC_LINK,
             $identifier,
             $success,
             $this->request->getIPAddress(),

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -107,7 +107,7 @@ class MagicLinkController extends BaseController
 
         $identity = $identityModel->getIdentityBySecret('magic-link', $token);
 
-        $identifier = 'magic-link: ' . $token;
+        $identifier = $token ?? '';
 
         // No token found?
         if ($identity === null) {
@@ -158,6 +158,7 @@ class MagicLinkController extends BaseController
         $loginModel = model(LoginModel::class);
 
         $loginModel->recordLoginAttempt(
+            'magic-link',
             $identifier,
             $success,
             $this->request->getIPAddress(),

--- a/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
@@ -57,6 +57,7 @@ class CreateAuthTables extends Migration
             'id'         => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
             'ip_address' => ['type' => 'varchar', 'constraint' => 255],
             'user_agent' => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
+            'id_type'    => ['type' => 'varchar', 'constraint' => 255],
             'identifier' => ['type' => 'varchar', 'constraint' => 255],
             'user_id'    => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'null' => true], // Only for successful logins
             'date'       => ['type' => 'datetime'],
@@ -76,6 +77,7 @@ class CreateAuthTables extends Migration
             'id'         => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'auto_increment' => true],
             'ip_address' => ['type' => 'varchar', 'constraint' => 255],
             'user_agent' => ['type' => 'varchar', 'constraint' => 255, 'null' => true],
+            'id_type'    => ['type' => 'varchar', 'constraint' => 255],
             'identifier' => ['type' => 'varchar', 'constraint' => 255],
             'user_id'    => ['type' => 'int', 'constraint' => 11, 'unsigned' => true, 'null' => true], // Only for successful logins
             'date'       => ['type' => 'datetime'],

--- a/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
@@ -64,7 +64,7 @@ class CreateAuthTables extends Migration
             'success'    => ['type' => 'tinyint', 'constraint' => 1],
         ]);
         $this->forge->addPrimaryKey('id');
-        $this->forge->addKey('identifier');
+        $this->forge->addKey(['id_type', 'identifier']);
         $this->forge->addKey('user_id');
         // NOTE: Do NOT delete the user_id or identifier when the user is deleted for security audits
         $this->forge->createTable('auth_logins', true);
@@ -84,7 +84,7 @@ class CreateAuthTables extends Migration
             'success'    => ['type' => 'tinyint', 'constraint' => 1],
         ]);
         $this->forge->addPrimaryKey('id');
-        $this->forge->addKey('identifier');
+        $this->forge->addKey(['id_type', 'identifier']);
         $this->forge->addKey('user_id');
         // NOTE: Do NOT delete the user_id or identifier when the user is deleted for security audits
         $this->forge->createTable('auth_token_logins', true);

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -3,6 +3,7 @@
 namespace CodeIgniter\Shield\Entities;
 
 use CodeIgniter\Entity\Entity;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Authentication\Traits\HasAccessTokens;
 use CodeIgniter\Shield\Authorization\Traits\Authorizable;
 use CodeIgniter\Shield\Models\LoginModel;
@@ -47,7 +48,8 @@ class User extends Entity
     /**
      * Returns the first identity of the given $type for this user.
      *
-     * @param string $type 'email_2fa'|'email_activate'|'email_password'|'magic-link'|'access_token'
+     * @param string $type See const ID_TYPE_* in Authenticator.
+     *                     'email_2fa'|'email_activate'|'email_password'|'magic-link'|'access_token'
      */
     public function getIdentity(string $type): ?UserIdentity
     {
@@ -116,7 +118,7 @@ class User extends Entity
      */
     public function getEmailIdentity(): ?UserIdentity
     {
-        return $this->getIdentity('email_password');
+        return $this->getIdentity(Session::ID_TYPE_EMAIL_PASSWORD);
     }
 
     /**

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -47,7 +47,7 @@ class User extends Entity
     /**
      * Returns the first identity of the given $type for this user.
      *
-     * @param string $type 'email_2fa'|'email_activate'|'email_password'|'magic-link'
+     * @param string $type 'email_2fa'|'email_activate'|'email_password'|'magic-link'|'access_token'
      */
     public function getIdentity(string $type): ?UserIdentity
     {

--- a/src/Models/CheckQueryReturnTrait.php
+++ b/src/Models/CheckQueryReturnTrait.php
@@ -2,6 +2,7 @@
 
 namespace CodeIgniter\Shield\Models;
 
+use CodeIgniter\Shield\Exceptions\RuntimeException;
 use ReflectionObject;
 use ReflectionProperty;
 
@@ -13,12 +14,29 @@ trait CheckQueryReturnTrait
     {
         $this->restoreDBDebug();
 
+        $this->checkValidationError();
+
         if ($return === false) {
             $error   = $this->db->error();
             $message = 'Query error: ' . $error['code'] . ', '
                 . $error['message'] . ', query: ' . $this->db->getLastQuery();
 
             throw new DatabaseException($message, $error['code']);
+        }
+    }
+
+    private function checkValidationError(): void
+    {
+        $validationErrors = $this->validation->getErrors();
+
+        if ($validationErrors !== []) {
+            $message = 'Validation error:';
+
+            foreach ($validationErrors as $field => $error) {
+                $message .= ' [' . $field . '] ' . $error;
+            }
+
+            throw new RuntimeException($message);
         }
     }
 

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -4,6 +4,7 @@ namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Model;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\Login;
 use CodeIgniter\Shield\Entities\User;
 use Exception;
@@ -87,7 +88,7 @@ class LoginModel extends Model
     {
         return new Login([
             'ip_address' => $faker->ipv4,
-            'id_type'    => 'email',
+            'id_type'    => Session::ID_TYPE_EMAIL_PASSWORD,
             'identifier' => $faker->email,
             'user_id'    => null,
             'date'       => Time::parse('-1 day')->toDateTimeString(),

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -20,6 +20,7 @@ class LoginModel extends Model
     protected $allowedFields  = [
         'ip_address',
         'user_agent',
+        'id_type',
         'identifier',
         'user_id',
         'date',
@@ -28,6 +29,7 @@ class LoginModel extends Model
     protected $useTimestamps   = false;
     protected $validationRules = [
         'ip_address' => 'required',
+        'id_type'    => 'required',
         'identifier' => 'required',
         'user_agent' => 'permit_empty|string',
         'user_id'    => 'permit_empty|integer',
@@ -40,6 +42,7 @@ class LoginModel extends Model
      * @param int|string|null $userId
      */
     public function recordLoginAttempt(
+        string $idType,
         string $identifier,
         bool $success,
         ?string $ipAddress = null,
@@ -49,6 +52,7 @@ class LoginModel extends Model
         $return = $this->insert([
             'ip_address' => $ipAddress,
             'user_agent' => $userAgent,
+            'id_type'    => $idType,
             'identifier' => $identifier,
             'user_id'    => $userId,
             'date'       => date('Y-m-d H:i:s'),
@@ -78,6 +82,7 @@ class LoginModel extends Model
     {
         return new Login([
             'ip_address' => $faker->ipv4,
+            'id_type'    => 'email',
             'identifier' => $faker->email,
             'user_id'    => null,
             'date'       => Time::parse('-1 day')->toDateTimeString(),

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -30,7 +30,7 @@ class LoginModel extends Model
     protected $validationRules = [
         'ip_address' => 'required',
         'id_type'    => 'required',
-        'identifier' => 'required',
+        'identifier' => 'permit_empty|string',
         'user_agent' => 'permit_empty|string',
         'user_id'    => 'permit_empty|integer',
         'date'       => 'required|valid_date',

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -41,9 +41,9 @@ class LoginModel extends Model
     /**
      * Records login attempt.
      *
-     * @param string          $idType Identifier type.
-     *                                auth_logins: 'email'|'username'|'magic-link'
-     *                                auth_token_logins: 'token'
+     * @param string          $idType Identifier type. See const ID_YPE_* in Authenticator.
+     *                                auth_logins: 'email_password'|'username'|'magic-link'
+     *                                auth_token_logins: 'access-token'
      * @param int|string|null $userId
      */
     public function recordLoginAttempt(

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -39,6 +39,11 @@ class LoginModel extends Model
     protected $skipValidation     = false;
 
     /**
+     * Records login attempt.
+     *
+     * @param string          $idType Identifier type.
+     *                                auth_logins: 'email'|'username'|'magic-link'
+     *                                auth_token_logins: 'token'
      * @param int|string|null $userId
      */
     public function recordLoginAttempt(

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -3,6 +3,8 @@
 namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\Model;
+use CodeIgniter\Shield\Authentication\Authenticators\AccessTokens;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Authentication\Passwords;
 use CodeIgniter\Shield\Entities\AccessToken;
 use CodeIgniter\Shield\Entities\User;
@@ -59,7 +61,7 @@ class UserIdentityModel extends Model
 
         $return = $this->insert([
             'user_id' => $user->id,
-            'type'    => 'email_password',
+            'type'    => Session::ID_TYPE_EMAIL_PASSWORD,
             'secret'  => $credentials['email'],
             'secret2' => $passwords->hash($credentials['password']),
         ]);
@@ -119,7 +121,7 @@ class UserIdentityModel extends Model
         helper('text');
 
         $return = $this->insert([
-            'type'    => 'access_token',
+            'type'    => AccessTokens::ID_TYPE_ACCESS_TOKEN,
             'user_id' => $user->id,
             'name'    => $name,
             'secret'  => hash('sha256', $rawToken = random_string('crypto', 64)),
@@ -141,7 +143,7 @@ class UserIdentityModel extends Model
     public function getAccessTokenByRawToken(string $rawToken): ?AccessToken
     {
         return $this
-            ->where('type', 'access_token')
+            ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->where('secret', hash('sha256', $rawToken))
             ->asObject(AccessToken::class)
             ->first();
@@ -150,7 +152,7 @@ class UserIdentityModel extends Model
     public function getAccessToken(User $user, string $rawToken): ?AccessToken
     {
         return $this->where('user_id', $user->id)
-            ->where('type', 'access_token')
+            ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->where('secret', hash('sha256', $rawToken))
             ->asObject(AccessToken::class)
             ->first();
@@ -164,7 +166,7 @@ class UserIdentityModel extends Model
     public function getAccessTokenById($id, User $user): ?AccessToken
     {
         return $this->where('user_id', $user->id)
-            ->where('type', 'access_token')
+            ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->where('id', $id)
             ->asObject(AccessToken::class)
             ->first();
@@ -177,7 +179,7 @@ class UserIdentityModel extends Model
     {
         return $this
             ->where('user_id', $user->id)
-            ->where('type', 'access_token')
+            ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->orderBy($this->primaryKey)
             ->asObject(AccessToken::class)
             ->findAll();
@@ -267,7 +269,7 @@ class UserIdentityModel extends Model
     public function revokeAccessToken(User $user, string $rawToken): void
     {
         $return = $this->where('user_id', $user->id)
-            ->where('type', 'access_token')
+            ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->where('secret', hash('sha256', $rawToken))
             ->delete();
 
@@ -280,7 +282,7 @@ class UserIdentityModel extends Model
     public function revokeAllAccessTokens(User $user): void
     {
         $return = $this->where('user_id', $user->id)
-            ->where('type', 'access_token')
+            ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->delete();
 
         $this->checkQueryReturn($return);
@@ -290,7 +292,7 @@ class UserIdentityModel extends Model
     {
         return new UserIdentity([
             'user_id'      => fake(UserModel::class)->id,
-            'type'         => 'email_password',
+            'type'         => Session::ID_TYPE_EMAIL_PASSWORD,
             'name'         => null,
             'secret'       => 'info@example.com',
             'secret2'      => password_hash('secret', PASSWORD_DEFAULT),

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -5,6 +5,7 @@ namespace CodeIgniter\Shield\Models;
 use CodeIgniter\Database\Database;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Model;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
 use Faker\Generator;
@@ -153,7 +154,7 @@ class UserModel extends Model
         if (! empty($email)) {
             $data = $this->select('users.*, auth_identities.secret as email, auth_identities.secret2 as password_hash')
                 ->join('auth_identities', 'auth_identities.user_id = users.id')
-                ->where('auth_identities.type', 'email_password')
+                ->where('auth_identities.type', Session::ID_TYPE_EMAIL_PASSWORD)
                 ->where("LOWER({$prefix}auth_identities.secret)", strtolower($email))
                 ->asArray()
                 ->first();

--- a/tests/Authentication/AccessTokenAuthenticatorTest.php
+++ b/tests/Authentication/AccessTokenAuthenticatorTest.php
@@ -60,7 +60,7 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
         $this->assertNull($this->auth->getUser());
     }
 
-    public function testLoginByidNoToken()
+    public function testLoginByIdNoToken()
     {
         $user = fake(UserModel::class);
 

--- a/tests/Authentication/AccessTokenAuthenticatorTest.php
+++ b/tests/Authentication/AccessTokenAuthenticatorTest.php
@@ -169,7 +169,8 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
 
         // A login attempt should have always been recorded
         $this->seeInDatabase('auth_token_logins', [
-            'identifier' => 'token: abc123',
+            'id_type'    => 'token',
+            'identifier' => 'abc123',
             'success'    => 0,
         ]);
     }
@@ -196,7 +197,8 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
 
         // A login attempt should have been recorded
         $this->seeInDatabase('auth_token_logins', [
-            'identifier' => 'token: ' . $token->raw_token,
+            'id_type'    => 'token',
+            'identifier' => $token->raw_token,
             'success'    => 1,
         ]);
     }

--- a/tests/Authentication/AccessTokenAuthenticatorTest.php
+++ b/tests/Authentication/AccessTokenAuthenticatorTest.php
@@ -169,7 +169,7 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
 
         // A login attempt should have always been recorded
         $this->seeInDatabase('auth_token_logins', [
-            'id_type'    => 'token',
+            'id_type'    => AccessTokens::ID_TYPE_ACCESS_TOKEN,
             'identifier' => 'abc123',
             'success'    => 0,
         ]);
@@ -197,7 +197,7 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
 
         // A login attempt should have been recorded
         $this->seeInDatabase('auth_token_logins', [
-            'id_type'    => 'token',
+            'id_type'    => AccessTokens::ID_TYPE_ACCESS_TOKEN,
             'identifier' => $token->raw_token,
             'success'    => 1,
         ]);

--- a/tests/Authentication/MagicLinkTest.php
+++ b/tests/Authentication/MagicLinkTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Authentication;
 
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\UserIdentityModel;
 use CodeIgniter\Shield\Models\UserModel;
@@ -79,7 +80,7 @@ final class MagicLinkTest extends TestCase
 
         $this->seeInDatabase('auth_identities', [
             'user_id' => $user->id,
-            'type'    => 'magic-link',
+            'type'    => Session::ID_TYPE_MAGIC_LINK,
         ]);
     }
 
@@ -101,7 +102,7 @@ final class MagicLinkTest extends TestCase
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
         $identities->insert([
             'user_id' => $user->id,
-            'type'    => 'magic-link',
+            'type'    => Session::ID_TYPE_MAGIC_LINK,
             'secret'  => 'abasdasdf',
             'expires' => Time::now()->subDays(5),
         ]);
@@ -120,7 +121,7 @@ final class MagicLinkTest extends TestCase
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
         $identities->insert([
             'user_id' => $user->id,
-            'type'    => 'magic-link',
+            'type'    => Session::ID_TYPE_MAGIC_LINK,
             'secret'  => 'abasdasdf',
             'expires' => Time::now()->addMinutes(60),
         ]);

--- a/tests/Controllers/ActionsTest.php
+++ b/tests/Controllers/ActionsTest.php
@@ -6,6 +6,7 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\Shield\Authentication\Actions\Email2FA;
 use CodeIgniter\Shield\Authentication\Actions\EmailActivator;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Models\UserIdentityModel;
 use CodeIgniter\Shield\Test\AuthenticationTesting;
 use CodeIgniter\Test\DatabaseTestTrait;
@@ -102,7 +103,7 @@ final class ActionsTest extends TestCase
         $identities = model(UserIdentityModel::class);
         $identities->insert([
             'user_id' => $this->user->id,
-            'type'    => 'email_2fa',
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
             'secret'  => '123456',
             'name'    => 'login',
             'extra'   => lang('Auth.need2FA'),
@@ -156,7 +157,7 @@ final class ActionsTest extends TestCase
         // Identity should have been removed
         $this->dontSeeInDatabase('auth_identities', [
             'user_id' => $this->user->id,
-            'type'    => 'email_2fa',
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
         ]);
 
         // Session should have been cleared
@@ -175,7 +176,7 @@ final class ActionsTest extends TestCase
 
         $this->seeInDatabase('auth_identities', [
             'user_id' => $this->user->id,
-            'type'    => 'email_2fa',
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
             'name'    => 'login',
         ]);
     }
@@ -191,7 +192,7 @@ final class ActionsTest extends TestCase
         $identities = model(UserIdentityModel::class);
         $identities->insert([
             'user_id' => $this->user->id,
-            'type'    => 'email_2fa',
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
             'secret'  => '123456',
             'name'    => 'login',
             'extra'   => lang('Auth.need2FA'),
@@ -212,7 +213,7 @@ final class ActionsTest extends TestCase
         $identities = model(UserIdentityModel::class);
         $identities->insert([
             'user_id' => $this->user->id,
-            'type'    => 'email_activate',
+            'type'    => Session::ID_TYPE_EMAIL_ACTIVATE,
             'secret'  => '123456',
             'name'    => 'register',
             'extra'   => lang('Auth.needVerification'),
@@ -260,7 +261,7 @@ final class ActionsTest extends TestCase
         // Identity should have been removed
         $this->dontSeeInDatabase('auth_identities', [
             'user_id' => $this->user->id,
-            'type'    => 'email_2fa',
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
         ]);
 
         // Session should have been cleared

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -4,6 +4,7 @@ namespace Tests\Controllers;
 
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Shield\Authentication\Actions\EmailActivator;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Authentication\Passwords\ValidationRules;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Test\FeatureTestTrait;
@@ -63,7 +64,7 @@ final class RegisterTest extends DatabaseTestCase
         $user = model(UserModel::class)->where('username', 'JohnDoe')->first();
         $this->seeInDatabase('auth_identities', [
             'user_id' => $user->id,
-            'type'    => 'email_password',
+            'type'    => Session::ID_TYPE_EMAIL_PASSWORD,
             'secret'  => 'john.doe@example.com',
         ]);
 

--- a/tests/Unit/LoginModelTest.php
+++ b/tests/Unit/LoginModelTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit;
+
+use CodeIgniter\Shield\Exceptions\RuntimeException;
+use CodeIgniter\Shield\Models\LoginModel;
+use CodeIgniter\Test\DatabaseTestTrait;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class LoginModelTest extends TestCase
+{
+    use DatabaseTestTrait;
+
+    protected $namespace;
+    protected $refresh = true;
+
+    private function createLoginModel(): LoginModel
+    {
+        return new LoginModel();
+    }
+
+    public function testRecordLoginAttemptThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Validation error: [ip_address] The ip_address field is required.'
+            . ' [id_type] The id_type field is required.'
+        );
+
+        $model = $this->createLoginModel();
+
+        $model->recordLoginAttempt(
+            '',
+            '',
+            true
+        );
+    }
+}

--- a/tests/Unit/UserIdentityModelTest.php
+++ b/tests/Unit/UserIdentityModelTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\DatabaseException;
 use CodeIgniter\Shield\Models\UserIdentityModel;
@@ -33,14 +34,14 @@ final class UserIdentityModelTest extends TestCase
         // "type and secret" are unique.
         $model->create([
             'user_id' => 1,
-            'type'    => 'email_activate',
+            'type'    => Session::ID_TYPE_EMAIL_ACTIVATE,
             'secret'  => '123456',
             'name'    => 'register',
             'extra'   => lang('Auth.needVerification'),
         ]);
         $model->create([
             'user_id' => 1,
-            'type'    => 'email_activate',
+            'type'    => Session::ID_TYPE_EMAIL_ACTIVATE,
             'secret'  => '123456',
             'name'    => 'register',
             'extra'   => lang('Auth.needVerification'),
@@ -53,7 +54,7 @@ final class UserIdentityModelTest extends TestCase
 
         /** @var User $user */
         $user = fake(UserModel::class, ['id' => '1']);
-        fake(UserIdentityModel::class, ['user_id' => 2, 'type' => 'email_activate', 'secret' => '666666']);
+        fake(UserIdentityModel::class, ['user_id' => 2, 'type' => Session::ID_TYPE_EMAIL_ACTIVATE, 'secret' => '666666']);
 
         $model = $this->createUserIdentityModel();
 
@@ -62,7 +63,7 @@ final class UserIdentityModelTest extends TestCase
         $model->createCodeIdentity(
             $user,
             [
-                'type'  => 'email_activate',
+                'type'  => Session::ID_TYPE_EMAIL_ACTIVATE,
                 'name'  => 'register',
                 'extra' => lang('Auth.needVerification'),
             ],

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -78,15 +78,20 @@ final class UserTest extends TestCase
 
         fake(
             LoginModel::class,
-            ['identifier' => $this->user->email, 'user_id' => $this->user->id]
+            ['id_type' => 'email', 'identifier' => $this->user->email, 'user_id' => $this->user->id]
         );
         $login2 = fake(
             LoginModel::class,
-            ['identifier' => $this->user->email, 'user_id' => $this->user->id]
+            ['id_type' => 'email', 'identifier' => $this->user->email, 'user_id' => $this->user->id]
         );
         fake(
             LoginModel::class,
-            ['identifier' => $this->user->email, 'user_id' => $this->user->id, 'success' => false]
+            [
+                'id_type'    => 'email',
+                'identifier' => $this->user->email,
+                'user_id'    => $this->user->id,
+                'success'    => false,
+            ]
         );
 
         $last = $this->user->lastLogin();

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\Login;
 use CodeIgniter\Shield\Entities\UserIdentity;
 use CodeIgniter\Shield\Models\LoginModel;
@@ -70,7 +71,7 @@ final class UserTest extends TestCase
     {
         fake(
             UserIdentityModel::class,
-            ['user_id' => $this->user->id, 'type' => 'email_password', 'secret' => 'foo@example.com']
+            ['user_id' => $this->user->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD, 'secret' => 'foo@example.com']
         );
 
         // No logins found.


### PR DESCRIPTION
~~Need to rebase after merging  #177~~

Identifiers can be added, and it will be not possible to determine what they are just from the identifier string.
Currently, `token: ` is also added to access tokens. 
Also, if there is no constraint, it is not possible to tell whether it is an `email` or a `username` just from the string.

It is easier to know what it is if we add a column for identifier type.

- add `id_type` in `auth_logins` and `auth_token_logins`
  - type: `email_password`, `username`, `magic-link`, and `access_token`
- add validation error check in `CheckQueryReturnTrait`
- add const `ID_TYPE_*` in `Session` and `AccessTokens`