### PR TITLE
docs: fix definition actions

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -110,7 +110,7 @@ Turned off by default, Shield's Email-based 2FA can be enabled by specifying the
 
 ```php
 public array $actions = [
-    'login'    => \CodeIgniter\Shield\Authentication\Actions\Email2FA,
+    'login'    => 'CodeIgniter\Shield\Authentication\Actions\Email2FA',
     'register' => null,
 ];
 ```
@@ -122,7 +122,7 @@ By default, once a user registers they have an active account that can be used. 
 ```php
 public array $actions = [
     'login'    => null,
-    'register' => \CodeIgniter\Shield\Authentication\Actions\EmailActivator,
+    'register' => 'CodeIgniter\Shield\Authentication\Actions\EmailActivator',
 ];
 ```
 


### PR DESCRIPTION
**Hello friends**, we have already presented the definition of actions in this way:
```php
public array $actions = [
    'login'    => 'CodeIgniter\Shield\Authentication\Actions\Email2FA',
    'register' => 'CodeIgniter\Shield\Authentication\Actions\EmailActivator',
];
```
Or it can be as follows
```php
public array $actions = [
    'login'    => \CodeIgniter\Shield\Authentication\Actions\Email2FA::class,
    'register' => \CodeIgniter\Shield\Authentication\Actions\EmailActivator::class,
];
```
In any case, correction was needed.