### PR TITLE
fix: add logic to skip filters if not in HTTP

### DIFF
--- a/src/Filters/AuthRates.php
+++ b/src/Filters/AuthRates.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Filters;
 
 use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
@@ -31,6 +32,10 @@ class AuthRates implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
+        if (! $request instanceof IncomingRequest) {
+            return;
+        }
+
         $throttler = service('throttler');
 
         // Restrict an IP address to no more than 10 requests

--- a/src/Filters/ChainAuth.php
+++ b/src/Filters/ChainAuth.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Filters;
 
 use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
@@ -35,6 +36,10 @@ class ChainAuth implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
+        if (! $request instanceof IncomingRequest) {
+            return;
+        }
+
         helper('settings');
 
         $chain = config('Auth')->authenticationChain;

--- a/src/Filters/SessionAuth.php
+++ b/src/Filters/SessionAuth.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Filters;
 
 use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
@@ -34,6 +35,10 @@ class SessionAuth implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
+        if (! $request instanceof IncomingRequest) {
+            return;
+        }
+
         helper('setting');
 
         /** @var Session $authenticator */

--- a/src/Filters/TokenAuth.php
+++ b/src/Filters/TokenAuth.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Filters;
 
 use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
@@ -34,6 +35,10 @@ class TokenAuth implements FilterInterface
      */
     public function before(RequestInterface $request, $arguments = null)
     {
+        if (! $request instanceof IncomingRequest) {
+            return;
+        }
+
         helper('setting');
 
         /** @var AccessTokens $authenticator */

--- a/tests/Unit/FilterInCliTest.php
+++ b/tests/Unit/FilterInCliTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\CLIRequest;
+use CodeIgniter\Shield\Filters\AuthRates;
+use CodeIgniter\Shield\Filters\ChainAuth;
+use CodeIgniter\Shield\Filters\SessionAuth;
+use CodeIgniter\Shield\Filters\TokenAuth;
+use Generator;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class FilterInCliTest extends TestCase
+{
+    /**
+     * @dataProvider filterProvider
+     */
+    public function testWhenInCliDoNothing(FilterInterface $filter): void
+    {
+        $clirequest = $this->createMock(CLIRequest::class);
+
+        $clirequest->expects($this->never())
+            ->method('getHeaderLine');
+
+        $filter->before($clirequest);
+    }
+
+    public function filterProvider(): Generator
+    {
+        yield from [
+            [new AuthRates()],
+            [new ChainAuth()],
+            [new SessionAuth()],
+            [new TokenAuth()],
+        ];
+    }
+}


### PR DESCRIPTION
All filters do not make sense in CLI.

Fixes the PHPStan error:

```
Error: Call to an undefined method CodeIgniter\HTTP\RequestInterface::getHeaderLine().
 ------ ----------------------------------------------------- 
  Line   src/Filters/TokenAuth.php                            
 ------ ----------------------------------------------------- 
  43     Call to an undefined method                          
         CodeIgniter\HTTP\RequestInterface::getHeaderLine().  
 ------ ----------------------------------------------------- 
```
https://github.com/codeigniter4/shield/runs/8072975213?check_suite_focus=true
