### PR TITLE
refactor: add intermediate variable and specify type in TokenAuth

### DIFF
--- a/src/Filters/TokenAuth.php
+++ b/src/Filters/TokenAuth.php
@@ -7,6 +7,7 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\Shield\Authentication\Authenticators\AccessTokens;
 
 /**
  * Access Token Authentication Filter.
@@ -33,7 +34,10 @@ class TokenAuth implements FilterInterface
     {
         helper(['auth', 'setting']);
 
-        $result = auth('tokens')->authenticate([
+        /** @var AccessTokens $authenticator */
+        $authenticator = auth('tokens')->getAuthenticator();
+
+        $result = $authenticator->attempt([
             'token' => $request->getHeaderLine(setting('Auth.authenticatorHeader')['tokens'] ?? 'Authorization'),
         ]);
 

--- a/tests/Authentication/AuthTest.php
+++ b/tests/Authentication/AuthTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Authentication;
+
+use CodeIgniter\Shield\Config\Services;
+use Tests\Support\DatabaseTestCase;
+
+/**
+ * @internal
+ */
+final class AuthTest extends DatabaseTestCase
+{
+    public function testAuthenticateFail(): void
+    {
+        $auth = Services::auth();
+
+        $credentials = ['email' => ''];
+        $result      = $auth->authenticate($credentials);
+
+        $this->assertFalse($result->isOK());
+    }
+}


### PR DESCRIPTION
To jump to the method definition quickly.

Before:
![スクリーンショット 2022-08-11 11 15 54](https://user-images.githubusercontent.com/87955/184055059-0eccd035-8aba-4726-b388-7c508366f7c7.png)
![スクリーンショット 2022-08-11 11 16 08](https://user-images.githubusercontent.com/87955/184055064-6e8538ef-1cfe-41fd-95fa-c8150635ea98.png)
![スクリーンショット 2022-08-11 11 16 14](https://user-images.githubusercontent.com/87955/184055070-701a376d-24f8-45c1-ac9f-48f2489d561d.png)
Can't go to `AccessTokens::attempt()`

After:
![スクリーンショット 2022-08-11 11 19 37](https://user-images.githubusercontent.com/87955/184055072-bd66dc53-3053-403d-897d-5abb20e79c41.png)
![スクリーンショット 2022-08-11 11 19 59](https://user-images.githubusercontent.com/87955/184055073-4fdc5870-5662-4276-9a5d-7bcdb61b9de1.png)

