### PR TITLE
fix: Models return type

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -604,7 +604,7 @@ class Session implements AuthenticatorInterface
         $this->completeLogin($user);
     }
 
-    private function issueRememberMeToken()
+    private function issueRememberMeToken(): void
     {
         if ($this->shouldRemember && setting('Auth.sessionConfig')['allowRemembering']) {
             $this->rememberUser($this->user);

--- a/src/Authentication/Traits/HasAccessTokens.php
+++ b/src/Authentication/Traits/HasAccessTokens.php
@@ -37,23 +37,23 @@ trait HasAccessTokens
     /**
      * Delete any access tokens for the given raw token.
      */
-    public function revokeAccessToken(string $rawToken): bool
+    public function revokeAccessToken(string $rawToken): void
     {
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        return $identityModel->revokeAccessToken($this, $rawToken);
+        $identityModel->revokeAccessToken($this, $rawToken);
     }
 
     /**
      * Revokes all access tokens for this user.
      */
-    public function revokeAllAccessTokens(): bool
+    public function revokeAllAccessTokens(): void
     {
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        return $identityModel->revokeAllAccessTokens($this);
+        $identityModel->revokeAllAccessTokens($this);
     }
 
     /**

--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -7,6 +7,8 @@ use CodeIgniter\Shield\Entities\User;
 
 class GroupModel extends Model
 {
+    use CheckQueryReturnTrait;
+
     protected $table          = 'auth_groups_users';
     protected $primaryKey     = 'id';
     protected $returnType     = 'array';
@@ -37,9 +39,11 @@ class GroupModel extends Model
      */
     public function deleteAll($userId): void
     {
-        $this->builder()
+        $return = $this->builder()
             ->where('user_id', $userId)
             ->delete();
+
+        $this->checkQueryReturn($return);
     }
 
     /**
@@ -48,9 +52,11 @@ class GroupModel extends Model
      */
     public function deleteNotIn($userId, $cache): void
     {
-        $this->builder()
+        $return = $this->builder()
             ->where('user_id', $userId)
             ->whereNotIn('group', $cache)
             ->delete();
+
+        $this->checkQueryReturn($return);
     }
 }

--- a/src/Models/PermissionModel.php
+++ b/src/Models/PermissionModel.php
@@ -7,6 +7,8 @@ use CodeIgniter\Shield\Entities\User;
 
 class PermissionModel extends Model
 {
+    use CheckQueryReturnTrait;
+
     protected $table          = 'auth_permissions_users';
     protected $primaryKey     = 'id';
     protected $returnType     = 'array';
@@ -37,9 +39,11 @@ class PermissionModel extends Model
      */
     public function deleteAll($userId): void
     {
-        $this->builder()
+        $return = $this->builder()
             ->where('user_id', $userId)
             ->delete();
+
+        $this->checkQueryReturn($return);
     }
 
     /**
@@ -48,9 +52,11 @@ class PermissionModel extends Model
      */
     public function deleteNotIn($userId, $cache): void
     {
-        $this->builder()
+        $return = $this->builder()
             ->where('user_id', $userId)
             ->whereNotIn('permission', $cache)
             ->delete();
+
+        $this->checkQueryReturn($return);
     }
 }

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -57,12 +57,14 @@ class UserIdentityModel extends Model
         /** @var Passwords $passwords */
         $passwords = service('passwords');
 
-        $this->insert([
+        $return = $this->insert([
             'user_id' => $user->id,
             'type'    => 'email_password',
             'secret'  => $credentials['email'],
             'secret2' => $passwords->hash($credentials['password']),
         ]);
+
+        $this->checkQueryReturn($return);
     }
 
     /**
@@ -116,13 +118,15 @@ class UserIdentityModel extends Model
     {
         helper('text');
 
-        $this->insert([
+        $return = $this->insert([
             'type'    => 'access_token',
             'user_id' => $user->id,
             'name'    => $name,
             'secret'  => hash('sha256', $rawToken = random_string('crypto', 64)),
             'extra'   => serialize($scopes),
         ]);
+
+        $this->checkQueryReturn($return);
 
         /** @var AccessToken $token */
         $token = $this
@@ -243,14 +247,18 @@ class UserIdentityModel extends Model
     {
         $identity->last_used_at = date('Y-m-d H:i:s');
 
-        $this->save($identity);
+        $return = $this->save($identity);
+
+        $this->checkQueryReturn($return);
     }
 
     public function deleteIdentitiesByType(User $user, string $type): void
     {
-        $this->where('user_id', $user->id)
+        $return = $this->where('user_id', $user->id)
             ->where('type', $type)
             ->delete();
+
+        $this->checkQueryReturn($return);
     }
 
     /**

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -256,22 +256,26 @@ class UserIdentityModel extends Model
     /**
      * Delete any access tokens for the given raw token.
      */
-    public function revokeAccessToken(User $user, string $rawToken)
+    public function revokeAccessToken(User $user, string $rawToken): void
     {
-        return $this->where('user_id', $user->id)
+        $return = $this->where('user_id', $user->id)
             ->where('type', 'access_token')
             ->where('secret', hash('sha256', $rawToken))
             ->delete();
+
+        $this->checkQueryReturn($return);
     }
 
     /**
      * Revokes all access tokens for this user.
      */
-    public function revokeAllAccessTokens(User $user)
+    public function revokeAllAccessTokens(User $user): void
     {
-        return $this->where('user_id', $user->id)
+        $return = $this->where('user_id', $user->id)
             ->where('type', 'access_token')
             ->delete();
+
+        $this->checkQueryReturn($return);
     }
 
     public function fake(Generator &$faker): UserIdentity

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -195,6 +195,8 @@ class UserModel extends Model
      * fields if they've been modified.
      *
      * @param array|User $data
+     *
+     * @TODO can't change the return type to void.
      */
     public function save($data): bool
     {


### PR DESCRIPTION
The return type of write-type query methods are not unified. 
Failures of writing to database are abnormal things, so Exceptions should be thrown.

- change return type to `void`
- add query return value checks

> If you forget to check an error, you’ll get silent bugs. Unchecked error values are worse than uncaught exceptions.
https://programmingduck.com/articles/exceptions-error-values