### PR TITLE
refactor: remove `helper('session')`

### DIFF
--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -27,8 +27,6 @@ class AccessTokens implements AuthenticatorInterface
 
     public function __construct(UserModel $provider)
     {
-        helper('session');
-
         $this->provider = $provider;
 
         $this->loginModel = model(TokenLoginModel::class); // @phpstan-ignore-line


### PR DESCRIPTION
session helper does not exist.
