### PR TITLE
fix: PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage of Shield requires the following:
 
 - A [CodeIgniter 4](https://github.com/codeigniter4/CodeIgniter4/)-based project
 - [Composer](https://getcomposer.org/) for package management
-- PHP 7.4+
+- PHP 7.4.3+
 
 ### Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "homepage": "https://github.com/codeigniter4/shield",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.4.3 || ^8.0",
         "codeigniter4/settings": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
The current code requires PHP 7.4.3+

> PASSWORD_DEFAULT was int 1; now is string '2y' (in *PHP 7.4.0, 7.4.1, and 7.4.2 it was null*)
https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.password-algorithm-constants

See #313
