### PR TITLE
feat: add request info to all emails

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -6,6 +6,7 @@ namespace CodeIgniter\Shield\Authentication\Actions;
 
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Entities\UserIdentity;
@@ -72,11 +73,15 @@ class Email2FA implements ActionInterface
             return redirect()->route('auth-action-show')->with('error', lang('Auth.need2FA'));
         }
 
+        $ipAddress = $request->getIPAddress();
+        $userAgent = (string) $request->getUserAgent();
+        $date      = Time::now()->toLocalizedString('MMM d, yyyy');
+
         // Send the user an email with the code
         $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($user->email);
         $email->setSubject(lang('Auth.email2FASubject'));
-        $email->setMessage(view(setting('Auth.views')['action_email_2fa_email'], ['code' => $identity->secret]));
+        $email->setMessage(view(setting('Auth.views')['action_email_2fa_email'], ['code' => $identity->secret, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));
 
         if ($email->send(false) === false) {
             throw new RuntimeException('Cannot send email for user: ' . $user->email . "\n" . $email->printDebugger(['headers']));

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -75,7 +75,7 @@ class Email2FA implements ActionInterface
 
         $ipAddress = $request->getIPAddress();
         $userAgent = (string) $request->getUserAgent();
-        $date      = Time::now()->toLocalizedString('MMM d, yyyy');
+        $date      = Time::now()->toDateTimeString();
 
         // Send the user an email with the code
         $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -8,6 +8,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
+use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Entities\UserIdentity;
@@ -43,11 +44,18 @@ class EmailActivator implements ActionInterface
 
         $code = $this->createIdentity($user);
 
+        /** @var IncomingRequest $request */
+        $request = service('request');
+
+        $ipAddress = $request->getIPAddress();
+        $userAgent = (string) $request->getUserAgent();
+        $date      = Time::now()->toLocalizedString('MMM d, yyyy');
+
         // Send the email
         $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($userEmail);
         $email->setSubject(lang('Auth.emailActivateSubject'));
-        $email->setMessage(view(setting('Auth.views')['action_email_activate_email'], ['code' => $code]));
+        $email->setMessage(view(setting('Auth.views')['action_email_activate_email'], ['code' => $code, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));
 
         if ($email->send(false) === false) {
             throw new RuntimeException('Cannot send email for user: ' . $user->email . "\n" . $email->printDebugger(['headers']));

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -49,7 +49,7 @@ class EmailActivator implements ActionInterface
 
         $ipAddress = $request->getIPAddress();
         $userAgent = (string) $request->getUserAgent();
-        $date      = Time::now()->toLocalizedString('MMM d, yyyy');
+        $date      = Time::now()->toDateTimeString();
 
         // Send the email
         $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');

--- a/src/Language/de/Auth.php
+++ b/src/Language/de/Auth.php
@@ -65,7 +65,7 @@ return [
     'resetTokenExpired'         => 'Tut mir leid. Ihr Reset-Token ist abgelaufen.',
 
     // Email Globals
-    'emailInfo'      => 'Einige Informationen über die Person, die nach dem Code gefragt hat:',
+    'emailInfo'      => 'Einige Informationen über die Person:',
     'emailIpAddress' => 'IP Adresse:',
     'emailDevice'    => 'Gerät:',
     'emailDate'      => 'Datum:',

--- a/src/Language/de/Auth.php
+++ b/src/Language/de/Auth.php
@@ -64,6 +64,12 @@ return [
     'userDoesNotExist'          => 'Passwort wurde nicht geändert. Der Benutzer existiert nicht',
     'resetTokenExpired'         => 'Tut mir leid. Ihr Reset-Token ist abgelaufen.',
 
+    // Email Globals
+    'emailInfo'      => 'Einige Informationen über die Person, die nach dem Code gefragt hat:',
+    'emailIpAddress' => 'IP Adresse:',
+    'emailDevice'    => 'Gerät:',
+    'emailDate'      => 'Datum:',
+
     // 2FA
     'email2FATitle'       => 'Zwei-Faktor-Authentifizierung',
     'confirmEmailAddress' => 'Bestätigen Sie Ihre E-Mail-Adresse.',

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -65,7 +65,7 @@ return [
     'resetTokenExpired'         => 'Sorry. Your reset token has expired.',
 
     // Email Globals
-    'emailInfo'      => 'Some information about the person who asked for the code:',
+    'emailInfo'      => 'Some information about the person:',
     'emailIpAddress' => 'IP Address:',
     'emailDevice'    => 'Device:',
     'emailDate'      => 'Date:',

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -64,6 +64,12 @@ return [
     'userDoesNotExist'          => 'Password was not changed. User does not exist',
     'resetTokenExpired'         => 'Sorry. Your reset token has expired.',
 
+    // Email Globals
+    'emailInfo'      => 'Some information about the person who asked for the code:',
+    'emailIpAddress' => 'IP Address:',
+    'emailDevice'    => 'Device:',
+    'emailDate'      => 'Date:',
+
     // 2FA
     'email2FATitle'       => 'Two Factor Authentication',
     'confirmEmailAddress' => 'Confirm your email address.',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -65,7 +65,7 @@ return [
     'resetTokenExpired'         => 'Lo sentimos. Tu token de reseteo ha caducado.',
 
     // Email Globals
-    'emailInfo'      => 'Algunos datos sobre la persona que pidió el código:',
+    'emailInfo'      => 'Algunos datos sobre la persona:',
     'emailIpAddress' => 'Dirección IP:',
     'emailDevice'    => 'Dispositivo:',
     'emailDate'      => 'Fecha:',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -64,6 +64,12 @@ return [
     'userDoesNotExist'          => 'No se ha cambiado la contraseña. No existe el usuario',
     'resetTokenExpired'         => 'Lo sentimos. Tu token de reseteo ha caducado.',
 
+    // Email Globals
+    'emailInfo'      => 'Algunos datos sobre la persona que pidió el código:',
+    'emailIpAddress' => 'Dirección IP:',
+    'emailDevice'    => 'Dispositivo:',
+    'emailDate'      => 'Fecha:',
+
     // 2FA
     'email2FATitle'       => 'Authenticación de Doble Factor',
     'confirmEmailAddress' => 'Confirma tu dirección de email.',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -76,7 +76,7 @@ return [
     // Email Globals
     'emailInfo'      => 'برخی از اطلاعات درخواست کننده کد:',
     'emailIpAddress' => 'آدرس ای پی:',
-    'emailDevice'    => '(To be translated) Device:',
+    'emailDevice'    => 'دستگاه:',
     'emailDate'      => '(To be translated) Date:',
 
     // 2FA

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -74,7 +74,7 @@ return [
     'resetTokenExpired'         => 'متاسفانه، توکن بازنشانی شما منقضی شده است.',
 
     // Email Globals
-    'emailInfo'      => '(To be translated) Some information about the person who asked for the code:',
+    'emailInfo'      => 'برخی از اطلاعات درخواست کننده کد:',
     'emailIpAddress' => '(To be translated) IP Address:',
     'emailDevice'    => '(To be translated) Device:',
     'emailDate'      => '(To be translated) Date:',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -73,6 +73,12 @@ return [
     'userDoesNotExist'          => 'رمز عبور تغییر نکرد. کاربر وجود ندارد.',
     'resetTokenExpired'         => 'متاسفانه، توکن بازنشانی شما منقضی شده است.',
 
+    // Email Globals
+    'emailInfo'      => 'Some information about the person who asked for the code:',
+    'emailIpAddress' => 'IP Address:',
+    'emailDevice'    => 'Device:',
+    'emailDate'      => 'Date:',
+
     // 2FA
     'email2FATitle'       => 'احراز هویت دو عاملی',
     'confirmEmailAddress' => 'آدرس ایمیل خود را تایید کنید.',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -74,7 +74,7 @@ return [
     'resetTokenExpired'         => 'متاسفانه، توکن بازنشانی شما منقضی شده است.',
 
     // Email Globals
-    'emailInfo'      => 'برخی از اطلاعات درخواست کننده کد:',
+    'emailInfo'      => 'برخی از اطلاعات درخواست کننده:',
     'emailIpAddress' => 'آدرس ای پی:',
     'emailDevice'    => 'دستگاه:',
     'emailDate'      => 'زمان:',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -77,7 +77,7 @@ return [
     'emailInfo'      => 'برخی از اطلاعات درخواست کننده کد:',
     'emailIpAddress' => 'آدرس ای پی:',
     'emailDevice'    => 'دستگاه:',
-    'emailDate'      => '(To be translated) Date:',
+    'emailDate'      => 'زمان:',
 
     // 2FA
     'email2FATitle'       => 'احراز هویت دو عاملی',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -74,10 +74,10 @@ return [
     'resetTokenExpired'         => 'متاسفانه، توکن بازنشانی شما منقضی شده است.',
 
     // Email Globals
-    'emailInfo'      => 'Some information about the person who asked for the code:',
-    'emailIpAddress' => 'IP Address:',
-    'emailDevice'    => 'Device:',
-    'emailDate'      => 'Date:',
+    'emailInfo'      => '(To be translated) Some information about the person who asked for the code:',
+    'emailIpAddress' => '(To be translated) IP Address:',
+    'emailDevice'    => '(To be translated) Device:',
+    'emailDate'      => '(To be translated) Date:',
 
     // 2FA
     'email2FATitle'       => 'احراز هویت دو عاملی',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -75,7 +75,7 @@ return [
 
     // Email Globals
     'emailInfo'      => 'برخی از اطلاعات درخواست کننده کد:',
-    'emailIpAddress' => '(To be translated) IP Address:',
+    'emailIpAddress' => 'آدرس ای پی:',
     'emailDevice'    => '(To be translated) Device:',
     'emailDate'      => '(To be translated) Date:',
 

--- a/src/Language/fr/Auth.php
+++ b/src/Language/fr/Auth.php
@@ -64,6 +64,12 @@ return [
     'userDoesNotExist'          => 'Le mot de passe n\'a pas été modifié. L\'utilisateur n\'existe pas',
     'resetTokenExpired'         => 'Désolé. Votre jeton de réinitialisation a expiré.',
 
+    // Email Globals
+    'emailInfo'      => 'Quelques informations sur la personne qui a demandé le code:',
+    'emailIpAddress' => 'Adresse IP:',
+    'emailDevice'    => 'Dispositif',
+    'emailDate'      => 'Date:',
+
     // 2FA
     'email2FATitle'       => 'Authentification à deux facteurs',
     'confirmEmailAddress' => 'Confirmer votre adresse email.',

--- a/src/Language/fr/Auth.php
+++ b/src/Language/fr/Auth.php
@@ -67,7 +67,7 @@ return [
     // Email Globals
     'emailInfo'      => 'Quelques informations sur la personne qui a demandé le code:',
     'emailIpAddress' => 'Adresse IP:',
-    'emailDevice'    => 'Dispositif',
+    'emailDevice'    => 'Dispositif:',
     'emailDate'      => 'Jour:',
 
     // 2FA

--- a/src/Language/fr/Auth.php
+++ b/src/Language/fr/Auth.php
@@ -68,7 +68,7 @@ return [
     'emailInfo'      => 'Quelques informations sur la personne qui a demandé le code:',
     'emailIpAddress' => 'Adresse IP:',
     'emailDevice'    => 'Dispositif',
-    'emailDate'      => 'Date:',
+    'emailDate'      => 'Jour:',
 
     // 2FA
     'email2FATitle'       => 'Authentification à deux facteurs',

--- a/src/Language/fr/Auth.php
+++ b/src/Language/fr/Auth.php
@@ -65,7 +65,7 @@ return [
     'resetTokenExpired'         => 'Désolé. Votre jeton de réinitialisation a expiré.',
 
     // Email Globals
-    'emailInfo'      => 'Quelques informations sur la personne qui a demandé le code:',
+    'emailInfo'      => 'Quelques informations sur la personne:',
     'emailIpAddress' => 'Adresse IP:',
     'emailDevice'    => 'Dispositif:',
     'emailDate'      => 'Jour:',

--- a/src/Language/id/Auth.php
+++ b/src/Language/id/Auth.php
@@ -65,10 +65,10 @@ return [
     'resetTokenExpired'         => 'Maaf, token setel ulang Anda sudah habis waktu.',
 
     // Email Globals
-    'emailInfo'      => 'Some information about the person who asked for the code:',
-    'emailIpAddress' => 'IP Address:',
-    'emailDevice'    => 'Device:',
-    'emailDate'      => 'Date:',
+    'emailInfo'      => '(To be translated) Some information about the person who asked for the code:',
+    'emailIpAddress' => '(To be translated) IP Address:',
+    'emailDevice'    => '(To be translated) Device:',
+    'emailDate'      => '(To be translated) Date:',
 
     // 2FA
     'email2FATitle'       => 'Otentikasi Dua Faktor',

--- a/src/Language/id/Auth.php
+++ b/src/Language/id/Auth.php
@@ -64,6 +64,12 @@ return [
     'userDoesNotExist'          => 'Kata sandi tidak diubah. User tidak ditemukan',
     'resetTokenExpired'         => 'Maaf, token setel ulang Anda sudah habis waktu.',
 
+    // Email Globals
+    'emailInfo'      => 'Some information about the person who asked for the code:',
+    'emailIpAddress' => 'IP Address:',
+    'emailDevice'    => 'Device:',
+    'emailDate'      => 'Date:',
+
     // 2FA
     'email2FATitle'       => 'Otentikasi Dua Faktor',
     'confirmEmailAddress' => 'Alamat email konfirmasi Anda.',

--- a/src/Language/id/Auth.php
+++ b/src/Language/id/Auth.php
@@ -65,10 +65,10 @@ return [
     'resetTokenExpired'         => 'Maaf, token setel ulang Anda sudah habis waktu.',
 
     // Email Globals
-    'emailInfo'      => '(To be translated) Some information about the person who asked for the code:',
-    'emailIpAddress' => '(To be translated) IP Address:',
-    'emailDevice'    => '(To be translated) Device:',
-    'emailDate'      => '(To be translated) Date:',
+    'emailInfo'      => 'Beberapa informasi tentang seseorang yang meminta kode:',
+    'emailIpAddress' => 'Alamat IP:',
+    'emailDevice'    => 'Perangkat:',
+    'emailDate'      => 'Tanggal:',
 
     // 2FA
     'email2FATitle'       => 'Otentikasi Dua Faktor',

--- a/src/Language/id/Auth.php
+++ b/src/Language/id/Auth.php
@@ -65,7 +65,7 @@ return [
     'resetTokenExpired'         => 'Maaf, token setel ulang Anda sudah habis waktu.',
 
     // Email Globals
-    'emailInfo'      => 'Beberapa informasi tentang seseorang yang meminta kode:',
+    'emailInfo'      => 'Beberapa informasi tentang seseorang:',
     'emailIpAddress' => 'Alamat IP:',
     'emailDevice'    => 'Perangkat:',
     'emailDate'      => 'Tanggal:',

--- a/src/Language/ja/Auth.php
+++ b/src/Language/ja/Auth.php
@@ -65,10 +65,10 @@ return [
     'resetTokenExpired'         => '申し訳ありません。リセットトークンの有効期限が切れました。', // 'Sorry. Your reset token has expired.',
 
     // Email Globals
-    'emailInfo'      => 'Some information about the person who asked for the code:',
-    'emailIpAddress' => 'IP Address:',
-    'emailDevice'    => 'Device:',
-    'emailDate'      => 'Date:',
+    'emailInfo'      => 'コードを要求した人に関する情報:',
+    'emailIpAddress' => 'IPアドレス:',
+    'emailDevice'    => 'デバイス:',
+    'emailDate'      => '日時:',
 
     // 2FA
     'email2FATitle'       => '二要素認証', // 'Two Factor Authentication',

--- a/src/Language/ja/Auth.php
+++ b/src/Language/ja/Auth.php
@@ -64,6 +64,12 @@ return [
     'userDoesNotExist'          => 'パスワードは変更されていません。ユーザーは存在しません', // 'Password was not changed. User does not exist',
     'resetTokenExpired'         => '申し訳ありません。リセットトークンの有効期限が切れました。', // 'Sorry. Your reset token has expired.',
 
+    // Email Globals
+    'emailInfo'      => 'Some information about the person who asked for the code:',
+    'emailIpAddress' => 'IP Address:',
+    'emailDevice'    => 'Device:',
+    'emailDate'      => 'Date:',
+
     // 2FA
     'email2FATitle'       => '二要素認証', // 'Two Factor Authentication',
     'confirmEmailAddress' => 'メールアドレスを確認してください。', // 'Confirm your email address.',

--- a/src/Language/ja/Auth.php
+++ b/src/Language/ja/Auth.php
@@ -65,7 +65,7 @@ return [
     'resetTokenExpired'         => '申し訳ありません。リセットトークンの有効期限が切れました。', // 'Sorry. Your reset token has expired.',
 
     // Email Globals
-    'emailInfo'      => 'コードを要求した人に関する情報:',
+    'emailInfo'      => '本人に関する情報:',
     'emailIpAddress' => 'IPアドレス:',
     'emailDevice'    => 'デバイス:',
     'emailDate'      => '日時:',

--- a/src/Language/sk/Auth.php
+++ b/src/Language/sk/Auth.php
@@ -64,6 +64,12 @@ return [
     'userDoesNotExist'          => 'Heslo nebolo zmenené. Používateľ neexistuje',
     'resetTokenExpired'         => 'Prepáčte. Platnosť vášho resetovacieho tokenu vypršala.',
 
+    // Email Globals
+    'emailInfo'      => 'Niektoré informácie o osobe, ktorá požiadala o kód:',
+    'emailIpAddress' => 'IP Adresa:',
+    'emailDevice'    => 'Zariadenie:',
+    'emailDate'      => 'Dátum:',
+
     // 2FA
     'email2FATitle'       => 'Dvojfaktorová autentifikácia',
     'confirmEmailAddress' => 'Potvrďte svoju e-mailovú adresu.',

--- a/src/Language/sk/Auth.php
+++ b/src/Language/sk/Auth.php
@@ -65,7 +65,7 @@ return [
     'resetTokenExpired'         => 'Prepáčte. Platnosť vášho resetovacieho tokenu vypršala.',
 
     // Email Globals
-    'emailInfo'      => 'Niektoré informácie o osobe, ktorá požiadala o kód:',
+    'emailInfo'      => 'Niektoré informácie o osobe:',
     'emailIpAddress' => 'IP Adresa:',
     'emailDevice'    => 'Zariadenie:',
     'emailDate'      => 'Dátum:',

--- a/src/Views/Email/email_2fa_email.php
+++ b/src/Views/Email/email_2fa_email.php
@@ -10,7 +10,7 @@
 <body>
     <p><?= lang('Auth.email2FAMailBody') ?></p>
     <div style="text-align: center"><h1><?= $code ?></h1></div>
-    <b><?= lang('Auth.emaiInfo') ?></b>
+    <b><?= lang('Auth.emailInfo') ?></b>
     <p><?= lang('Auth.emailIpAddress') ?> <?= $ipAddress ?></p>
     <p><?= lang('Auth.emailDevice') ?> <?= $userAgent ?></p>
     <p><?= lang('Auth.emailDate') ?> <?= $date ?></p>

--- a/src/Views/Email/email_2fa_email.php
+++ b/src/Views/Email/email_2fa_email.php
@@ -1,19 +1,31 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title><?= lang('Auth.email2FASubject') ?></title>
 </head>
 
 <body>
     <p><?= lang('Auth.email2FAMailBody') ?></p>
-    <div style="text-align: center"><h1><?= $code ?></h1></div>
+    <div style="text-align: center">
+        <h1><?= $code ?></h1>
+    </div>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+        <tbody>
+            <tr>
+                <td style="line-height: 20px; font-size: 20px; width: 100%; height: 20px; margin: 0;" align="left" width="100%" height="20">
+                    &#160;
+                </td>
+            </tr>
+        </tbody>
+    </table>
     <b><?= lang('Auth.emailInfo') ?></b>
-    <p><?= lang('Auth.emailIpAddress') ?> <?= $ipAddress ?></p>
-    <p><?= lang('Auth.emailDevice') ?> <?= $userAgent ?></p>
-    <p><?= lang('Auth.emailDate') ?> <?= $date ?></p>
+    <p><?= lang('Auth.emailIpAddress') ?> <?= esc($ipAddress) ?></p>
+    <p><?= lang('Auth.emailDevice') ?> <?= esc($userAgent) ?></p>
+    <p><?= lang('Auth.emailDate') ?> <?= esc($date) ?></p>
 </body>
 
 </html>

--- a/src/Views/Email/email_2fa_email.php
+++ b/src/Views/Email/email_2fa_email.php
@@ -1,1 +1,19 @@
-<p><?= lang('Auth.email2FAMailBody') ?> <b><?= $code ?></b></p>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><?= lang('Auth.email2FASubject') ?></title>
+</head>
+
+<body>
+    <p><?= lang('Auth.email2FAMailBody') ?></p>
+    <div style="text-align: center"><h1><?= $code ?></h1></div>
+    <b><?= lang('Auth.emaiInfo') ?></b>
+    <p><?= lang('Auth.emailIpAddress') ?> <?= $ipAddress ?></p>
+    <p><?= lang('Auth.emailDevice') ?> <?= $userAgent ?></p>
+    <p><?= lang('Auth.emailDate') ?> <?= $date ?></p>
+</body>
+
+</html>

--- a/src/Views/Email/email_activate_email.php
+++ b/src/Views/Email/email_activate_email.php
@@ -1,19 +1,31 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title><?= lang('Auth.emailActivateSubject') ?></title>
 </head>
 
 <body>
     <p><?= lang('Auth.emailActivateMailBody') ?></p>
-    <div style="text-align: center"><h1><?= $code ?></h1></div>
+    <div style="text-align: center">
+        <h1><?= $code ?></h1>
+    </div>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+        <tbody>
+            <tr>
+                <td style="line-height: 20px; font-size: 20px; width: 100%; height: 20px; margin: 0;" align="left" width="100%" height="20">
+                    &#160;
+                </td>
+            </tr>
+        </tbody>
+    </table>
     <b><?= lang('Auth.emailInfo') ?></b>
-    <p><?= lang('Auth.emailIpAddress') ?> <?= $ipAddress ?></p>
-    <p><?= lang('Auth.emailDevice') ?> <?= $userAgent ?></p>
-    <p><?= lang('Auth.emailDate') ?> <?= $date ?></p>
+    <p><?= lang('Auth.emailIpAddress') ?> <?= esc($ipAddress) ?></p>
+    <p><?= lang('Auth.emailDevice') ?> <?= esc($userAgent) ?></p>
+    <p><?= lang('Auth.emailDate') ?> <?= esc($date) ?></p>
 </body>
 
 </html>

--- a/src/Views/Email/email_activate_email.php
+++ b/src/Views/Email/email_activate_email.php
@@ -1,3 +1,19 @@
-<p><?= lang('Auth.emailActivateMailBody') ?></p>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
 
-<p><?= $code ?></p>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><?= lang('Auth.emailActivateSubject') ?></title>
+</head>
+
+<body>
+    <p><?= lang('Auth.emailActivateMailBody') ?></p>
+    <div style="text-align: center"><h1><?= $code ?></h1></div>
+    <b><?= lang('Auth.emailInfo') ?></b>
+    <p><?= lang('Auth.emailIpAddress') ?> <?= $ipAddress ?></p>
+    <p><?= lang('Auth.emailDevice') ?> <?= $userAgent ?></p>
+    <p><?= lang('Auth.emailDate') ?> <?= $date ?></p>
+</body>
+
+</html>

--- a/src/Views/Email/magic_link_email.php
+++ b/src/Views/Email/magic_link_email.php
@@ -1,5 +1,36 @@
-<p>
-    <a href="<?= url_to('verify-magic-link') ?>?token=<?= $token ?>">
-        <?= lang('Auth.login') ?>
-    </a>
-</p>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<head>
+    <meta name="x-apple-disable-message-reformatting">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title><?= lang('Auth.magicLinkSubject') ?></title>
+</head>
+
+<body>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-radius: 6px; border-collapse: separate !important;">
+        <tbody>
+            <tr>
+                <td style="line-height: 24px; font-size: 16px; border-radius: 6px; margin: 0;" align="center" bgcolor="#0d6efd">
+                    <a href="<?= url_to('verify-magic-link') ?>?token=<?= $token ?>" style="color: #ffffff; font-size: 16px; font-family: Helvetica, Arial, sans-serif; text-decoration: none; border-radius: 6px; line-height: 20px; display: inline-block; font-weight: normal; white-space: nowrap; background-color: #0d6efd; padding: 8px 12px; border: 1px solid #0d6efd;"><?= lang('Auth.login') ?></a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="width: 100%;" width="100%">
+        <tbody>
+            <tr>
+                <td style="line-height: 20px; font-size: 20px; width: 100%; height: 20px; margin: 0;" align="left" width="100%" height="20">
+                    &#160;
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <b><?= lang('Auth.emailInfo') ?></b>
+    <p><?= lang('Auth.emailIpAddress') ?> <?= esc($ipAddress) ?></p>
+    <p><?= lang('Auth.emailDevice') ?> <?= esc($userAgent) ?></p>
+    <p><?= lang('Auth.emailDate') ?> <?= esc($date) ?></p>
+</body>
+
+</html>

--- a/tests/Controllers/ActionsTest.php
+++ b/tests/Controllers/ActionsTest.php
@@ -236,7 +236,7 @@ final class ActionsTest extends TestCase
             service('email')->archive['body']
         );
         $this->assertMatchesRegularExpression(
-            '!<p>[0-9]{6}</p>!',
+            '!<h1>[0-9]{6}</h1>!',
             service('email')->archive['body']
         );
     }


### PR DESCRIPTION
It is common practice to include in email verification emails some user request info like `IP Address`, `User Agent Device` & `Date` when a user is asked for some code. This PR adds this information.

I also improved default email templates to improve readability of the `code`.  

@lonnieezell  @kenjis  @MGatner I don't know if we want to provide more complex Email templates, or if basic HTML is fine for the start of using this library and leave it completely to the developer.

Language files are not completed, some translated with Google Translator. 

Please help with translations. 

Here is what it looks like now in the Email client.

![CleanShot 2022-09-10 at 12 45 43@2x](https://user-images.githubusercontent.com/36922215/189479886-e08b861a-a72e-472c-aba8-b5b3f22ee691.png)


