### PR TITLE
fix: secret is `sha256` so not need convert `sha256`

### DIFF
--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -146,7 +146,7 @@ class UserIdentityModel extends Model
     {
         return $this
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
-            ->where('secret', hash('sha256', $rawToken))
+            ->where('secret', $rawToken)
             ->asObject(AccessToken::class)
             ->first();
     }


### PR DESCRIPTION
I'm not sure yet what effect it will have, but what is clear is that we need to make changes here.
see : 
https://github.com/codeigniter4/shield/blob/55f92fe1b3fc3768ad8a5790340321500476524e/src/Models/UserIdentityModel.php#L121-L131

https://github.com/codeigniter4/shield/blob/55f92fe1b3fc3768ad8a5790340321500476524e/src/Models/UserIdentityModel.php#L145-L161

**AFTER:**
```console
Data of Table "test__auth_token_logins":

+-----+------------+--------------------+--------------+--------------------+---------+--------------------+---------+
| id  | ip_address | user_agent         | id_type      | identifier         | user_id | date               | success |
+-----+------------+--------------------+--------------+--------------------+---------+--------------------+---------+
| 853 | ::1        | PostmanRuntime/... | access_token | Bearer 46e16bec... | 1       | 2022-09-18 16:0... | 1       |
| 854 | ::1        | PostmanRuntime/... | access_token | Bearer 46e16bec... | 1       | 2022-09-18 16:0... | 1       |
+-----+------------+--------------------+--------------+--------------------+---------+--------------------+---------+
```