### PR TITLE
docs: remove unnecessary details of `CI4.1.x`

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -95,8 +95,6 @@ If you get `Specified key was too long` error:
 > php spark shield:setup
 ```
 
-2. If you are running CodeIgniter v4.1.x, go to *Manual Setup* 4.
-
 ### Manual Setup
 
 There are a few setup items to do before you can start using Shield in
@@ -137,21 +135,6 @@ This requires that all of your controllers extend the `BaseController`, but that
 
 ```php
 service('auth')->routes($routes);
-```
-
-4. (If you are running CodeIgniter v4.2.0 or higher you can skip this step). Add the new password validation rules
-by editing `app/Config/Validation.php`:
-
-```php
-use CodeIgniter\Shield\Authentication\Passwords\ValidationRules as PasswordRules;
-
-public $ruleSets = [
-        Rules::class,
-        FormatRules::class,
-        FileRules::class,
-        CreditCardRules::class,
-        PasswordRules::class     // <!-- add this line
-    ];
 ```
 
 ## Controller Filters


### PR DESCRIPTION
Hello friends,
CodeIgniter Shield requires Codeigniter v4.2.3 or later.
Do we need a description of the lower version?