### PR TITLE
Remove superfluous `--using-cache` option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
             "phpstan analyze",
             "psalm"
         ],
-        "cs-fix": "php-cs-fixer fix --ansi --verbose --diff --using-cache=yes",
+        "cs-fix": "php-cs-fixer fix --ansi --verbose --diff",
         "style": "@cs-fix",
         "test": "phpunit"
     }


### PR DESCRIPTION
When using `nexusphp/cs-config`, the `--using-cache` is default `true` if not provided.
https://github.com/NexusPHP/cs-config/blob/e9092a9ab3a59c982bf0c79c89df36a7b2c0b86e/src/Factory.php#L122