### PR TITLE
docs: improve sample code in `0 - install.md`

### DIFF
--- a/docs/0 - install.md
+++ b/docs/0 - install.md
@@ -29,14 +29,12 @@ your project.
 
 namespace Config;
 
-use CodeIgniter\Config\BaseConfig;
-use CodeIgniter\Shield\Authentication\Authenticators\AccessTokens;
-use CodeIgniter\Shield\Authentication\Authenticators\Session;
+// ...
 use CodeIgniter\Shield\Config\Auth as ShieldAuth;
 
 class Auth extends ShieldAuth
 {
-    //
+    // ...
 }
 ```
 


### PR DESCRIPTION
Actually the class has the following `use`:
```php
use CodeIgniter\Config\BaseConfig;
use CodeIgniter\Shield\Authentication\Actions\ActionInterface;
use CodeIgniter\Shield\Authentication\AuthenticatorInterface;
use CodeIgniter\Shield\Authentication\Authenticators\AccessTokens;
use CodeIgniter\Shield\Authentication\Authenticators\Session;
use CodeIgniter\Shield\Authentication\Passwords\ValidatorInterface;
use CodeIgniter\Shield\Models\UserModel;
use CodeIgniter\Shield\Config\Auth as ShieldAuth;
```
