### PR TITLE
fix: correctly record the datetime for `last_active` 

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -326,7 +326,10 @@ class UserModel extends Model
      */
     public function updateActiveDate(User $user): void
     {
-        $this->builder->set('last_active', $user->last_active)
+        // Safe date string for database
+        $last_active = $user->last_active->format('Y-m-d H:i:s');
+
+        $this->builder->set('last_active', $last_active)
             ->where('id', $user->id)
             ->update();
     }


### PR DESCRIPTION
Hello friends,
correctly record the datetime for last_active in case of change `defaultLocale`.

**Before:**
```console
+----+--------------------+--------+----------------+--------+--------------------+--------------------+--------------------+------------+
| id | username           | status | status_message | active | last_active        | created_at         | updated_at         | deleted_at |
+----+--------------------+--------+----------------+--------+--------------------+--------------------+--------------------+------------+
| 1  | pooyaparsadadas... |        |                | 1      | 0000-00-00 00:0... | 2022-08-25 15:3... | 2022-08-25 15:3... |            |
+----+--------------------+--------+----------------+--------+--------------------+--------------------+--------------------+------------+
```
**After:**
```console
+----+--------------------+--------+----------------+--------+--------------------+--------------------+--------------------+------------+
| id | username           | status | status_message | active | last_active        | created_at         | updated_at         | deleted_at |
+----+--------------------+--------+----------------+--------+--------------------+--------------------+--------------------+------------+
| 1  | pooyaparsadadas... |        |                | 1      | 2022-08-25 15:4... | 2022-08-25 15:3... | 2022-08-25 15:3... |            |
+----+--------------------+--------+----------------+--------+--------------------+--------------------+--------------------+------------+
```

Ref #238
