### PR TITLE
fix: `Session::logout()` does not work

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -706,6 +706,8 @@ class Session implements AuthenticatorInterface
      */
     public function logout(): void
     {
+        $this->checkUserState();
+
         if ($this->user === null) {
             return;
         }

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -179,6 +179,15 @@ final class SessionAuthenticatorTest extends TestCase
         $this->dontSeeInDatabase('auth_remember_tokens', ['user_id' => $this->user->id]);
     }
 
+    public function testLogoutOnlyLogoutCalled(): void
+    {
+        $_SESSION['user']['id'] = $this->user->id;
+
+        $this->auth->logout();
+
+        $this->assertArrayNotHasKey('user', $_SESSION);
+    }
+
     public function testLoginByIdBadUser(): void
     {
         $this->expectException(AuthenticationException::class);


### PR DESCRIPTION
Fixes #225

`Session::logout()` does not work if only `Session::logout()` is called.
