### PR TITLE
docs: fix the way to use  `syncPermissions()`

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -144,7 +144,7 @@ Updates the user's permissions to only include the permissions in the given list
 not in this list will be removed.
 
 ```php
-$user->syncPermissions(['admin.access', 'beta.access']);
+$user->syncPermissions('admin.access', 'beta.access');
 ```
 
 ## Managing User Groups


### PR DESCRIPTION
Hello friends,
Ref #266.
The documents needed to be modified.