### PR TITLE
Fix route_to issue

### DIFF
--- a/src/Views/email_2fa_show.php
+++ b/src/Views/email_2fa_show.php
@@ -15,7 +15,7 @@
                 <div class="alert alert-danger"><?= session('error') ?></div>
             <?php endif ?>
 
-            <form action="<?= site_url(route_to('auth-action-handle')) ?>" method="post">
+            <form action="<?= url_to('auth-action-handle') ?>" method="post">
                 <?= csrf_field() ?>
 
                 <!-- Email -->

--- a/src/Views/email_2fa_verify.php
+++ b/src/Views/email_2fa_verify.php
@@ -15,7 +15,7 @@
             <div class="alert alert-danger"><?= session('error') ?></div>
             <?php endif ?>
 
-            <form action="<?= site_url(route_to('auth-action-verify')) ?>" method="post">
+            <form action="<?= url_to('auth-action-verify') ?>" method="post">
                 <?= csrf_field() ?>
 
                 <!-- Code -->

--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -28,7 +28,7 @@
                 <div class="alert alert-success" role="alert"><?= session('message') ?></div>
                 <?php endif ?>
 
-                <form action="<?= route_to('login') ?>" method="post">
+                <form action="<?= url_to('login') ?>" method="post">
                     <?= csrf_field() ?>
 
                     <!-- Email -->
@@ -56,11 +56,11 @@
                     </div>
 
                     <?php if (setting('Auth.allowMagicLinkLogins')) : ?>
-                        <p class="text-center"><?= lang('Auth.forgotPassword') ?> <a href="<?= route_to('magic-link') ?>"><?= lang('Auth.useMagicLink') ?></a></p>
+                        <p class="text-center"><?= lang('Auth.forgotPassword') ?> <a href="<?= url_to('magic-link') ?>"><?= lang('Auth.useMagicLink') ?></a></p>
                     <?php endif ?>
 
                     <?php if (setting('Auth.allowRegistration')) : ?>
-                        <p class="text-center"><?= lang('Auth.needAccount') ?> <a href="<?= route_to('register') ?>"><?= lang('Auth.register') ?></a></p>
+                        <p class="text-center"><?= lang('Auth.needAccount') ?> <a href="<?= url_to('register') ?>"><?= lang('Auth.register') ?></a></p>
                     <?php endif ?>
 
                 </form>

--- a/src/Views/magic_link_form.php
+++ b/src/Views/magic_link_form.php
@@ -13,7 +13,7 @@
             <div class="alert alert-danger" role="alert"><?= session('error') ?></div>
             <?php endif ?>
 
-            <form action="<?= route_to('magic-link') ?>" method="post">
+            <form action="<?= url_to('magic-link') ?>" method="post">
                 <?= csrf_field() ?>
 
                 <!-- Email -->

--- a/src/Views/register.php
+++ b/src/Views/register.php
@@ -24,7 +24,7 @@
                     </div>
                 <?php endif ?>
 
-                <form action="<?= route_to('register') ?>" method="post">
+                <form action="<?= url_to('register') ?>" method="post">
                     <?= csrf_field() ?>
 
                     <!-- Email -->
@@ -51,7 +51,7 @@
                         <button type="submit" class="btn btn-primary btn-block"><?= lang('Auth.register') ?></button>
                     </div>
 
-                    <p class="text-center"><?= lang('Auth.haveAccount') ?> <a href="<?= route_to('login') ?>"><?= lang('Auth.login') ?></a></p>
+                    <p class="text-center"><?= lang('Auth.haveAccount') ?> <a href="<?= url_to('login') ?>"><?= lang('Auth.login') ?></a></p>
 
                 </form>
             </div>

--- a/tests/Authentication/MagicLinkTest.php
+++ b/tests/Authentication/MagicLinkTest.php
@@ -37,7 +37,7 @@ final class MagicLinkTest extends TestCase
 
     public function testCanSeeMagicLinkForm(): void
     {
-        $result = $this->get(url_to('magic-link'));
+        $result = $this->get(route_to('magic-link'));
 
         $result->assertOK();
         $result->assertSee(lang('Auth.useMagicLink'));
@@ -45,21 +45,21 @@ final class MagicLinkTest extends TestCase
 
     public function testMagicLinkSubmitNoEmail(): void
     {
-        $result = $this->post(url_to('magic-link'), [
+        $result = $this->post(route_to('magic-link'), [
             'email' => '',
         ]);
 
-        $result->assertRedirectTo(url_to('magic-link'));
+        $result->assertRedirectTo(route_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.invalidEmail'));
     }
 
     public function testMagicLinkSubmitBadEmail(): void
     {
-        $result = $this->post(url_to('magic-link'), [
+        $result = $this->post(route_to('magic-link'), [
             'email' => 'foo@example.com',
         ]);
 
-        $result->assertRedirectTo(url_to('magic-link'));
+        $result->assertRedirectTo(route_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.invalidEmail'));
     }
 
@@ -71,7 +71,7 @@ final class MagicLinkTest extends TestCase
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
 
-        $result = $this->post(url_to('magic-link'), [
+        $result = $this->post(route_to('magic-link'), [
             'email' => 'foo@example.com',
         ]);
 
@@ -86,9 +86,9 @@ final class MagicLinkTest extends TestCase
 
     public function testMagicLinkVerifyNoToken(): void
     {
-        $result = $this->get(url_to('verify-magic-link'));
+        $result = $this->get(route_to('verify-magic-link'));
 
-        $result->assertRedirectTo(url_to('magic-link'));
+        $result->assertRedirectTo(route_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.magicTokenNotFound'));
     }
 
@@ -107,9 +107,9 @@ final class MagicLinkTest extends TestCase
             'expires' => Time::now()->subDays(5),
         ]);
 
-        $result = $this->get(url_to('verify-magic-link') . '?token=' . 'abasdasdf');
+        $result = $this->get(route_to('verify-magic-link') . '?token=' . 'abasdasdf');
 
-        $result->assertRedirectTo(url_to('magic-link'));
+        $result->assertRedirectTo(route_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.magicLinkExpired'));
     }
 
@@ -126,7 +126,7 @@ final class MagicLinkTest extends TestCase
             'expires' => Time::now()->addMinutes(60),
         ]);
 
-        $result = $this->get(url_to('verify-magic-link') . '?token=' . 'abasdasdf');
+        $result = $this->get(route_to('verify-magic-link') . '?token=' . 'abasdasdf');
 
         $result->assertRedirectTo(site_url());
         $result->assertSessionHas('user', ['id' => $user->id]);

--- a/tests/Authentication/MagicLinkTest.php
+++ b/tests/Authentication/MagicLinkTest.php
@@ -37,7 +37,7 @@ final class MagicLinkTest extends TestCase
 
     public function testCanSeeMagicLinkForm(): void
     {
-        $result = $this->get(route_to('magic-link'));
+        $result = $this->get(url_to('magic-link'));
 
         $result->assertOK();
         $result->assertSee(lang('Auth.useMagicLink'));
@@ -45,21 +45,21 @@ final class MagicLinkTest extends TestCase
 
     public function testMagicLinkSubmitNoEmail(): void
     {
-        $result = $this->post(route_to('magic-link'), [
+        $result = $this->post(url_to('magic-link'), [
             'email' => '',
         ]);
 
-        $result->assertRedirectTo(route_to('magic-link'));
+        $result->assertRedirectTo(url_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.invalidEmail'));
     }
 
     public function testMagicLinkSubmitBadEmail(): void
     {
-        $result = $this->post(route_to('magic-link'), [
+        $result = $this->post(url_to('magic-link'), [
             'email' => 'foo@example.com',
         ]);
 
-        $result->assertRedirectTo(route_to('magic-link'));
+        $result->assertRedirectTo(url_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.invalidEmail'));
     }
 
@@ -71,7 +71,7 @@ final class MagicLinkTest extends TestCase
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
 
-        $result = $this->post(route_to('magic-link'), [
+        $result = $this->post(url_to('magic-link'), [
             'email' => 'foo@example.com',
         ]);
 
@@ -86,9 +86,9 @@ final class MagicLinkTest extends TestCase
 
     public function testMagicLinkVerifyNoToken(): void
     {
-        $result = $this->get(route_to('verify-magic-link'));
+        $result = $this->get(url_to('verify-magic-link'));
 
-        $result->assertRedirectTo(route_to('magic-link'));
+        $result->assertRedirectTo(url_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.magicTokenNotFound'));
     }
 
@@ -107,9 +107,9 @@ final class MagicLinkTest extends TestCase
             'expires' => Time::now()->subDays(5),
         ]);
 
-        $result = $this->get(route_to('verify-magic-link') . '?token=' . 'abasdasdf');
+        $result = $this->get(url_to('verify-magic-link') . '?token=' . 'abasdasdf');
 
-        $result->assertRedirectTo(route_to('magic-link'));
+        $result->assertRedirectTo(url_to('magic-link'));
         $result->assertSessionHas('error', lang('Auth.magicLinkExpired'));
     }
 
@@ -126,7 +126,7 @@ final class MagicLinkTest extends TestCase
             'expires' => Time::now()->addMinutes(60),
         ]);
 
-        $result = $this->get(route_to('verify-magic-link') . '?token=' . 'abasdasdf');
+        $result = $this->get(url_to('verify-magic-link') . '?token=' . 'abasdasdf');
 
         $result->assertRedirectTo(site_url());
         $result->assertSessionHas('user', ['id' => $user->id]);


### PR DESCRIPTION
Fixes #267

- Replaced `route_to()` by `url_to()` in the views, when is was used alone.
- When `route_to()` was used with `site_url()`, as in `site_url(route_to(...))`, I've left it for the sake of diversity.
- Changed `route_to()` to `url_to()` also in `tests/Authentication/MagicLinkTest.php` (please check carefully for this one as I'm not too sure about it).
> First PR here, sorry in advance if I missed something. Remarks/advice welcome.