### PR TITLE
Change the scope of `createIdentity()` method

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -115,7 +115,7 @@ class Email2FA implements ActionInterface
         $this->createIdentity($user);
     }
 
-    private function createIdentity(User $user): void
+    protected function createIdentity(User $user): void
     {
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -115,7 +115,7 @@ class Email2FA implements ActionInterface
         $this->createIdentity($user);
     }
 
-    protected function createIdentity(User $user): void
+    final protected function createIdentity(User $user): void
     {
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -101,7 +101,7 @@ class EmailActivator implements ActionInterface
         $this->createIdentity($user);
     }
 
-    protected function createIdentity(User $user): string
+    final protected function createIdentity(User $user): string
     {
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -101,7 +101,7 @@ class EmailActivator implements ActionInterface
         $this->createIdentity($user);
     }
 
-    private function createIdentity(User $user): string
+    protected function createIdentity(User $user): string
     {
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);


### PR DESCRIPTION
Sometimes developers might prefer to just extend the default Auth actions classes instead of creating a new one, and since the creation/generation of tokens is done in the `createIdentity()` methods, it is impossible to use it inside child classes as it is `private`. See:
https://github.com/codeigniter4/shield/blob/44e65eff3043530e21337ffdb2d2f6c991a0e548/src/Authentication/Actions/Email2FA.php#L118
https://github.com/codeigniter4/shield/blob/44e65eff3043530e21337ffdb2d2f6c991a0e548/src/Authentication/Actions/EmailActivator.php#L104

Ref #330