### PR TITLE
chore: add language unit tests

### DIFF
--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Test with PHPUnit
-        run: vendor/bin/phpunit --verbose --coverage-text --testsuite lang
+        run: vendor/bin/phpunit --verbose --no-coverage --testsuite lang
         env:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled

--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -1,0 +1,64 @@
+name: Language Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - 'src/Language/**.php'
+      - '!src/Language/en/**.php'
+      - 'phpunit*'
+      - '.github/workflows/phpunit-lang.yml'
+  push:
+    branches:
+      - develop
+    paths:
+      - 'src/Language/**.php'
+      - '!src/Language/en/**.php'
+      - 'phpunit*'
+      - '.github/workflows/phpunit-lang.yml'
+
+jobs:
+  main:
+    name: Language Unit Tests
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          tools: composer, phive, phpunit
+          extensions: intl, json, mbstring, gd, xdebug, xml, sqlite3
+          coverage: xdebug
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: |
+          if [ -f composer.lock ]; then
+            composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+          else
+            composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+          fi
+
+      - name: Test with PHPUnit
+        run: vendor/bin/phpunit --verbose --coverage-text --testsuite lang
+        env:
+          TERM: xterm-256color
+          TACHYCARDIA_MONITOR_GA: enabled

--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           tools: composer, phive, phpunit
           extensions: intl, json, mbstring, gd, xdebug, xml, sqlite3
           coverage: xdebug

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,7 +41,7 @@
 			<directory>./tests</directory>
             <exclude>./tests/Language</exclude>
 		</testsuite>
-		<testsuite name="language">
+		<testsuite name="lang">
 			<directory>./tests/Language</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
-  add language unit tests workflow

I tested on my repository: https://github.com/kenjis/codeigniter-shield/pull/1
```
Run vendor/bin/phpunit --verbose --no-coverage --testsuite lang
PHPUnit 9.5.21 #StandWithUkraine
Runtime:       PHP 8.0.20
Configuration: /home/runner/work/codeigniter-shield/codeigniter-shield/phpunit.xml.dist
Random Seed:   1656800527
.....................                                             21 / 21 (100%)
Time: 00:00.026, Memory: 10.00 MB
OK (21 tests, 21 assertions)
```
