### PR TITLE
fix: shield:setup adds routes in wrong location

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -211,7 +211,7 @@ class Setup extends BaseCommand
         $file = 'Config/Routes.php';
 
         $check   = 'service(\'auth\')->routes($routes);';
-        $pattern = '/(.*)(\n' . preg_quote('$routes->', '/') . '[^\n]+?\n)/su';
+        $pattern = '/(.*)(\n' . preg_quote('$routes->', '/') . '[^\n]+?;\n)/su';
         $replace = '$1$2' . "\n" . $check . "\n";
 
         $this->add($file, $check, $pattern, $replace);

--- a/tests/Commands/Setup/ContentReplacerTest.php
+++ b/tests/Commands/Setup/ContentReplacerTest.php
@@ -61,6 +61,11 @@ final class ContentReplacerTest extends TestCase
 
             $routes->get('/', 'Home::index');
 
+            $routes->group('admin', static function ($routes) {
+                $routes->get('users', 'Admin\Users::index');
+                $routes->get('blog', 'Admin\Blog::index');
+            });
+
             /**
              * You will have access to the $routes object within that file without
              * needing to reload it.
@@ -69,7 +74,7 @@ final class ContentReplacerTest extends TestCase
             FILE;
 
         $text    = 'service(\'auth\')->routes($routes);';
-        $pattern = '/(.*)(\n' . preg_quote('$routes->', '/') . '[^\n]+?\n)/su';
+        $pattern = '/(.*)(\n' . preg_quote('$routes->', '/') . '[^\n]+?;\n)/su';
         $replace = '$1$2' . "\n" . $text . "\n";
         $output  = $replacer->add($content, $text, $pattern, $replace);
 
@@ -87,6 +92,11 @@ final class ContentReplacerTest extends TestCase
             $routes->get('/', 'Home::index');
 
             service('auth')->routes($routes);
+
+            $routes->group('admin', static function ($routes) {
+                $routes->get('users', 'Admin\Users::index');
+                $routes->get('blog', 'Admin\Blog::index');
+            });
 
             /**
              * You will have access to the $routes object within that file without


### PR DESCRIPTION
Fixes #295

It is difficult to find the code block with regex, so this is ad hoc solution.

Before:
add the Shield routes after the last `$routes->...` line.

After:
add the Shield routes after the last `$routes->...;` line.