### PR TITLE
fix: field name translation in validation errors

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -95,35 +95,47 @@ Shield has the following rules for registration:
 
 ```php
 [
-    'username'         => [
-            'required',
-            'max_length[30]',
-            'min_length[3]',
-            'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
-            'is_unique[users.username]',
-        ],
-    'email'            => 'required|max_length[254]|valid_email|is_unique[auth_identities.secret]',
-    'password'         => 'required|strong_password',
-    'password_confirm' => 'required|matches[password]',
+    'username' => [
+        'label' =>  'Auth.username',
+        'rules' => 'required|max_length[30]|min_length[3]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|is_unique[users.username]',
+    ],
+    'email' => [
+        'label' =>  'Auth.email',
+        'rules' => 'required|max_length[254]|valid_email|is_unique[auth_identities.secret]',
+    ],
+    'password' => [
+        'label' =>  'Auth.password',
+        'rules' => 'required|strong_password',
+    ],
+    'password_confirm' => [
+        'label' =>  'Auth.passwordConfirm',
+        'rules' => 'required|matches[password]',
+    ],
 ];
 ```
 
 If you need a different set of rules for registration, you can specify them in your `Validation` configuration (**app/Config/Validation.php**) like:
 
 ```php
-//--------------------------------------------------------------------
-// Rules
-//--------------------------------------------------------------------
-public $registration = [
-    'username'         => [
-            'required',
-            'max_length[30]',
-            'min_length[3]',
-            'regex_match[/\A[a-zA-Z0-9\.]+\z/]',
-            'is_unique[users.username]',
+    //--------------------------------------------------------------------
+    // Rules
+    //--------------------------------------------------------------------
+    public $registration = [
+        'username' => [
+            'label' =>  'Auth.username',
+            'rules' => 'required|max_length[30]|min_length[3]|regex_match[/\A[a-zA-Z0-9\.]+\z/]|is_unique[users.username]',
         ],
-    'email'            => 'required|max_length[254]|valid_email|is_unique[auth_identities.secret]',
-    'password'         => 'required|strong_password',
-    'password_confirm' => 'required|matches[password]',
-];
+        'email' => [
+            'label' =>  'Auth.email',
+            'rules' => 'required|max_length[254]|valid_email|is_unique[auth_identities.secret]',
+        ],
+        'password' => [
+            'label' =>  'Auth.password',
+            'rules' => 'required|strong_password',
+        ],
+        'password_confirm' => [
+            'label' =>  'Auth.passwordConfirm',
+            'rules' => 'required|matches[password]',
+        ],
+    ];
 ```

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -70,9 +70,18 @@ class LoginController extends BaseController
     protected function getValidationRules(): array
     {
         return setting('Validation.login') ?? [
-            //'username' => config('AuthSession')->usernameValidationRules,
-            'email'    => config('AuthSession')->emailValidationRules,
-            'password' => 'required',
+            // 'username' => [
+            //     'label' => 'Auth.username',
+            //     'rules' => config('AuthSession')->usernameValidationRules,
+            // ],
+            'email' => [
+                'label' => 'Auth.email',
+                'rules' => config('AuthSession')->emailValidationRules,
+            ],
+            'password' => [
+                'label' => 'Auth.password',
+                'rules' => 'required',
+            ],
         ];
     }
 

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -191,7 +191,10 @@ class MagicLinkController extends BaseController
     protected function getValidationRules(): array
     {
         return [
-            'email' => config('AuthSession')->emailValidationRules,
+            'email' => [
+                'label' => 'Auth.email',
+                'rules' => config('AuthSession')->emailValidationRules,
+            ],
         ];
     }
 }

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -151,10 +151,22 @@ class RegisterController extends BaseController
         );
 
         return setting('Validation.registration') ?? [
-            'username'         => $registrationUsernameRules,
-            'email'            => $registrationEmailRules,
-            'password'         => 'required|strong_password',
-            'password_confirm' => 'required|matches[password]',
+            'username' => [
+                'label' => 'Auth.username',
+                'rules' => $registrationUsernameRules,
+            ],
+            'email' => [
+                'label' => 'Auth.email',
+                'rules' => $registrationEmailRules,
+            ],
+            'password' => [
+                'label' => 'Auth.password',
+                'rules' => 'required|strong_password',
+            ],
+            'password_confirm' => [
+                'label' => 'Auth.passwordConfirm',
+                'rules' => 'required|matches[password]',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Before:
![befor](https://user-images.githubusercontent.com/9530214/183339728-26041fc4-062e-4318-9d6f-508ef39757b6.jpg)

After:
![After](https://user-images.githubusercontent.com/9530214/183339762-ca07d222-6500-42b8-9dc9-db500fab2909.jpg)

