### PR TITLE
fix: Session auth action checks

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -152,6 +152,9 @@ class Session implements AuthenticatorInterface
         // Update the user's last used date on their password identity.
         $user->touchIdentity($user->getEmailIdentity());
 
+        // Check ID_TYPE_EMAIL_ACTIVATE identity
+        $hasEmailActivate = $this->setAuthActionEmailActivate();
+
         // If an action has been defined for login, start it up.
         $hasAction = $this->startUpAction('login', $user);
 
@@ -161,7 +164,7 @@ class Session implements AuthenticatorInterface
 
         $this->issueRememberMeToken();
 
-        if (! $hasAction) {
+        if (! $hasAction && ! $hasEmailActivate) {
             $this->completeLogin($user);
         }
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -412,15 +412,38 @@ class Session implements AuthenticatorInterface
     }
 
     /**
-     * Gets identities for action from database, and set session.
+     * Has Auth Action?
      */
-    private function setAuthAction(): void
+    public function hasAction(): bool
     {
+        // Check the Session
+        if ($this->getSessionKey('auth_action')) {
+            return true;
+        }
+
+        // Check the database
+        return $this->setAuthAction();
+    }
+
+    /**
+     * Gets identities for action from database, and set session.
+     *
+     * @return bool true if the action is set in the session.
+     */
+    private function setAuthAction(): bool
+    {
+        if ($this->user === null) {
+            return false;
+        }
+
         // First, check ID_TYPE_EMAIL_ACTIVATE identity
-        $this->setAuthActionEmailActivate();
+        $hasAction = $this->setAuthActionEmailActivate();
+        if ($hasAction) {
+            return true;
+        }
 
         // Next, check ID_TYPE_EMAIL_2FA identity
-        $this->setAuthActionEmail2FA();
+        return $this->setAuthActionEmail2FA();
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -35,14 +35,17 @@ class Session implements AuthenticatorInterface
      */
     public const ID_TYPE_USERNAME = 'username';
 
+    // Identity types
     public const ID_TYPE_EMAIL_PASSWORD = 'email_password';
     public const ID_TYPE_MAGIC_LINK     = 'magic-link';
     public const ID_TYPE_EMAIL_2FA      = 'email_2fa';
     public const ID_TYPE_EMAIL_ACTIVATE = 'email_activate';
-    private const STATE_UNKNOWN         = 0;
-    private const STATE_ANONYMOUS       = 1;
-    private const STATE_PENDING         = 2;
-    private const STATE_LOGGED_IN       = 3;
+
+    // User states
+    private const STATE_UNKNOWN   = 0; // Not checked yet.
+    private const STATE_ANONYMOUS = 1;
+    private const STATE_PENDING   = 2; // 2FA or Activation required.
+    private const STATE_LOGGED_IN = 3;
 
     /**
      * The persistence engine

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -423,6 +423,9 @@ class Session implements AuthenticatorInterface
         $this->setAuthActionEmail2FA();
     }
 
+    /**
+     * @return bool true if the action is set in the session.
+     */
     private function setAuthActionEmailActivate(): bool
     {
         $identity = $this->userIdentityModel->getIdentityByType(
@@ -446,6 +449,9 @@ class Session implements AuthenticatorInterface
         return false;
     }
 
+    /**
+     * @return bool true if the action is set in the session.
+     */
     private function setAuthActionEmail2FA(): bool
     {
         $identity = $this->userIdentityModel->getIdentityByType(

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -26,7 +26,7 @@ class LoginController extends BaseController
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
-        // If an action has been defined for login, start it up.
+        // If an action has been defined, start it up.
         if ($authenticator->hasAction()) {
             return redirect()->route('auth-action-show');
         }

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -44,14 +44,18 @@ class LoginController extends BaseController
         $credentials['password'] = $this->request->getPost('password');
         $remember                = (bool) $this->request->getPost('remember');
 
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
         // Attempt to login
-        $result = auth('session')->remember($remember)->attempt($credentials);
+        $result = $authenticator->remember($remember)->attempt($credentials);
         if (! $result->isOK()) {
             return redirect()->route('login')->withInput()->with('error', $result->reason());
         }
 
         // custom bit of information
         $user = $result->extraInfo();
+
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -60,8 +60,7 @@ class LoginController extends BaseController
         $authenticator = auth('session')->getAuthenticator();
 
         // If an action has been defined for login, start it up.
-        $hasAction = $authenticator->startUpAction('login', $user);
-        if ($hasAction) {
+        if ($authenticator->hasAction()) {
             return redirect()->route('auth-action-show')->withCookies();
         }
 

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -61,9 +61,6 @@ class LoginController extends BaseController
             return redirect()->route('login')->withInput()->with('error', $result->reason());
         }
 
-        // custom bit of information
-        $user = $result->extraInfo();
-
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -23,6 +23,14 @@ class LoginController extends BaseController
             return redirect()->to(config('Auth')->loginRedirect());
         }
 
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        // If an action has been defined for login, start it up.
+        if ($authenticator->hasAction()) {
+            return redirect()->route('auth-action-show');
+        }
+
         return view(setting('Auth.views')['login']);
     }
 

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -39,6 +39,14 @@ class RegisterController extends BaseController
                 ->with('error', lang('Auth.registerDisabled'));
         }
 
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        // If an action has been defined, start it up.
+        if ($authenticator->hasAction()) {
+            return redirect()->route('auth-action-show');
+        }
+
         return view(setting('Auth.views')['register']);
     }
 

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -147,6 +147,83 @@ final class RegisterTest extends DatabaseTestCase
         ]);
     }
 
+    public function testRegisteredButNotActivatedAndLogin(): void
+    {
+        // Ensure our action is defined
+        $config                      = config('Auth');
+        $config->actions['register'] = EmailActivator::class;
+        Factories::injectMock('config', 'Auth', $config);
+
+        $result = $this->post('/register', [
+            'email'            => 'foo@example.com',
+            'username'         => 'foo',
+            'password'         => 'abkdhflkjsdflkjasd;lkjf',
+            'password_confirm' => 'abkdhflkjsdflkjasd;lkjf',
+        ]);
+
+        // Should have been redirected to the action's page.
+        $result->assertRedirectTo('/auth/a/show');
+
+        // Not activated yet, but login again.
+        $result = $this->withSession()->get('/login');
+
+        // Should have been redirected to the action's page.
+        $result->assertRedirectTo('/auth/a/show');
+    }
+
+    public function testRegisteredButNotActivatedAndRegisterAgain(): void
+    {
+        // Ensure our action is defined
+        $config                      = config('Auth');
+        $config->actions['register'] = EmailActivator::class;
+        Factories::injectMock('config', 'Auth', $config);
+
+        $password = 'abkdhflkjsdflkjasd;lkjf';
+
+        $result = $this->post('/register', [
+            'email'            => 'foo@example.com',
+            'username'         => 'foo',
+            'password'         => $password,
+            'password_confirm' => $password,
+        ]);
+
+        // Should have been redirected to the action's page.
+        $result->assertRedirectTo('/auth/a/show');
+
+        // Not activated yet, but register again.
+        $result = $this->withSession()->get('/register');
+
+        // Should have been redirected to the action's page.
+        $result->assertRedirectTo('/auth/a/show');
+    }
+
+    public function testRegisteredAndSessionExpiredAndLogin(): void
+    {
+        // Ensure our action is defined
+        $config                      = config('Auth');
+        $config->actions['register'] = EmailActivator::class;
+        Factories::injectMock('config', 'Auth', $config);
+
+        $result = $this->post('/register', [
+            'email'            => 'foo@example.com',
+            'username'         => 'foo',
+            'password'         => 'abkdhflkjsdflkjasd;lkjf',
+            'password_confirm' => 'abkdhflkjsdflkjasd;lkjf',
+        ]);
+
+        // Should have been redirected to the action's page.
+        $result->assertRedirectTo('/auth/a/show');
+
+        // Not activated yet, and do not set Session (= the session is expired) and login again.
+        $result = $this->post('/login', [
+            'email'    => 'foo@example.com',
+            'password' => 'abkdhflkjsdflkjasd;lkjf',
+        ]);
+
+        // Should have been redirected to the action's page.
+        $result->assertRedirectTo('/auth/a/show');
+    }
+
     public function testRegisterRedirectsIfLoggedIn(): void
     {
         // log them in


### PR DESCRIPTION
- Fixes #349
  - if the user goes to the login page, redirected to the Email Activation page and the code will be sent again
- After registration, when the user do not send activation code and the session expires
  - if the user logs in, the Email Activation code will be sent again