### PR TITLE
refactor: fix PHPStan error

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -106,7 +106,7 @@ class Auth
 
         $routes->group('/', ['namespace' => 'CodeIgniter\Shield\Controllers'], static function (RouteCollection $routes) use ($authRoutes, $config): void {
             foreach ($authRoutes as $name => $row) {
-                if (! isset($config['except']) || (isset($config['except']) && ! in_array($name, $config['except'], true))) {
+                if (! isset($config['except']) || ! in_array($name, $config['except'], true)) {
                     foreach ($row as $params) {
                         $options = isset($params[3])
                             ? ['as' => $params[3]]

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -122,6 +122,7 @@ class Auth extends BaseConfig
      * If no match is found, then the next in the chain will be checked.
      *
      * @var string[]
+     *
      * @phpstan-var list<string>
      */
     public array $authenticationChain = [

--- a/src/Entities/Entity.php
+++ b/src/Entities/Entity.php
@@ -16,6 +16,7 @@ abstract class Entity extends FrameworkEntity
      * Custom convert handlers
      *
      * @var array<string, string>
+     *
      * @phpstan-var array<string, class-string>
      */
     protected $castHandlers = [

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -27,7 +27,9 @@ class User extends Entity
 
     /**
      * @var string[]
+     *
      * @phpstan-var list<string>
+     *
      * @psalm-var list<string>
      */
     protected $dates = [

--- a/src/Entities/UserIdentity.php
+++ b/src/Entities/UserIdentity.php
@@ -32,7 +32,9 @@ class UserIdentity extends Entity
 
     /**
      * @var string[]
+     *
      * @phpstan-var list<string>
+     *
      * @psalm-var list<string>
      */
     protected $dates = [

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -98,6 +98,7 @@ class UserModel extends Model
      * @param UserIdentity[] $identities
      *
      * @return User[] UserId => User object
+     *
      * @phpstan-return array<int|string, User> UserId => User object
      */
     private function assignIdentities(array $data, array $identities): array

--- a/src/Result.php
+++ b/src/Result.php
@@ -26,6 +26,7 @@ class Result
 
     /**
      * @phpstan-param array{success: bool, reason?: string|null, extraInfo?: string|User} $details
+     *
      * @psalm-param array{success: bool, reason?: string|null, extraInfo?: string|User} $details
      */
     public function __construct(array $details)


### PR DESCRIPTION
- fix PHPStan error
  ```
  Error: Offset 'except' on array in isset() always exists and is not nullable.
   ------ -------------------------------------------------------------- 
    Line   src/Auth.php                                                  
   ------ -------------------------------------------------------------- 
    109    Offset 'except' on array in isset() always exists and is not  
           nullable.                                                     
   ------ -------------------------------------------------------------- 
  ```
- update coding style

Because of:
  - Upgrading friendsofphp/php-cs-fixer (v3.10.0 => v3.11.0)
  - Upgrading phpstan/phpstan (1.8.2 => 1.8.3)
 