### PR TITLE
chore: update composer cs-fix command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,6 @@
             "rector process",
             "@style"
         ],
-        "cs-fix": "@style",
         "deduplicate": "phpcpd app/ src/",
         "inspect": "deptrac analyze --cache-file=build/deptrac.cache",
         "mutate": "infection --threads=2 --skip-initial-tests --coverage=build/phpunit",
@@ -72,7 +71,8 @@
             "phpstan analyze",
             "psalm"
         ],
-        "style": "php-cs-fixer fix --verbose --ansi --using-cache=no",
+        "cs-fix": "php-cs-fixer fix --ansi --verbose --diff --using-cache=yes",
+        "style": "@cs-fix",
         "test": "phpunit"
     }
 }


### PR DESCRIPTION
- Use cache. No cache is slow.
- Make `cs-fix` default. CodeIgniter4 repository does not have `style` command.