### PR TITLE
feat: add allow to cancel actions for custom cases

### DIFF
--- a/docs/auth_actions.md
+++ b/docs/auth_actions.md
@@ -2,7 +2,9 @@
 
 - [Authentication Actions](#authentication-actions)
   - [Configuring Actions](#configuring-actions)
+  - [Cancel Actions For Custom Cases](#cancel-actions-for-custom-cases)
   - [Defining New Actions](#defining-new-actions)
+
 
 Authentication Actions are a way to group actions that can happen after login or registration.
 Shield ships with two actions you can use, and makes it simple for you to define your own.
@@ -54,6 +56,23 @@ Views for all of these pages are defined in the `Auth` config file, with the `$v
         'action_email_activate_show'  => '\CodeIgniter\Shield\Views\email_activate_show',
     ];
 ```
+
+## Cancel Actions For Custom Cases
+
+By default, if the actions are set with the `$actions` variable, Actions will be applied regardless of the limit.
+If you need actions cancel for custom cases, you can complete the following cases.
+
+```php
+public array $cancelActions = [
+    'groups'      => ['superadmin', 'admin'],
+    'permissions' => ['users.create', 'users.edit'],
+    'usersId'     => null,
+];
+```
+
+In the above example, given that the groups value and permissions are set, if the target user
+has one of the `superadmin` or `admin` groups, or one of the permissions `users.create` or `users.edit`,
+The actions is not executed for him.
 
 ## Defining New Actions
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -156,6 +156,30 @@ class Session implements AuthenticatorInterface
             return false;
         }
 
+        $hasCancelAction = setting('Auth.cancelActions')['groups'] !== null
+                            || setting('Auth.cancelActions')['permissions'] !== null
+                            || setting('Auth.cancelActions')['usersId'] !== null;
+
+        if ($hasCancelAction) {
+            $userPermissions = $user->getPermissions();
+            $userGroups      = $user->getGroups();
+            $userId          = (array) $user->id;
+
+            $currentUserInfo = array_merge($userPermissions, $userGroups, $userId);
+
+            $casesforCancelAction = array_merge(
+                setting('Auth.cancelActions')['groups'] ?? [],
+                setting('Auth.cancelActions')['permissions'] ?? [],
+                setting('Auth.cancelActions')['usersId'] ?? [],
+            );
+
+            foreach ($casesforCancelAction as $casesCancel) {
+                if (in_array($casesCancel, $currentUserInfo, true)) {
+                    return false;
+                }
+            }
+        }
+
         $action = Factories::actions($actionClass); // @phpstan-ignore-line
 
         // Create identity for the action.

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -67,6 +67,30 @@ class Auth extends BaseConfig
 
     /**
      * --------------------------------------------------------------------
+     * Cancel Authentication Actions For Custom Cases
+     * --------------------------------------------------------------------
+     * By default, if the actions are set, they will be applied regardless of the limit.
+     * If you need actions cancel for custom cases,you can complete the following cases.
+     *
+     * Method of set values:
+     * - groups:      ['superadmin', 'admin'],
+     * - permissions: ['users.create'],
+     * - usersId:     ['1','2','3'],
+     *
+     * Example:
+     * If set this, actions not applay for users have groups "superadmin" or "admin"
+     * - groups:      ['superadmin', 'admin'],
+     *
+     * @var array<string, array|null>
+     */
+    public array $cancelActions = [
+        'groups'      => ['superadmin', 'staff'],
+        'permissions' => null,
+        'usersId'     => null,
+    ];
+
+    /**
+     * --------------------------------------------------------------------
      * Authenticators
      * --------------------------------------------------------------------
      * The available authentication systems, listed


### PR DESCRIPTION
Hello friends.
The purpose of these PR,
Add a feature to cancel actions if there are custom cases. 
This PR allows the shield to cancel actions by checking the user `groups`,`permissions `or `userID`.

Task checklist:
- [x] Add to docs
- [x] Edit `Session::class`
- [ ] Add test
