### PR TITLE
feat: prevent logged-in users from trying to log in again

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -550,6 +550,20 @@ class Session implements AuthenticatorInterface
      */
     public function startLogin(User $user): void
     {
+        /** @var int|string|null $userId */
+        $userId = $this->getSessionKey('id');
+
+        // Check if already logged in.
+        if ($userId !== null) {
+            throw new LogicException(
+                'The user has User Info in Session, so already logged in or in pending login state.'
+                . ' If a logged in user logs in again with other account, the session data of the previous'
+                . ' user will be used as the new user.'
+                . ' Fix your code to prevent users from logging in without logging out or delete the session data.'
+                . ' user_id: ' . $userId
+            );
+        }
+
         $this->user = $user;
 
         // Regenerate the session ID to help protect against session fixation

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -355,7 +355,7 @@ final class SessionAuthenticatorTest extends TestCase
             'password' => 'secret123',
         ]);
 
-        $result = $this->auth->attempt([
+        $this->auth->attempt([
             'email'    => $this->user->email,
             'password' => 'secret123',
         ]);

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -7,6 +7,7 @@ use CodeIgniter\Shield\Authentication\AuthenticationException;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Config\Auth;
 use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Models\RememberModel;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Result;
@@ -337,6 +338,26 @@ final class SessionAuthenticatorTest extends TestCase
         $this->seeInDatabase('auth_logins', [
             'identifier' => $this->user->email,
             'success'    => 1,
+        ]);
+    }
+
+    public function testAttemptUserHavingSessionDataAttemptsAgain(): void
+    {
+        $_SESSION['user']['id'] = '999';
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'The user has User Info in Session, so already logged in or in pending login state.'
+        );
+
+        $this->user->createEmailIdentity([
+            'email'    => 'foo@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $result = $this->auth->attempt([
+            'email'    => $this->user->email,
+            'password' => 'secret123',
         ]);
     }
 


### PR DESCRIPTION
Basically, a logged-in user is not supposed to log in again without logging out, 
and should be protected so that he/she cannot do so with filters and/or controllers.

But a developer may misconfigure and if a logged-in user logs in with a different user account, 
the session data of the previous user is carried over.

This PR prevents such behavior by making errors.