### PR TITLE
fix: NothingPersonalValidator strip_explode too sensible

### DIFF
--- a/src/Authentication/Passwords/NothingPersonalValidator.php
+++ b/src/Authentication/Passwords/NothingPersonalValidator.php
@@ -114,8 +114,8 @@ class NothingPersonalValidator extends BaseValidator implements ValidatorInterfa
             $haystacks = $this->strip_explode($password);
 
             foreach ($haystacks as $haystack) {
-                if (empty($haystack) || in_array($haystack, $trivial, true)) {
-                    continue;  //ignore trivial words
+                if (empty($haystack) || in_array($haystack, $trivial, true) || strlen($haystack)<3) {
+                    continue;  //ignore trivial words, or little words of less than 3 characters
                 }
 
                 foreach ($needles as $needle) {


### PR DESCRIPTION
Fixes https://github.com/codeigniter4/shield/issues/385

What happened?
The function NothingPersonalValidator->strip_explode() is too sensible for exploding the user password.
Indeed, it explode any part separated for example with an underscore or a "-".
This can produce the search of only one letter in the username and/or email adresse as part of a personal information.
The user is then prompted wrongly that his password cannot contain any personal information contained is his username or email.

Steps to Reproduce
Try to register with :
email : xxx@gmail.com
password : G-test#1234

In this case, NothingPersonalValidator will fail cause "G" is considered as part of "xxx@gmail.com"

Expected Output
I think the NothingPersonalValidator->strip_explode() function should check if the searched string is not too short and then try to make a match only if the searching string contain 3 or more caracters.