### PR TITLE
refactor: change logout() return type to void

### DIFF
--- a/src/Authentication/AuthenticatorInterface.php
+++ b/src/Authentication/AuthenticatorInterface.php
@@ -50,7 +50,7 @@ interface AuthenticatorInterface
      *
      * @see https://codeigniter4.github.io/CodeIgniter4/extending/authentication.html
      */
-    public function logout(): bool;
+    public function logout(): void;
 
     /**
      * Returns the currently logged in user.

--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -189,11 +189,9 @@ class AccessTokens implements AuthenticatorInterface
     /**
      * Logs the current user out.
      */
-    public function logout(): bool
+    public function logout(): void
     {
         $this->user = null;
-
-        return true;
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -660,10 +660,10 @@ class Session implements AuthenticatorInterface
     /**
      * Logs the current user out.
      */
-    public function logout(): bool
+    public function logout(): void
     {
         if ($this->user === null) {
-            return true;
+            return;
         }
 
         helper('cookie');
@@ -686,11 +686,9 @@ class Session implements AuthenticatorInterface
         $this->rememberModel->purgeRememberTokens($this->user);
 
         // Trigger logout event
-        $result = Events::trigger('logout', $this->user);
+        Events::trigger('logout', $this->user);
 
         $this->user = null;
-
-        return $result;
     }
 
     /**


### PR DESCRIPTION
- nobody checks the return value of `logout()`
  - normally, the logout process cannot fail.
  -  if something is wrong, it should throw an Exception.
- `Events::trigger()` may return false, but it does not mean errors.
  - when one listener returns false, the execution of listeners stops.
  - https://github.com/codeigniter4/CodeIgniter4/blob/ad956b426a1595a490f6b83b9e74338e0eb219e4/system/Events/Events.php#L149-L161