### PR TITLE
docs: Missing apostrophe

### DIFF
--- a/docs/guides/api-tokens.md
+++ b/docs/guides/api-tokens.md
@@ -8,7 +8,7 @@ The `generateAccessToken()` method requires a name for the token. These are free
 
 ```php
 $routes->get('/access/token', static function() {
-    $token = auth()->user()->generateAccessToken(service('request')->getVar('token_name));
+    $token = auth()->user()->generateAccessToken(service('request')->getVar('token_name'));
 
     return json_encode(['token' => $token->raw_token]);
 });


### PR DESCRIPTION
Missing apostrophe in getVar() method parameter

```php
$routes->get('/access/token', static function() {
    $token = auth()->user()->generateAccessToken(service('request')->getVar('token_name));

    return json_encode(['token' => $token->raw_token]);
});
```