### PR TITLE
Use variadic passing of groups/permissions

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,9 @@ NOTE: The examples assume that you have run the setup script and that you have c
     - [Assign Permissions to a Group](#assign-permissions-to-a-group)
     - [Assign Permissions to a User](#assign-permissions-to-a-user)
   - [Check If a User Has Permission](#check-if-a-user-has-permission)
+    - [Adding A Group To A User](#adding-a-group-to-a-user)
+    - [Removing A Group From A User](#removing-a-group-from-a-user)
+    - [Checking If User Belongs To A Group](#checking-if-user-belongs-to-a-group)
   - [Managing Users](#managing-users)
     - [Creating Users](#creating-users)
     - [Deleting Users](#deleting-users)
@@ -208,7 +211,50 @@ if (! auth()->user()->can('users.create')) {
 
 Note: The example above can also be done through a [controller filter](https://codeigniter.com/user_guide/incoming/filters.html) if you want to apply it to multiple pages of your site.
 
+### Adding A Group To A User
 
+Groups are assigned to a user via the `addGroup` method. You can pass multiple groups in and they will all be assigned to the user.
+
+```php
+$user = auth()->user();
+$user->addGroup('admin', 'beta');
+```
+
+This will add all new groups. You can also sync groups so that the user ONLY belongs to the groups directly assigned to them. Any not in the provided list are removed from the user.
+
+```php
+$user = auth()->user();
+$user->syncGroups('admin', 'beta');
+```
+
+### Removing A Group From A User
+
+Groups are removed from a user via the `removeGroup` method. Multiple groups may be removed at once by passing all of their names into the method.
+
+```php
+$user = auth()->user();
+$user->removeGroup('admin', 'beta');
+```
+
+### Checking If User Belongs To A Group
+
+You can check if a user belongs to a group with the `inGroup` method.
+
+```php
+$user = auth()->user();
+if($user->inGroup('admin')) {
+    // do something
+}
+```
+
+You can pass more than one group to the method and it will return `true` if the user belongs to any of the specified groups.
+
+```php
+$user = auth()->user();
+if($user->inGroup('admin', 'beta')) {
+    // do something
+}
+```
 
 
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -242,7 +242,7 @@ You can check if a user belongs to a group with the `inGroup` method.
 
 ```php
 $user = auth()->user();
-if($user->inGroup('admin')) {
+if ($user->inGroup('admin')) {
     // do something
 }
 ```
@@ -251,7 +251,7 @@ You can pass more than one group to the method and it will return `true` if the 
 
 ```php
 $user = auth()->user();
-if($user->inGroup('admin', 'beta')) {
+if ($user->inGroup('admin', 'beta')) {
     // do something
 }
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -193,7 +193,7 @@ This will add all new permissions. You can also sync permissions so that the use
 ```php
 $user = auth()->user();
 
-$user->syncPermissions(['users.create', 'beta.access']);
+$user->syncPermissions('users.create', 'beta.access');
 ```
 
 ## Check If a User Has Permission

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -80,7 +80,7 @@ trait Authorizable
      *
      * @return $this
      */
-    public function syncGroups(array $groups): self
+    public function syncGroups(...$groups): self
     {
         $this->populateGroups();
 
@@ -189,7 +189,7 @@ trait Authorizable
      *
      * @return $this
      */
-    public function syncPermissions(array $permissions): self
+    public function syncPermissions(...$permissions): self
     {
         $this->populatePermissions();
 

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -80,7 +80,7 @@ trait Authorizable
      *
      * @return $this
      */
-    public function syncGroups(...$groups): self
+    public function syncGroups(string ...$groups): self
     {
         $this->populateGroups();
 
@@ -189,7 +189,7 @@ trait Authorizable
      *
      * @return $this
      */
-    public function syncPermissions(...$permissions): self
+    public function syncPermissions(string ...$permissions): self
     {
         $this->populatePermissions();
 

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -142,7 +142,7 @@ final class AuthorizableTest extends TestCase
             'created_at' => Time::now()->toDateTimeString(),
         ]);
 
-        $this->user->syncGroups(['admin', 'beta']);
+        $this->user->syncGroups('admin', 'beta');
         $this->assertSame(['admin', 'beta'], $this->user->getGroups());
         $this->seeInDatabase('auth_groups_users', [
             'user_id' => $this->user->id,
@@ -263,7 +263,7 @@ final class AuthorizableTest extends TestCase
             'created_at' => Time::now()->toDateTimeString(),
         ]);
 
-        $this->user->syncPermissions(['admin.access', 'beta.access']);
+        $this->user->syncPermissions('admin.access', 'beta.access');
         $this->assertSame(['admin.access', 'beta.access'], $this->user->getPermissions());
         $this->seeInDatabase('auth_permissions_users', [
             'user_id'    => $this->user->id,


### PR DESCRIPTION
- Standardize variadic passing of groups/permissions to the syncGroups and syncPermissions methods.
- Added docs for groups to the quick start.

Replaces #256 