### PR TITLE
fix: datetime for defaultLocale set fa

### DIFF
--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -124,7 +124,7 @@ class AccessTokens implements AuthenticatorInterface
             ]);
         }
 
-        $token->last_used_at = Time::now()->toDateTimeString();
+        $token->last_used_at = Time::now()->format('Y-m-d H:i:s');
         $identityModel->save($token);
 
         // Ensure the token is set as the current token

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -367,7 +367,7 @@ trait Authorizable
                 $inserts[] = [
                     'user_id'    => $this->id,
                     $type        => $item,
-                    'created_at' => Time::now()->toDateTimeString(),
+                    'created_at' => Time::now()->format('Y-m-d H:i:s'),
                 ];
             }
 

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -78,7 +78,7 @@ class MagicLinkController extends BaseController
             'user_id' => $user->id,
             'type'    => Session::ID_TYPE_MAGIC_LINK,
             'secret'  => $token,
-            'expires' => Time::now()->addSeconds(setting('Auth.magicLinkLifetime'))->toDateTimeString(),
+            'expires' => Time::now()->addSeconds(setting('Auth.magicLinkLifetime'))->format('Y-m-d H:i:s'),
         ]);
 
         // Send the user an email with the code

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -91,7 +91,7 @@ class LoginModel extends Model
             'id_type'    => Session::ID_TYPE_EMAIL_PASSWORD,
             'identifier' => $faker->email,
             'user_id'    => null,
-            'date'       => Time::parse('-1 day')->toDateTimeString(),
+            'date'       => Time::parse('-1 day')->format('Y-m-d H:i:s'),
             'success'    => true,
         ]);
     }

--- a/src/Models/TokenLoginModel.php
+++ b/src/Models/TokenLoginModel.php
@@ -22,7 +22,7 @@ class TokenLoginModel extends LoginModel
             'ip_address' => $faker->ipv4,
             'identifier' => 'token: ' . random_string('crypto', 64),
             'user_id'    => fake(UserModel::class)->id,
-            'date'       => Time::parse('-1 day')->toDateTimeString(),
+            'date'       => Time::parse('-1 day')->format('Y-m-d H:i:s'),
             'success'    => true,
         ]);
     }

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Authorization;
 
+use CodeIgniter\CodeIgniter;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authorization\AuthorizationException;
 use CodeIgniter\Shield\Models\UserModel;
@@ -302,22 +303,23 @@ final class AuthorizableTest extends TestCase
      */
     public function testCreatedAtIfDefaultLocaleSetFaWithAddGroup(): void
     {
+        if (version_compare(CodeIgniter::CI_VERSION, '4.2.1', '<')) {
+            $this->markTestSkipped('This test does not work on CI v4.2.0 or before due to a bug.');
+        }
+
         $currentLocale = Locale::getDefault();
         Locale::setDefault('fa');
 
-        $this->hasInDatabase('auth_groups_users', [
-            'user_id'    => $this->user->id,
-            'group'      => 'admin',
-            'created_at' => Time::now()->format('Y-m-d H:i:s'),
-        ]);
+        Time::setTestNow('March 10, 2017', 'America/Chicago');
 
         $this->user->addGroup('admin');
 
-        $this->dontSeeInDatabase('auth_groups_users', [
+        $this->seeInDatabase('auth_groups_users', [
             'user_id'    => $this->user->id,
             'group'      => 'admin',
-            'created_at' => '0000-00-00 00:00:00',
+            'created_at' => '2017-03-10 00:00:00',
         ]);
+
         Locale::setDefault($currentLocale);
     }
 }

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Authorization;
 
-use CodeIgniter\CodeIgniter;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authorization\AuthorizationException;
 use CodeIgniter\Shield\Models\UserModel;

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -303,6 +303,7 @@ final class AuthorizableTest extends TestCase
      */
     public function testCreatedAtIfDefaultLocaleSetFaWithAddGroup(): void
     {
+        // @phpstan-ignore-next-line
         if (version_compare(CodeIgniter::CI_VERSION, '4.2.1', '<')) {
             $this->markTestSkipped('This test does not work on CI v4.2.0 or before due to a bug.');
         }

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -318,5 +318,6 @@ final class AuthorizableTest extends TestCase
             'group'      => 'admin',
             'created_at' => '0000-00-00 00:00:00',
         ]);
+        Locale::setDefault($currentLocale);
     }
 }

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -302,7 +302,8 @@ final class AuthorizableTest extends TestCase
      */
     public function testCreatedAtIfDefaultLocaleSetFaWithAddGroup(): void
     {
-        locale::setDefault('fa');
+        $currentLocale = Locale::getDefault();
+        Locale::setDefault('fa');
 
         $this->hasInDatabase('auth_groups_users', [
             'user_id'    => $this->user->id,

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -303,11 +303,6 @@ final class AuthorizableTest extends TestCase
      */
     public function testCreatedAtIfDefaultLocaleSetFaWithAddGroup(): void
     {
-        // @phpstan-ignore-next-line
-        if (version_compare(CodeIgniter::CI_VERSION, '4.2.1', '<')) {
-            $this->markTestSkipped('This test does not work on CI v4.2.0 or before due to a bug.');
-        }
-
         $currentLocale = Locale::getDefault();
         Locale::setDefault('fa');
 

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -6,6 +6,7 @@ use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authorization\AuthorizationException;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Test\DatabaseTestTrait;
+use Locale;
 use Tests\Support\FakeUser;
 use Tests\Support\TestCase;
 
@@ -294,5 +295,25 @@ final class AuthorizableTest extends TestCase
         $this->user->addGroup('superadmin');
 
         $this->assertTrue($this->user->can('admin.access'));
+    }
+
+    // see https://github.com/codeigniter4/shield/pull/238
+    public function testCreatedAtIfDefaultLocaleSetFaWithAddGroup(): void
+    {
+        locale::setDefault('fa');
+
+        $this->hasInDatabase('auth_groups_users', [
+            'user_id'    => $this->user->id,
+            'group'      => 'admin',
+            'created_at' => Time::now()->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->user->addGroup('admin');
+
+        $this->dontSeeInDatabase('auth_groups_users', [
+            'user_id'    => $this->user->id,
+            'group'      => 'admin',
+            'created_at' => '0000-00-00 00:00:00',
+        ]);
     }
 }

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -297,7 +297,9 @@ final class AuthorizableTest extends TestCase
         $this->assertTrue($this->user->can('admin.access'));
     }
 
-    // see https://github.com/codeigniter4/shield/pull/238
+    /**
+     * @see https://github.com/codeigniter4/shield/pull/238
+     */
     public function testCreatedAtIfDefaultLocaleSetFaWithAddGroup(): void
     {
         locale::setDefault('fa');


### PR DESCRIPTION
When `toDateTimeString() ` is used. If `defaultLocale = 'fa'`.
The value of the datetime will be `UTF-8 string (33) "۲۰۲۲-۰۶-۱۲ ۲۲:۳۰:۳۵"`.
In this case, the database enters the information as `0000-00-00 00:0:00`.
Which causes a bug in the shield.
In this PR I tried to solve this problem.

note: This method can also solve the problem. `$time = new Time('now','','en-US') `

```
Data of Table "auth_groups_users":

+----+---------+-------+--------------------+
| id | user_id | group | created_at         |
+----+---------+-------+--------------------+
| 7  | 7       | user  | 0000-00-00 00:0... |
| 22 | 22      | user  | 0000-00-00 00:0... |
| 23 | 23      | user  | 2022-06-12 19:3... |
+----+---------+-------+--------------------+
```