### PR TITLE
fix: redirect user if `loggedIn()` and called `/login` page

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -12,6 +12,8 @@ class LoginController extends BaseController
 
     /**
      * Displays the form the login to the site.
+     *
+     * @return
      */
     public function loginView()
     {

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -4,6 +4,7 @@ namespace CodeIgniter\Shield\Controllers;
 
 use App\Controllers\BaseController;
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
 
 class LoginController extends BaseController
@@ -13,7 +14,7 @@ class LoginController extends BaseController
     /**
      * Displays the form the login to the site.
      *
-     * @return
+     * @return RedirectResponse|string
      */
     public function loginView()
     {

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -13,8 +13,12 @@ class LoginController extends BaseController
     /**
      * Displays the form the login to the site.
      */
-    public function loginView(): string
+    public function loginView()
     {
+        if (auth()->loggedIn()) {
+            return redirect()->to(config('Auth')->loginRedirect());
+        }
+
         return view(setting('Auth.views')['login']);
     }
 

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -91,6 +91,22 @@ final class LoginTest extends TestCase
         $this->assertSame($this->user->id, session('user')['id']);
     }
 
+    public function testAfterLoggedInNotDesplayLoginPage(): void
+    {
+        $this->user->createEmailIdentity([
+            'email'    => 'foo@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $result = $this->post('/login', [
+            'email'    => 'foo@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $result = $this->get('/login');
+        $result->assertRedirectTo(config('Auth')->loginRedirect());
+    }
+
     public function testLoginActionUsernameSuccess(): void
     {
         $this->user->createEmailIdentity([


### PR DESCRIPTION
Hello, my hardworking friends.
When the user `loggedIn`, if he calls the `/login` form again, **the form will be displayed!**
This is completely meaningless.
Suggestions came to my mind.
1. Display the message "You are already logged in."
2. User logout if this happens.
3. User transfer to `config('Auth')->loginRedirect()`.
**I chose option 3.**
what is your idea about this?