### PR TITLE
fix: remove `permissions` from allowedFields UserModel

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -26,7 +26,6 @@ class UserModel extends Model
         'active',
         'last_active',
         'deleted_at',
-        'permissions',
     ];
     protected $useTimestamps = true;
     protected $afterFind     = ['fetchIdentities'];


### PR DESCRIPTION
Hello,
We don't have `permissions `  column in `users `table.