### PR TITLE
bug: fix magic_link_message view template

### DIFF
--- a/src/Views/magic_link_message.php
+++ b/src/Views/magic_link_message.php
@@ -12,8 +12,6 @@
             <p><b><?= lang('Auth.checkYourEmail') ?></b></p>
 
             <p><?= lang('Auth.magicLinkDetails', [setting('Auth.magicLinkLifetime') / 60]) ?></p>
-
-            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Removed unnecessary ending form tag from `magic_link_message.php`