### PR TITLE
ApiToken docs and filter update.

### DIFF
--- a/docs/guides/api-tokens.md
+++ b/docs/guides/api-tokens.md
@@ -1,4 +1,4 @@
-# API Tokens
+# Protecting an API with Access Tokens
 
 Access Tokens can be used to authenticate users for your own site, or when allowing third-party developers to access your API. When making requests using access tokens, the token should be included in the `Authorization` header as a `Bearer` token.
 

--- a/docs/guides/api-tokens.md
+++ b/docs/guides/api-tokens.md
@@ -1,0 +1,88 @@
+# API Tokens
+
+Access Tokens can be used to authenticate users for your own site, or when allowing third-party developers to access your API. When making requests using access tokens, the token should be included in the `Authorization` header as a `Bearer` token.
+
+To issue tokens for users, the `UserModel` must use the `CodeIgniter\Shield\Authentication\Traits\HasAccessTokens` trait. The `UserModel` that ships with Shield already uses this trait.
+
+```php
+use CodeIgniter\Shield\Authentication\Traits\HasAccessTokens
+use CodeIgniter\Model;
+
+class UserModel extneds Model
+{
+    use HasAccessTokens;
+}
+```
+
+Tokens are issued with the `generateAccessToken()` method on the user. This returns a `CodeIgniter\Shield\Entities\AccessToken` instance. Tokens are hashed using a SHA-256 algorithm before being saved to the database. The access token returned when you generate it will include a `raw_token` field that contains the plain-text, un-hashed, token. You should display this to your user at once so they have a chance to copy it somewhere safe, as this is the only time this will be available. After this request, there is no way to get the raw token.
+
+The `generateAccessToken` method requires a name for the token. These are free strings and are often used to identify the user/device the token was generated from, like 'Johns MacBook Air'.
+
+```php
+$routes->get('/access/token', static function() {
+    $token = auth()->user()->generateAccessToken(request()->getVar('token_name));
+
+    return ['token' => $token->raw_token];
+});
+```
+
+You can access all of the users' tokens with the `accessTokens()` method on the user.
+
+```php
+$tokens = $user->accessTokens();
+foreach($tokens as $token) {
+    //
+}
+```
+
+## Token Permissions
+
+Access tokens can be given `scopes`, which are basically permission strings, for the token. This is generally not the same as the permission the user has, but is used to specify the permissions on the API itself. If not specified, the token is granted all access to all scopes. This might be enough for a smaller API.
+
+```php
+return $user->generateAccessToken('token-name', ['users-read'])->raw_token;
+```
+
+NOTE: At this time, scope names should avoid using a colon (:) as this causes issues with the route filters being correctly recognized.
+
+When handling incoming requests you can check if the token has been granted access to the scope with the `tokenCan` method.
+
+```php
+if ($user->tokenCan('users-read')) {
+    //
+}
+```
+
+### Revoking Tokens
+
+Tokens can be revoked by deleting them from the database with the `revokeAccessToken($rawToken)` or `revokeAllAccessTokens()` methods.
+
+```php
+$user->revokeAccessToken($rawToken);
+$user->revokeAllAccessTokens();
+```
+
+## Protecting Routes
+
+The first way to specify which routes are protected is to use the `tokens` controller filter.
+
+For example, to ensure it protects all routes under the `/api` route group, you would use the `$filters` setting on `app/Config/Filters.php`.
+
+```php
+public $filters = [
+    'tokens' => ['before' => ['api/*']],
+];
+```
+
+You can also specify the filter should run on one or more routes within the routes file itself:
+
+```php
+$routes->group('api', ['filter' => 'tokens'], function($routes) {
+    //
+});
+$routes->get('users', 'UserController::list', ['filter' => 'tokens:users-read']);
+```
+
+When the filter runs, it checks the `Authorization` header for a `Bearer` value that has the raw token. It then looks hashes the raw token and looks it up in the database. Once found, it can determine the correct user, which will then be available through an `auth()->user()` call.
+
+Note: Currently only a single scope can be used on a route filter. If multiple scopes are passed in, only the first one is checked.

--- a/docs/guides/api-tokens.md
+++ b/docs/guides/api-tokens.md
@@ -2,18 +2,6 @@
 
 Access Tokens can be used to authenticate users for your own site, or when allowing third-party developers to access your API. When making requests using access tokens, the token should be included in the `Authorization` header as a `Bearer` token.
 
-To issue tokens for users, the `UserModel` must use the `CodeIgniter\Shield\Authentication\Traits\HasAccessTokens` trait. The `UserModel` that ships with Shield already uses this trait.
-
-```php
-use CodeIgniter\Shield\Authentication\Traits\HasAccessTokens
-use CodeIgniter\Model;
-
-class UserModel extneds Model
-{
-    use HasAccessTokens;
-}
-```
-
 Tokens are issued with the `generateAccessToken()` method on the user. This returns a `CodeIgniter\Shield\Entities\AccessToken` instance. Tokens are hashed using a SHA-256 algorithm before being saved to the database. The access token returned when you generate it will include a `raw_token` field that contains the plain-text, un-hashed, token. You should display this to your user at once so they have a chance to copy it somewhere safe, as this is the only time this will be available. After this request, there is no way to get the raw token.
 
 The `generateAccessToken` method requires a name for the token. These are free strings and are often used to identify the user/device the token was generated from, like 'Johns MacBook Air'.
@@ -22,11 +10,11 @@ The `generateAccessToken` method requires a name for the token. These are free s
 $routes->get('/access/token', static function() {
     $token = auth()->user()->generateAccessToken(request()->getVar('token_name));
 
-    return ['token' => $token->raw_token];
+    return json_encode(['token' => $token->raw_token]);
 });
 ```
 
-You can access all of the users' tokens with the `accessTokens()` method on the user.
+You can access all of the user's tokens with the `accessTokens()` method on that user.
 
 ```php
 $tokens = $user->accessTokens();
@@ -83,6 +71,6 @@ $routes->group('api', ['filter' => 'tokens'], function($routes) {
 $routes->get('users', 'UserController::list', ['filter' => 'tokens:users-read']);
 ```
 
-When the filter runs, it checks the `Authorization` header for a `Bearer` value that has the raw token. It then looks hashes the raw token and looks it up in the database. Once found, it can determine the correct user, which will then be available through an `auth()->user()` call.
+When the filter runs, it checks the `Authorization` header for a `Bearer` value that has the raw token. It then hashes the raw token and looks it up in the database. Once found, it can determine the correct user, which will then be available through an `auth()->user()` call.
 
 Note: Currently only a single scope can be used on a route filter. If multiple scopes are passed in, only the first one is checked.

--- a/docs/guides/api-tokens.md
+++ b/docs/guides/api-tokens.md
@@ -8,7 +8,7 @@ The `generateAccessToken()` method requires a name for the token. These are free
 
 ```php
 $routes->get('/access/token', static function() {
-    $token = auth()->user()->generateAccessToken(request()->getVar('token_name));
+    $token = auth()->user()->generateAccessToken(service('request')->getVar('token_name));
 
     return json_encode(['token' => $token->raw_token]);
 });

--- a/docs/guides/api-tokens.md
+++ b/docs/guides/api-tokens.md
@@ -4,7 +4,7 @@ Access Tokens can be used to authenticate users for your own site, or when allow
 
 Tokens are issued with the `generateAccessToken()` method on the user. This returns a `CodeIgniter\Shield\Entities\AccessToken` instance. Tokens are hashed using a SHA-256 algorithm before being saved to the database. The access token returned when you generate it will include a `raw_token` field that contains the plain-text, un-hashed, token. You should display this to your user at once so they have a chance to copy it somewhere safe, as this is the only time this will be available. After this request, there is no way to get the raw token.
 
-The `generateAccessToken` method requires a name for the token. These are free strings and are often used to identify the user/device the token was generated from, like 'Johns MacBook Air'.
+The `generateAccessToken()` method requires a name for the token. These are free strings and are often used to identify the user/device the token was generated from, like 'Johns MacBook Air'.
 
 ```php
 $routes->get('/access/token', static function() {
@@ -31,9 +31,10 @@ Access tokens can be given `scopes`, which are basically permission strings, for
 return $user->generateAccessToken('token-name', ['users-read'])->raw_token;
 ```
 
-NOTE: At this time, scope names should avoid using a colon (:) as this causes issues with the route filters being correctly recognized.
+> **Note**
+> At this time, scope names should avoid using a colon (`:`) as this causes issues with the route filters being correctly recognized.
 
-When handling incoming requests you can check if the token has been granted access to the scope with the `tokenCan` method.
+When handling incoming requests you can check if the token has been granted access to the scope with the `tokenCan()` method.
 
 ```php
 if ($user->tokenCan('users-read')) {
@@ -73,4 +74,5 @@ $routes->get('users', 'UserController::list', ['filter' => 'tokens:users-read'])
 
 When the filter runs, it checks the `Authorization` header for a `Bearer` value that has the raw token. It then hashes the raw token and looks it up in the database. Once found, it can determine the correct user, which will then be available through an `auth()->user()` call.
 
-Note: Currently only a single scope can be used on a route filter. If multiple scopes are passed in, only the first one is checked.
+> **Note**
+> Currently only a single scope can be used on a route filter. If multiple scopes are passed in, only the first one is checked.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,3 @@
+# Shield Guides
+
+These guides provide short tutorials on setting up or using different aspects of Shield.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,3 +1,0 @@
-# Shield Guides
-
-These guides provide short tutorials on setting up or using different aspects of Shield.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,6 @@
 * [Events](events.md)
 * [Testing](testing.md)
 * [Customization](customization.md)
+
+Guides:
+* [Protecting an API with Access Tokens](guides/api-tokens.md)

--- a/src/Filters/TokenAuth.php
+++ b/src/Filters/TokenAuth.php
@@ -48,7 +48,7 @@ class TokenAuth implements FilterInterface
             'token' => $request->getHeaderLine(setting('Auth.authenticatorHeader')['tokens'] ?? 'Authorization'),
         ]);
 
-        if (! $result->isOK()) {
+        if (! $result->isOK() || (! empty($arguments) && $result->extraInfo()->tokenCant($arguments[0]))) {
             return redirect()->to('/login');
         }
 

--- a/tests/Authentication/Filters/AbstractFilterTest.php
+++ b/tests/Authentication/Filters/AbstractFilterTest.php
@@ -61,6 +61,9 @@ abstract class AbstractFilterTest extends TestCase
             echo 'Open';
         });
         $routes->get('login', 'AuthController::login', ['as' => 'login']);
+        $routes->get('protected-user-route', static function (): void {
+            echo 'Protected';
+        }, ['filter' => $this->alias . ':users-read']);
 
         Services::injectMock('routes', $routes);
     }


### PR DESCRIPTION
Added the first of a handful of guides stepping through setup and use Access Tokens to handle various situations. This one covers generic API requests. 

Along the way I discovered that the `TokenAuth` filter didn't support checking against a scope, so I updated the filter to handle a single permission added when used as a route filter.

```php
$routes->get('users', 'UserController::list', ['filter' => 'tokens:users-read']);
```