### PR TITLE
fix: redirect user after `loggedIn()` and called `/login/magic-link` page

### DIFF
--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -36,9 +36,15 @@ class MagicLinkController extends BaseController
     /**
      * Displays the view to enter their email address
      * so an email can be sent to them.
+     *
+     * @return RedirectResponse|string
      */
-    public function loginView(): string
+    public function loginView()
     {
+        if (auth()->loggedIn()) {
+            return redirect()->to(config('Auth')->loginRedirect());
+        }
+
         return view(setting('Auth.views')['magic-link-login']);
     }
 

--- a/tests/Controllers/MagicLinkTest.php
+++ b/tests/Controllers/MagicLinkTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Controllers;
+
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+use Config\Services;
+use Tests\Support\FakeUser;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class MagicLinkTest extends TestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+    use FakeUser;
+
+    protected $namespace;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        helper('auth');
+
+        // Add auth routes
+        $routes = service('routes');
+        auth()->routes($routes);
+        Services::injectMock('routes', $routes);
+    }
+
+    public function testAfterLoggedInNotAllowDesplaMagicLink()
+    {
+        $this->user->createEmailIdentity([
+            'email'    => 'foo@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $result = $this->post('/login', [
+            'email'    => 'foo@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $result = $this->get('/login/magic-link');
+        $result->assertRedirectTo(config('Auth')->loginRedirect());
+    }
+}

--- a/tests/Controllers/MagicLinkTest.php
+++ b/tests/Controllers/MagicLinkTest.php
@@ -31,7 +31,7 @@ final class MagicLinkTest extends TestCase
         Services::injectMock('routes', $routes);
     }
 
-    public function testAfterLoggedInNotAllowDesplayMagicLink()
+    public function testAfterLoggedInNotAllowDisplayMagicLink()
     {
         $this->user->createEmailIdentity([
             'email'    => 'foo@example.com',

--- a/tests/Controllers/MagicLinkTest.php
+++ b/tests/Controllers/MagicLinkTest.php
@@ -31,7 +31,7 @@ final class MagicLinkTest extends TestCase
         Services::injectMock('routes', $routes);
     }
 
-    public function testAfterLoggedInNotAllowDesplaMagicLink()
+    public function testAfterLoggedInNotAllowDesplayMagicLink()
     {
         $this->user->createEmailIdentity([
             'email'    => 'foo@example.com',


### PR DESCRIPTION
Hello good guys
Ref: #215 
It seems that changes should have been made here as well.