### PR TITLE
refactor: fix incorrect types

### DIFF
--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -44,7 +44,7 @@ class AccessTokens implements AuthenticatorInterface
         $request = service('request');
 
         $ipAddress = $request->getIPAddress();
-        $userAgent = $request->getUserAgent();
+        $userAgent = (string) $request->getUserAgent();
 
         $result = $this->check($credentials);
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -98,7 +98,7 @@ class Session implements AuthenticatorInterface
         $request = service('request');
 
         $ipAddress = $request->getIPAddress();
-        $userAgent = $request->getUserAgent();
+        $userAgent = (string) $request->getUserAgent();
 
         $result = $this->check($credentials);
 

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -178,7 +178,7 @@ class MagicLinkController extends BaseController
             $identifier,
             $success,
             $this->request->getIPAddress(),
-            $this->request->getUserAgent(),
+            (string) $this->request->getUserAgent(),
             $userId
         );
     }

--- a/src/Models/CheckQueryReturnTrait.php
+++ b/src/Models/CheckQueryReturnTrait.php
@@ -10,7 +10,10 @@ trait CheckQueryReturnTrait
 {
     private ?bool $currentDBDebug = null;
 
-    private function checkQueryReturn(bool $return): void
+    /**
+     * @param bool|int|string $return insert() returns insert ID.
+     */
+    private function checkQueryReturn($return): void
     {
         $this->restoreDBDebug();
 


### PR DESCRIPTION
We don't use `declare(strict_types=1)` yet, so these do not cause errors now.
