### PR TITLE
fix: username validation rules

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -141,7 +141,7 @@ $credentials = [
     'password' => $this->request->getPost('password')
 ];
 
-$validCreds? = auth()->check($credentials);
+$validCreds = auth()->check($credentials);
 
 if (! $validCreds->isOK()) {
     return redirect()->back()->with('error', $loginAttempt->reason());

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -108,7 +108,7 @@ Shield has the following rules for registration:
 ];
 ```
 
-If you need a different set of rules for registration, you can specify them in your `Validation` configuration (**app\Config\Validation.php**) like:
+If you need a different set of rules for registration, you can specify them in your `Validation` configuration (**app/Config/Validation.php**) like:
 
 ```php
 //--------------------------------------------------------------------

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -95,8 +95,14 @@ Shield has the following rules for registration:
 
 ```php
 [
-    'username'         => 'required|alpha_numeric_space|min_length[3]|is_unique[users.username]',
-    'email'            => 'required|valid_email|is_unique[auth_identities.secret]',
+    'username'         => [
+            'required',
+            'max_length[30]',
+            'min_length[3]',
+            'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
+            'is_unique[users.username]',
+        ],
+    'email'            => 'required|max_length[254]|valid_email|is_unique[auth_identities.secret]',
     'password'         => 'required|strong_password',
     'password_confirm' => 'required|matches[password]',
 ];
@@ -109,8 +115,14 @@ If you need a different set of rules for registration, you can specify them in y
 // Rules
 //--------------------------------------------------------------------
 public $registration = [
-    'username'         => 'required|alpha_numeric_space|min_length[3]|is_unique[users.username]',
-    'email'            => 'required|valid_email|is_unique[auth_identities.secret]',
+    'username'         => [
+            'required',
+            'max_length[30]',
+            'min_length[3]',
+            'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
+            'is_unique[users.username]',
+        ],
+    'email'            => 'required|max_length[254]|valid_email|is_unique[auth_identities.secret]',
     'password'         => 'required|strong_password',
     'password_confirm' => 'required|matches[password]',
 ];

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -225,6 +225,20 @@ class Auth extends BaseConfig
 
     /**
      * --------------------------------------------------------------------
+     * Validation Rules for username
+     * --------------------------------------------------------------------
+     *
+     * @var string[]
+     */
+    public array $validationRulesUsername = [
+        'required',
+        'max_length[30]',
+        'min_length[3]',
+        'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
+    ];
+
+    /**
+     * --------------------------------------------------------------------
      * Additional Fields for "Nothing Personal"
      * --------------------------------------------------------------------
      * The NothingPersonalValidator prevents personal information from

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -225,20 +225,6 @@ class Auth extends BaseConfig
 
     /**
      * --------------------------------------------------------------------
-     * Validation Rules for username
-     * --------------------------------------------------------------------
-     *
-     * @var string[]
-     */
-    public array $validationRulesUsername = [
-        'required',
-        'max_length[30]',
-        'min_length[3]',
-        'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
-    ];
-
-    /**
-     * --------------------------------------------------------------------
      * Additional Fields for "Nothing Personal"
      * --------------------------------------------------------------------
      * The NothingPersonalValidator prevents personal information from

--- a/src/Config/AuthSession.php
+++ b/src/Config/AuthSession.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CodeIgniter\Shield\Config;
+
+use CodeIgniter\Config\BaseConfig;
+
+/**
+ * Config for Session Authenticator
+ */
+class AuthSession extends BaseConfig
+{
+    /**
+     * The validation rules for username
+     *
+     * @var string[]
+     */
+    public array $usernameValidationRules = [
+        'required',
+        'max_length[30]',
+        'min_length[3]',
+        'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
+    ];
+
+    /**
+     * The validation rules for email
+     *
+     * @var string[]
+     */
+    public array $emailValidationRules = [
+        'required',
+        'max_length[254]',
+        'valid_email',
+    ];
+}

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -32,10 +32,6 @@ class Registrar
             'ruleSets' => [
                 PasswordRules::class,
             ],
-            'users' => [
-                'email'    => 'required|valid_email|unique_email[{id}]',
-                'username' => 'required|string|is_unique[users.username,id,{id}]',
-            ],
         ];
     }
 

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -64,7 +64,7 @@ class LoginController extends BaseController
     protected function getValidationRules(): array
     {
         return setting('Validation.login') ?? [
-            //'username' => 'required|max_length[30]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|min_length[3]',
+            //'username' => setting('Auth.validationRulesUsername'),
             'email'    => 'required|max_length[254]|valid_email',
             'password' => 'required',
         ];

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -64,9 +64,24 @@ class LoginController extends BaseController
     protected function getValidationRules(): array
     {
         return setting('Validation.login') ?? [
-            //'username' => setting('Auth.validationRulesUsername'),
+            //'username' => setting('Validation._username') ?? $this->getUsernameRules(),
             'email'    => 'required|max_length[254]|valid_email',
             'password' => 'required',
+        ];
+    }
+
+    /**
+     * Returns the validation rules for username
+     *
+     * @return string[]
+     */
+    public static function getUsernameRules(): array
+    {
+        return [
+            'required',
+            'max_length[30]',
+            'min_length[3]',
+            'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
         ];
     }
 

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -65,7 +65,7 @@ class LoginController extends BaseController
     {
         return setting('Validation.login') ?? [
             //'username' => setting('Validation._username') ?? $this->getUsernameRules(),
-            'email'    => $this->getEmailRules(),
+            'email'    => static::getEmailRules(),
             'password' => 'required',
         ];
     }

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -64,7 +64,7 @@ class LoginController extends BaseController
     protected function getValidationRules(): array
     {
         return setting('Validation.login') ?? [
-            //'username' => setting('Validation._username') ?? $this->getUsernameRules(),
+            //'username' => static::getUsernameRules(),
             'email'    => static::getEmailRules(),
             'password' => 'required',
         ];

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -64,7 +64,7 @@ class LoginController extends BaseController
     protected function getValidationRules(): array
     {
         return setting('Validation.login') ?? [
-            //'username' => 'required|max_length[30]|alpha_numeric_space|min_length[3]',
+            //'username' => 'required|max_length[30]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|min_length[3]',
             'email'    => 'required|max_length[254]|valid_email',
             'password' => 'required',
         ];

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -64,38 +64,9 @@ class LoginController extends BaseController
     protected function getValidationRules(): array
     {
         return setting('Validation.login') ?? [
-            //'username' => static::getUsernameRules(),
-            'email'    => static::getEmailRules(),
+            //'username' => config('AuthSession')->usernameValidationRules,
+            'email'    => config('AuthSession')->emailValidationRules,
             'password' => 'required',
-        ];
-    }
-
-    /**
-     * Returns the validation rules for username
-     *
-     * @return string[]
-     */
-    public static function getUsernameRules(): array
-    {
-        return [
-            'required',
-            'max_length[30]',
-            'min_length[3]',
-            'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
-        ];
-    }
-
-    /**
-     * Returns the validation rules for email
-     *
-     * @return string[]
-     */
-    public static function getEmailRules(): array
-    {
-        return [
-            'required',
-            'max_length[254]',
-            'valid_email',
         ];
     }
 

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -65,7 +65,7 @@ class LoginController extends BaseController
     {
         return setting('Validation.login') ?? [
             //'username' => setting('Validation._username') ?? $this->getUsernameRules(),
-            'email'    => 'required|max_length[254]|valid_email',
+            'email'    => $this->getEmailRules(),
             'password' => 'required',
         ];
     }
@@ -82,6 +82,20 @@ class LoginController extends BaseController
             'max_length[30]',
             'min_length[3]',
             'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
+        ];
+    }
+
+    /**
+     * Returns the validation rules for email
+     *
+     * @return string[]
+     */
+    public static function getEmailRules(): array
+    {
+        return [
+            'required',
+            'max_length[254]',
+            'valid_email',
         ];
     }
 

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -186,12 +186,12 @@ class MagicLinkController extends BaseController
     /**
      * Returns the rules that should be used for validation.
      *
-     * @return array<string, string>
+     * @return array<string, array<string, string>>
      */
     protected function getValidationRules(): array
     {
         return [
-            'email' => 'required|max_length[254]|valid_email',
+            'email' => LoginController::getEmailRules(),
         ];
     }
 }

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -191,7 +191,7 @@ class MagicLinkController extends BaseController
     protected function getValidationRules(): array
     {
         return [
-            'email' => LoginController::getEmailRules(),
+            'email' => config('AuthSession')->emailValidationRules,
         ];
     }
 }

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -131,11 +131,11 @@ class RegisterController extends BaseController
     protected function getValidationRules(): array
     {
         $registrationUsernameRules = array_merge(
-            LoginController::getUsernameRules(),
+            config('AuthSession')->usernameValidationRules,
             ['is_unique[users.username]']
         );
         $registrationEmailRules = array_merge(
-            LoginController::getEmailRules(),
+            config('AuthSession')->emailValidationRules,
             ['is_unique[auth_identities.secret]']
         );
 

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -130,10 +130,8 @@ class RegisterController extends BaseController
      */
     protected function getValidationRules(): array
     {
-        $usernameRules = setting('Validation._username') ?? LoginController::getUsernameRules();
-
         $registrationUsernameRules = array_merge(
-            $usernameRules,
+            LoginController::getUsernameRules(),
             ['is_unique[users.username]']
         );
         $registrationEmailRules = array_merge(

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -131,7 +131,7 @@ class RegisterController extends BaseController
     protected function getValidationRules(): array
     {
         return setting('Validation.registration') ?? [
-            'username'         => 'required|alpha_numeric_space|min_length[3]|is_unique[users.username]',
+            'username'         => 'required|max_length[30]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|min_length[3]|is_unique[users.username]',
             'email'            => 'required|valid_email|is_unique[auth_identities.secret]',
             'password'         => 'required|strong_password',
             'password_confirm' => 'required|matches[password]',

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -130,13 +130,15 @@ class RegisterController extends BaseController
      */
     protected function getValidationRules(): array
     {
-        $usernameRules = array_merge(
-            setting('Auth.validationRulesUsername'),
+        $usernameRules = setting('Validation._username') ?? LoginController::getUsernameRules();
+
+        $registrationUsernameRules = array_merge(
+            $usernameRules,
             ['is_unique[users.username]']
         );
 
         return setting('Validation.registration') ?? [
-            'username'         => $usernameRules,
+            'username'         => $registrationUsernameRules,
             'email'            => 'required|valid_email|is_unique[auth_identities.secret]',
             'password'         => 'required|strong_password',
             'password_confirm' => 'required|matches[password]',

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -130,8 +130,13 @@ class RegisterController extends BaseController
      */
     protected function getValidationRules(): array
     {
+        $usernameRules = array_merge(
+            setting('Auth.validationRulesUsername'),
+            ['is_unique[users.username]']
+        );
+
         return setting('Validation.registration') ?? [
-            'username'         => 'required|max_length[30]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|min_length[3]|is_unique[users.username]',
+            'username'         => $usernameRules,
             'email'            => 'required|valid_email|is_unique[auth_identities.secret]',
             'password'         => 'required|strong_password',
             'password_confirm' => 'required|matches[password]',

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -136,10 +136,14 @@ class RegisterController extends BaseController
             $usernameRules,
             ['is_unique[users.username]']
         );
+        $registrationEmailRules = array_merge(
+            LoginController::getEmailRules(),
+            ['is_unique[auth_identities.secret]']
+        );
 
         return setting('Validation.registration') ?? [
             'username'         => $registrationUsernameRules,
-            'email'            => 'required|valid_email|is_unique[auth_identities.secret]',
+            'email'            => $registrationEmailRules,
             'password'         => 'required|strong_password',
             'password_confirm' => 'required|matches[password]',
         ];

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -118,7 +118,7 @@ class UserModel extends Model
     public function fake(Generator &$faker): User
     {
         return new User([
-            'username' => str_replace('.', ' ', $faker->userName),
+            'username' => $faker->userName,
             'active'   => true,
         ]);
     }

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -120,10 +120,10 @@ final class LoginTest extends TestCase
         // Change the validation rules
         $config           = new class () extends Validation {
             public $login = [
-                'username' => 'required|max_length[30]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|min_length[3]',
                 'password' => 'required',
             ];
         };
+        $config->login['username'] = setting('Auth.validationRulesUsername');
         Factories::injectMock('config', 'Validation', $config);
 
         $this->user->createEmailIdentity([

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -139,6 +139,8 @@ final class LoginTest extends TestCase
         $result->assertSessionHas('user', ['id' => 1]);
         $result->assertStatus(302);
         $result->assertRedirect();
+        $result->assertSessionMissing('error');
+        $result->assertSessionMissing('errors');
         $this->assertSame(site_url(), $result->getRedirectUrl());
 
         // Login should have been recorded successfully
@@ -191,6 +193,8 @@ final class LoginTest extends TestCase
         // Should have been redirected to the action's page.
         $result->assertStatus(302);
         $result->assertRedirect();
+        $result->assertSessionMissing('error');
+        $result->assertSessionMissing('errors');
         $this->assertSame(site_url('auth/a/show'), $result->getRedirectUrl());
     }
 }

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -5,7 +5,6 @@ namespace Tests\Controllers;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Actions\Email2FA;
-use CodeIgniter\Shield\Controllers\LoginController;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
 use Config\Services;
@@ -124,7 +123,7 @@ final class LoginTest extends TestCase
                 'password' => 'required',
             ];
         };
-        $config->login['username'] = LoginController::getUsernameRules();
+        $config->login['username'] = config('AuthSession')->usernameValidationRules;
         Factories::injectMock('config', 'Validation', $config);
 
         $this->user->createEmailIdentity([

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -120,7 +120,7 @@ final class LoginTest extends TestCase
         // Change the validation rules
         $config           = new class () extends Validation {
             public $login = [
-                'username' => 'required|max_length[30]|alpha_numeric_space|min_length[3]',
+                'username' => 'required|max_length[30]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|min_length[3]',
                 'password' => 'required',
             ];
         };

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -5,6 +5,7 @@ namespace Tests\Controllers;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Actions\Email2FA;
+use CodeIgniter\Shield\Controllers\LoginController;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
 use Config\Services;
@@ -123,7 +124,7 @@ final class LoginTest extends TestCase
                 'password' => 'required',
             ];
         };
-        $config->login['username'] = setting('Auth.validationRulesUsername');
+        $config->login['username'] = LoginController::getUsernameRules();
         Factories::injectMock('config', 'Validation', $config);
 
         $this->user->createEmailIdentity([

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -53,6 +53,8 @@ final class RegisterTest extends DatabaseTestCase
 
         $result->assertStatus(302);
         $result->assertRedirect();
+        $result->assertSessionMissing('error');
+        $result->assertSessionMissing('errors');
 
         $this->assertSame(site_url(), $result->getRedirectUrl());
 
@@ -96,6 +98,7 @@ final class RegisterTest extends DatabaseTestCase
 
         $result->assertStatus(302);
         $result->assertRedirect();
+        $result->assertSessionHas('error');
     }
 
     public function testRegisterActionRedirectsIfNotAllowed(): void
@@ -108,6 +111,7 @@ final class RegisterTest extends DatabaseTestCase
 
         $result->assertStatus(302);
         $result->assertRedirect();
+        $result->assertSessionHas('error');
     }
 
     public function testRegisterActionInvalidData(): void


### PR DESCRIPTION
See #260

- change validation rules to `regex_match[/\A[a-zA-Z0-9\.]+\z/]`
- add `Config\AuthSession` and move validation rules to it
- refactor
- fix docs
