### PR TITLE
fix: redirect()->withInput() causes ValidationException

### DIFF
--- a/src/Models/CheckQueryReturnTrait.php
+++ b/src/Models/CheckQueryReturnTrait.php
@@ -52,8 +52,8 @@ trait CheckQueryReturnTrait
      */
     private function getValidationErrors(): array
     {
-        // @TODO When CI v4.3 is released, you can use `$this->validation->getErrors(false)`.
-        // See https://github.com/codeigniter4/CodeIgniter4/pull/6381
+        // @TODO When CI v4.3 is released, you don't need this hack.
+        //       See https://github.com/codeigniter4/CodeIgniter4/pull/6384
         return $this->getValidationPropertyErrors();
     }
 

--- a/src/Models/CheckQueryReturnTrait.php
+++ b/src/Models/CheckQueryReturnTrait.php
@@ -32,7 +32,7 @@ trait CheckQueryReturnTrait
 
     private function checkValidationError(): void
     {
-        $validationErrors = $this->validation->getErrors();
+        $validationErrors = $this->getValidationErrors();
 
         if ($validationErrors !== []) {
             $message = 'Validation error:';
@@ -43,6 +43,25 @@ trait CheckQueryReturnTrait
 
             throw new ValidationException($message);
         }
+    }
+
+    /**
+     * Gets real validation errors that are not saved in the Session.
+     *
+     * @return string[]
+     */
+    private function getValidationErrors(): array
+    {
+        return $this->getValidationPropertyErrors();
+    }
+
+    private function getValidationPropertyErrors(): array
+    {
+        $refClass    = new ReflectionObject($this->validation);
+        $refProperty = $refClass->getProperty('errors');
+        $refProperty->setAccessible(true);
+
+        return $refProperty->getValue($this->validation);
     }
 
     private function disableDBDebug(): void

--- a/src/Models/CheckQueryReturnTrait.php
+++ b/src/Models/CheckQueryReturnTrait.php
@@ -52,6 +52,8 @@ trait CheckQueryReturnTrait
      */
     private function getValidationErrors(): array
     {
+        // @TODO When CI v4.3 is released, you can use `$this->validation->getErrors(false)`.
+        // See https://github.com/codeigniter4/CodeIgniter4/pull/6381
         return $this->getValidationPropertyErrors();
     }
 


### PR DESCRIPTION
Fixes https://github.com/codeigniter4/shield/discussions/381

`redirect()->withInput()` or `withErrors()` saves validation errors in the Session.
And the check of the validation errors in Model (`checkQueryReturn()`),
`$this->validation->getErrors()` returns the errors in the Session. 

**How to Test**
```diff
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -36,6 +36,7 @@ class Filters extends BaseConfig
             // 'honeypot',
             // 'csrf',
             // 'invalidchars',
+            'session' => ['except' => 'login*'],
         ],
         'after' => [
             'toolbar',
```
```diff
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -2,10 +2,22 @@
 
 namespace App\Controllers;
 
+use Config\Services;
+
 class Home extends BaseController
 {
     public function index()
     {
-        return view('welcome_message');
+        $this->validation = Services::validation();
+
+        $this->validation->setRules([
+            'email' => 'required|valid_email|unique_email[{user_id}]',
+        ]);
+
+        if (! $this->validation->withRequest($this->request)->run()) {
+            return redirect()
+                ->to('logout')
+                ->withInput();
+        }
     }
 }
```

