### PR TITLE
fix: Debugbar error after logout 

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -688,7 +688,8 @@ class Session implements AuthenticatorInterface
         // Trigger logout event
         Events::trigger('logout', $this->user);
 
-        $this->user = null;
+        $this->user      = null;
+        $this->userState = self::STATE_ANONYMOUS;
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -666,8 +666,6 @@ class Session implements AuthenticatorInterface
             return;
         }
 
-        helper('cookie');
-
         // Destroy the session data - but ensure a session is still
         // available for flash messages, etc.
         /** @var \CodeIgniter\Session\Session $session */

--- a/tests/Collectors/AuthTest.php
+++ b/tests/Collectors/AuthTest.php
@@ -51,6 +51,18 @@ final class AuthTest extends TestCase
         $this->assertStringContainsString('<td>Groups</td><td>admin, beta</td>', $output);
     }
 
+    public function testDisplayNotLoggedInAfterLogout(): void
+    {
+        $authenticator = service('auth')->getAuthenticator();
+        assert($authenticator instanceof Session);
+        $authenticator->login($this->user);
+
+        $authenticator->logout();
+
+        $output = $this->collector->display();
+        $this->assertStringContainsString('Not logged in', $output);
+    }
+
     public function testGetTitleDetails(): void
     {
         $output = $this->collector->getTitleDetails();


### PR DESCRIPTION
Fixes #210

- fix: update `$this->userState` when logout
- remove unneeded helper loading