### PR TITLE
fix: RememberMe cookie does not work with Cookie prefix

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -495,9 +495,12 @@ class Session implements AuthenticatorInterface
 
     private function getRememberMeToken(): ?string
     {
-        helper('cookie');
+        /** @var IncomingRequest $request */
+        $request = service('request');
 
-        return get_cookie('remember');
+        $cookieName = setting('Cookie.prefix') . setting('Auth.sessionConfig')['rememberCookieName'];
+
+        return $request->getCookie($cookieName);
     }
 
     /**
@@ -627,8 +630,16 @@ class Session implements AuthenticatorInterface
             // Reset so it doesn't mess up future calls.
             $this->shouldRemember = false;
         } elseif ($this->getRememberMeToken()) {
+            /** @var Response $response */
+            $response = service('response');
+
             // Remove incoming remember-me token
-            delete_cookie(setting('Auth.sessionConfig')['rememberCookieName']);
+            $response->deleteCookie(
+                setting('Auth.sessionConfig')['rememberCookieName'],
+                setting('Cookie.domain'),
+                setting('Cookie.path'),
+                setting('Cookie.prefix')
+            );
 
             // @TODO delete the token record.
         }

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -65,6 +65,9 @@ final class SessionAuthenticatorTest extends TestCase
     public function testLoggedInWithRememberCookie(): void
     {
         unset($_SESSION['user']);
+        // Set Cookie.prefix
+        $cookiePrefix = 'prefix_';
+        setting('Cookie.prefix', $cookiePrefix);
 
         $this->user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret']);
 
@@ -77,8 +80,9 @@ final class SessionAuthenticatorTest extends TestCase
         $rememberModel->rememberUser($this->user, $selector, hash('sha256', $validator), $expires);
 
         // Set Cookie value for remember-me.
-        $token               = $selector . ':' . $validator;
-        $_COOKIE['remember'] = $token;
+        $token                = $selector . ':' . $validator;
+        $cookieName           = $cookiePrefix . setting('Auth.sessionConfig')['rememberCookieName'];
+        $_COOKIE[$cookieName] = $token;
 
         $this->assertTrue($this->auth->loggedIn());
 
@@ -86,6 +90,9 @@ final class SessionAuthenticatorTest extends TestCase
 
         $this->assertInstanceOf(User::class, $authUser);
         $this->assertSame($this->user->id, $authUser->id);
+
+        // Forget Cookie.prefix
+        setting()->forget('Cookie.prefix');
     }
 
     public function testLoginNoRemember(): void


### PR DESCRIPTION
- fix missing `Cookie.prefix`
- fix hard coded cookie name `remember`