### PR TITLE
fix: `use` is missing in the replaced source files

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -108,7 +108,7 @@ class Setup extends BaseCommand
         $file     = 'Config/Auth.php';
         $replaces = [
             'namespace CodeIgniter\Shield\Config'  => 'namespace Config',
-            'use CodeIgniter\\Config\\BaseConfig;' => 'CodeIgniter\\Shield\\Config\\Auth as ShieldAuth;',
+            'use CodeIgniter\\Config\\BaseConfig;' => 'use CodeIgniter\\Shield\\Config\\Auth as ShieldAuth;',
             'extends BaseConfig'                   => 'extends ShieldAuth',
         ];
 
@@ -120,7 +120,7 @@ class Setup extends BaseCommand
         $file     = 'Config/AuthGroups.php';
         $replaces = [
             'namespace CodeIgniter\Shield\Config'  => 'namespace Config',
-            'use CodeIgniter\\Config\\BaseConfig;' => 'CodeIgniter\\Shield\\Config\\AuthGroups as ShieldAuthGroups;',
+            'use CodeIgniter\\Config\\BaseConfig;' => 'use CodeIgniter\\Shield\\Config\\AuthGroups as ShieldAuthGroups;',
             'extends BaseConfig'                   => 'extends ShieldAuthGroups',
         ];
 

--- a/tests/Commands/SetupTest.php
+++ b/tests/Commands/SetupTest.php
@@ -53,6 +53,7 @@ final class SetupTest extends TestCase
 
         $auth = file_get_contents($appFolder . 'Config/Auth.php');
         $this->assertStringContainsString('namespace Config;', $auth);
+        $this->assertStringContainsString('use CodeIgniter\Shield\Config\Auth as ShieldAuth;', $auth);
 
         $routes = file_get_contents($appFolder . 'Config/Routes.php');
         $this->assertStringContainsString('service(\'auth\')->routes($routes);', $routes);


### PR DESCRIPTION
Follow-up #205
Fixed #219
