### PR TITLE
Change the second param in Forge's `createTable()` method

### DIFF
--- a/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
@@ -22,7 +22,7 @@ class CreateAuthTables extends Migration
         ]);
         $this->forge->addPrimaryKey('id');
         $this->forge->addUniqueKey('username');
-        $this->forge->createTable('users', true);
+        $this->forge->createTable('users');
 
         /*
          * Auth Identities Table
@@ -46,7 +46,7 @@ class CreateAuthTables extends Migration
         $this->forge->addUniqueKey(['type', 'secret']);
         $this->forge->addKey('user_id');
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'CASCADE');
-        $this->forge->createTable('auth_identities', true);
+        $this->forge->createTable('auth_identities');
 
         /**
          * Auth Login Attempts Table
@@ -67,7 +67,7 @@ class CreateAuthTables extends Migration
         $this->forge->addKey(['id_type', 'identifier']);
         $this->forge->addKey('user_id');
         // NOTE: Do NOT delete the user_id or identifier when the user is deleted for security audits
-        $this->forge->createTable('auth_logins', true);
+        $this->forge->createTable('auth_logins');
 
         /*
          * Auth Token Login Attempts Table
@@ -87,7 +87,7 @@ class CreateAuthTables extends Migration
         $this->forge->addKey(['id_type', 'identifier']);
         $this->forge->addKey('user_id');
         // NOTE: Do NOT delete the user_id or identifier when the user is deleted for security audits
-        $this->forge->createTable('auth_token_logins', true);
+        $this->forge->createTable('auth_token_logins');
 
         /*
          * Auth Remember Tokens (remember-me) Table
@@ -105,7 +105,7 @@ class CreateAuthTables extends Migration
         $this->forge->addPrimaryKey('id');
         $this->forge->addUniqueKey('selector');
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'CASCADE');
-        $this->forge->createTable('auth_remember_tokens', true);
+        $this->forge->createTable('auth_remember_tokens');
 
         // Groups Users Table
         $this->forge->addField([
@@ -116,7 +116,7 @@ class CreateAuthTables extends Migration
         ]);
         $this->forge->addPrimaryKey('id');
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'CASCADE');
-        $this->forge->createTable('auth_groups_users', true);
+        $this->forge->createTable('auth_groups_users');
 
         // Users Permissions Table
         $this->forge->addField([
@@ -127,7 +127,7 @@ class CreateAuthTables extends Migration
         ]);
         $this->forge->addPrimaryKey('id');
         $this->forge->addForeignKey('user_id', 'users', 'id', '', 'CASCADE');
-        $this->forge->createTable('auth_permissions_users', true);
+        $this->forge->createTable('auth_permissions_users');
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
According to the [docs](https://codeigniter4.github.io/CodeIgniter4/installation/upgrade_422.html#others), 
* The method `Forge::createTable()` no longer executes a `CREATE TABLE IF NOT EXISTS`. If table is not found in `$db->tableExists($table)` then `CREATE TABLE` is executed.
* The second parameter `$ifNotExists` of `Forge::_createTable()` is deprecated. It is no longer used and will be removed in a future release.

And since shield has been updated to `^4.2.3`, I think this should be followed.