### PR TITLE
fix: AccessTokens throws DataException

### DIFF
--- a/src/Authentication/Authenticators/AccessTokens.php
+++ b/src/Authentication/Authenticators/AccessTokens.php
@@ -125,7 +125,10 @@ class AccessTokens implements AuthenticatorInterface
         }
 
         $token->last_used_at = Time::now()->format('Y-m-d H:i:s');
-        $identityModel->save($token);
+
+        if ($token->hasChanged()) {
+            $identityModel->save($token);
+        }
 
         // Ensure the token is set as the current token
         $user = $token->user();

--- a/tests/Authentication/Authenticators/AccessTokenAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/AccessTokenAuthenticatorTest.php
@@ -155,6 +155,9 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
 
         $updatedToken = $result->extraInfo()->currentAccessToken();
         $this->assertNotEmpty($updatedToken->last_used_at);
+
+        // Checking token in the same second does not throw "DataException : There is no data to update."
+        $this->auth->check(['token' => $token->raw_token]);
     }
 
     public function testAttemptCannotFindUser(): void


### PR DESCRIPTION
Fixes #360

Checking token in the same second twice throwed "DataException : There is no data to update."
