### PR TITLE
docs: add `string` property for `$last_used_at`

### DIFF
--- a/src/Entities/AccessToken.php
+++ b/src/Entities/AccessToken.php
@@ -13,7 +13,7 @@ use CodeIgniter\I18n\Time;
  * Represents a single Personal Access Token, used
  * for authenticating users for an API.
  *
- * @property Time|null $last_used_at
+ * @property Time|null|string $last_used_at
  */
 class AccessToken extends Entity
 {

--- a/src/Entities/AccessToken.php
+++ b/src/Entities/AccessToken.php
@@ -13,7 +13,7 @@ use CodeIgniter\I18n\Time;
  * Represents a single Personal Access Token, used
  * for authenticating users for an API.
  *
- * @property Time|null|string $last_used_at
+ * @property string|Time|null $last_used_at
  */
 class AccessToken extends Entity
 {

--- a/src/Entities/UserIdentity.php
+++ b/src/Entities/UserIdentity.php
@@ -21,7 +21,7 @@ use CodeIgniter\Shield\Authentication\Passwords;
  * though a Authenticator may want to enforce only one exists for that
  * user, like a password.
  *
- * @property Time|null   $last_used_at
+ * @property Time|null|string   $last_used_at
  * @property string|null $secret
  * @property string|null $secret2
  */

--- a/src/Entities/UserIdentity.php
+++ b/src/Entities/UserIdentity.php
@@ -21,9 +21,9 @@ use CodeIgniter\Shield\Authentication\Passwords;
  * though a Authenticator may want to enforce only one exists for that
  * user, like a password.
  *
- * @property Time|null|string   $last_used_at
- * @property string|null $secret
- * @property string|null $secret2
+ * @property string|Time|null $last_used_at
+ * @property string|null      $secret
+ * @property string|null      $secret2
  */
 class UserIdentity extends Entity
 {


### PR DESCRIPTION
see https://github.com/codeigniter4/shield/actions/runs/3182827194/jobs/5189273566
```
Error: Property CodeIgniter\Shield\Entities\AccessToken::$last_used_at (CodeIgniter\I18n\Time|null) does not accept string.
Error: Property CodeIgniter\Shield\Entities\UserIdentity::$last_used_at (CodeIgniter\I18n\Time|null) does not accept string.
 ------ ----------------------------------------------------------------- 
  Line   src/Authentication/Authenticators/AccessTokens.php               
 ------ ----------------------------------------------------------------- 
  131    Property CodeIgniter\Shield\Entities\AccessToken::$last_used_at  
         (CodeIgniter\I18n\Time|null) does not accept string.             
 ------ ----------------------------------------------------------------- 

 ------ ------------------------------------------------------------------ 
  Line   src/Models/UserIdentityModel.php                                  
 ------ ------------------------------------------------------------------ 
  285    Property CodeIgniter\Shield\Entities\UserIdentity::$last_used_at  
         (CodeIgniter\I18n\Time|null) does not accept string.              
 ------ ------------------------------------------------------------------ 
```