### PR TITLE
fix: bug that when UserIdentity is changed, the correct user identities are not returned afterwards

### DIFF
--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -121,6 +121,9 @@ class User extends Entity
         $identityModel = model(UserIdentityModel::class);
 
         $identityModel->createEmailIdentity($this, $credentials);
+
+        // Ensure we will reload all identities
+        $this->identities = null;
     }
 
     /**

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -154,6 +154,7 @@ class User extends Entity
                 'email'    => $this->email,
                 'password' => '',
             ]);
+
             $identity = $this->getEmailIdentity();
         }
 

--- a/src/Entities/UserIdentity.php
+++ b/src/Entities/UserIdentity.php
@@ -21,7 +21,9 @@ use CodeIgniter\Shield\Authentication\Passwords;
  * though a Authenticator may want to enforce only one exists for that
  * user, like a password.
  *
- * @property Time|null $last_used_at
+ * @property Time|null   $last_used_at
+ * @property string|null $secret
+ * @property string|null $secret2
  */
 class UserIdentity extends Entity
 {

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -12,6 +12,7 @@ use CodeIgniter\Shield\Authentication\Passwords;
 use CodeIgniter\Shield\Entities\AccessToken;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Entities\UserIdentity;
+use CodeIgniter\Shield\Exceptions\LogicException;
 use Faker\Generator;
 
 class UserIdentityModel extends Model
@@ -59,7 +60,7 @@ class UserIdentityModel extends Model
      */
     public function createEmailIdentity(User $user, array $credentials): void
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         /** @var Passwords $passwords */
         $passwords = service('passwords');
@@ -72,6 +73,15 @@ class UserIdentityModel extends Model
         ]);
 
         $this->checkQueryReturn($return);
+    }
+
+    private function checkUserId(User $user): void
+    {
+        if ($user->id === null) {
+            throw new LogicException(
+                '"$user->id" is null. You should not use the incomplete User object.'
+            );
+        }
     }
 
     /**
@@ -87,7 +97,7 @@ class UserIdentityModel extends Model
         array $data,
         callable $codeGenerator
     ): string {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         helper('text');
 
@@ -122,7 +132,7 @@ class UserIdentityModel extends Model
      */
     public function generateAccessToken(User $user, string $name, array $scopes = ['*']): AccessToken
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         helper('text');
 
@@ -157,7 +167,7 @@ class UserIdentityModel extends Model
 
     public function getAccessToken(User $user, string $rawToken): ?AccessToken
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         return $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
@@ -173,7 +183,7 @@ class UserIdentityModel extends Model
      */
     public function getAccessTokenById($id, User $user): ?AccessToken
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         return $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
@@ -187,7 +197,7 @@ class UserIdentityModel extends Model
      */
     public function getAllAccessTokens(User $user): array
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         return $this
             ->where('user_id', $user->id)
@@ -218,7 +228,7 @@ class UserIdentityModel extends Model
      */
     public function getIdentities(User $user): array
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         return $this->where('user_id', $user->id)->orderBy($this->primaryKey)->findAll();
     }
@@ -238,7 +248,7 @@ class UserIdentityModel extends Model
      */
     public function getIdentityByType(User $user, string $type): ?UserIdentity
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         return $this->where('user_id', $user->id)
             ->where('type', $type)
@@ -255,7 +265,7 @@ class UserIdentityModel extends Model
      */
     public function getIdentitiesByTypes(User $user, array $types): array
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         if ($types === []) {
             return [];
@@ -281,7 +291,7 @@ class UserIdentityModel extends Model
 
     public function deleteIdentitiesByType(User $user, string $type): void
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         $return = $this->where('user_id', $user->id)
             ->where('type', $type)
@@ -295,7 +305,7 @@ class UserIdentityModel extends Model
      */
     public function revokeAccessToken(User $user, string $rawToken): void
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         $return = $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
@@ -310,7 +320,7 @@ class UserIdentityModel extends Model
      */
     public function revokeAllAccessTokens(User $user): void
     {
-        assert($user->id !== null, '"$user->id" must not be null.');
+        $this->checkUserId($user);
 
         $return = $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -59,6 +59,8 @@ class UserIdentityModel extends Model
      */
     public function createEmailIdentity(User $user, array $credentials): void
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         /** @var Passwords $passwords */
         $passwords = service('passwords');
 
@@ -85,7 +87,7 @@ class UserIdentityModel extends Model
         array $data,
         callable $codeGenerator
     ): string {
-        assert($user->id !== null);
+        assert($user->id !== null, '"$user->id" must not be null.');
 
         helper('text');
 
@@ -120,6 +122,8 @@ class UserIdentityModel extends Model
      */
     public function generateAccessToken(User $user, string $name, array $scopes = ['*']): AccessToken
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         helper('text');
 
         $return = $this->insert([
@@ -153,6 +157,8 @@ class UserIdentityModel extends Model
 
     public function getAccessToken(User $user, string $rawToken): ?AccessToken
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         return $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->where('secret', hash('sha256', $rawToken))
@@ -167,6 +173,8 @@ class UserIdentityModel extends Model
      */
     public function getAccessTokenById($id, User $user): ?AccessToken
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         return $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->where('id', $id)
@@ -179,6 +187,8 @@ class UserIdentityModel extends Model
      */
     public function getAllAccessTokens(User $user): array
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         return $this
             ->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
@@ -208,6 +218,8 @@ class UserIdentityModel extends Model
      */
     public function getIdentities(User $user): array
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         return $this->where('user_id', $user->id)->orderBy($this->primaryKey)->findAll();
     }
 
@@ -226,6 +238,8 @@ class UserIdentityModel extends Model
      */
     public function getIdentityByType(User $user, string $type): ?UserIdentity
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         return $this->where('user_id', $user->id)
             ->where('type', $type)
             ->orderBy($this->primaryKey)
@@ -241,6 +255,8 @@ class UserIdentityModel extends Model
      */
     public function getIdentitiesByTypes(User $user, array $types): array
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         if ($types === []) {
             return [];
         }
@@ -265,6 +281,8 @@ class UserIdentityModel extends Model
 
     public function deleteIdentitiesByType(User $user, string $type): void
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         $return = $this->where('user_id', $user->id)
             ->where('type', $type)
             ->delete();
@@ -277,6 +295,8 @@ class UserIdentityModel extends Model
      */
     public function revokeAccessToken(User $user, string $rawToken): void
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         $return = $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->where('secret', hash('sha256', $rawToken))
@@ -290,6 +310,8 @@ class UserIdentityModel extends Model
      */
     public function revokeAllAccessTokens(User $user): void
     {
+        assert($user->id !== null, '"$user->id" must not be null.');
+
         $return = $this->where('user_id', $user->id)
             ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
             ->delete();

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -232,11 +232,6 @@ class UserModel extends Model
 
         $this->checkQueryReturn($result);
 
-        // Set user id to the passed User object.
-        if ($data instanceof User) {
-            $data->id = $this->insertID;
-        }
-
         return $returnID ? $this->insertID : $result;
     }
 

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -225,11 +225,17 @@ class UserModel extends Model
      */
     public function insert($data = null, bool $returnID = true)
     {
-        $this->tempUser = $data instanceof User ? $data : null;
+        // Clone User object for not changing the passed object.
+        $this->tempUser = $data instanceof User ? clone $data : null;
 
         $result = parent::insert($data, $returnID);
 
         $this->checkQueryReturn($result);
+
+        // Set user id to the passed User object.
+        if ($data instanceof User) {
+            $data->id = $this->insertID;
+        }
 
         return $returnID ? $this->insertID : $result;
     }
@@ -245,7 +251,8 @@ class UserModel extends Model
      */
     public function update($id = null, $data = null): bool
     {
-        $this->tempUser = $data instanceof User ? $data : null;
+        // Clone User object for not changing the passed object.
+        $this->tempUser = $data instanceof User ? clone $data : null;
 
         try {
             /** @throws DataException */

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -303,6 +303,9 @@ class UserModel extends Model
             /** @var User $user */
             $user = $this->find($this->db->insertID());
 
+            // If you get identity (email/password), the User object must have the id.
+            $this->tempUser->id = $user->id;
+
             $user->email         = $this->tempUser->email ?? '';
             $user->password      = $this->tempUser->password ?? '';
             $user->password_hash = $this->tempUser->password_hash ?? '';

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Tests\Support\TestCase;
@@ -67,14 +68,15 @@ final class UserModelTest extends TestCase
      */
     public function testSaveNewUserAndGetEmailIdentity(): void
     {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('"$user->id" is null. You should not use the incomplete User object.');
+
         $users = $this->createUserModel();
         $user  = $this->createNewUser();
 
         $users->save($user);
 
-        $identity = $user->getEmailIdentity();
-
-        $this->assertSame('foo@bar.com', $identity->secret);
+        $user->getEmailIdentity();
     }
 
     /**

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -63,6 +63,21 @@ final class UserModelTest extends TestCase
     }
 
     /**
+     * @see https://github.com/codeigniter4/shield/issues/450
+     */
+    public function testSaveNewUserAndGetEmailIdentity(): void
+    {
+        $users = $this->createUserModel();
+        $user  = $this->createNewUser();
+
+        $users->save($user);
+
+        $identity = $user->getEmailIdentity();
+
+        $this->assertSame('foo@bar.com', $identity->secret);
+    }
+
+    /**
      * This test is not correct.
      *
      * Entity's `toArray()` method returns array with properties and values.

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -216,4 +216,18 @@ final class UserTest extends TestCase
             'secret2' => $hash,
         ]);
     }
+
+    public function testCreateEmailIdentity(): void
+    {
+        $identity = $this->user->getEmailIdentity();
+        $this->assertNull($identity);
+
+        $this->user->createEmailIdentity([
+            'email'    => 'foo@example.com',
+            'password' => 'passbar',
+        ]);
+
+        $identity = $this->user->getEmailIdentity();
+        $this->assertSame('foo@example.com', $identity->secret);
+    }
 }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -55,7 +55,7 @@ final class UserTest extends TestCase
         $this->assertEmpty($this->user->getIdentities('foo'));
     }
 
-    public function testModelfindAllWithIdentities(): void
+    public function testModelFindAllWithIdentities(): void
     {
         fake(UserModel::class);
         fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'password']);
@@ -69,7 +69,7 @@ final class UserTest extends TestCase
         $this->assertCount(2, $identities);
     }
 
-    public function testModelfindByIdWithIdentities(): void
+    public function testModelFindByIdWithIdentities(): void
     {
         fake(UserModel::class);
         fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'password']);

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -230,4 +230,16 @@ final class UserTest extends TestCase
         $identity = $this->user->getEmailIdentity();
         $this->assertSame('foo@example.com', $identity->secret);
     }
+
+    public function testSaveEmailIdentity(): void
+    {
+        $hash                      = service('passwords')->hash('passbar');
+        $this->user->email         = 'foo@example.com';
+        $this->user->password_hash = $hash;
+
+        $this->user->saveEmailIdentity();
+
+        $identity = $this->user->getEmailIdentity();
+        $this->assertSame('foo@example.com', $identity->secret);
+    }
 }


### PR DESCRIPTION
Fixes #450

- Fix bug that when `UserIdentity` is changed (including when saving User object), the correct user identities does not be returned afterwards.
- Now `UserModel` does not alter the passed `User` object state when saving, ~~but when it is an insertion, add the user id to it.~~
