### PR TITLE
feat: add `shield:model` command for make custom `UserModel`

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -26,7 +26,7 @@ on the standard Config class if nothing is found in the database.
 
 You can use your own models to handle user persistence. Shield calls this the "User Provider" class. A default model
 is provided for you at `CodeIgniter\Shield\Models\UserModel`. You can change this in the `Config\Auth->userProvider` setting.
-The only requirement is that your new class MUST extend the provided `UserModel`. Shield has a CLI command to quickly create a custom `UserModel`, for example if you run the following command in terminal:
+The only requirement is that your new class MUST extend the provided `UserModel`. Shield has a CLI command to quickly create a custom `MyUserModel` by running the following command in terminal:
 
 ```console
 php spark shield:model MyUserModel

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -32,7 +32,7 @@ The only requirement is that your new class MUST extend the provided `UserModel`
 php spark shield:model MyUserModel
 ```
 
-You should set the `Config\Auth->userProvider` as below:
+You should set `Config\Auth::$userProvider` as follows:
 
 ```php
 public $userProvider = 'App\Models\MyUserModel';

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -35,7 +35,7 @@ php spark shield:model MyUserModel
 You should set `Config\Auth::$userProvider` as follows:
 
 ```php
-public $userProvider = 'App\Models\MyUserModel';
+public $userProvider = \App\Models\MyUserModel::class;
 ```
 
 <a name="identities" />

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -26,10 +26,16 @@ on the standard Config class if nothing is found in the database.
 
 You can use your own models to handle user persistence. Shield calls this the "User Provider" class. A default model
 is provided for you at `CodeIgniter\Shield\Models\UserModel`. You can change this in the `Config\Auth->userProvider` setting.
-The only requirement is that your new class MUST extend the provided `UserModel`.
+The only requirement is that your new class MUST extend the provided `UserModel`. Shield has a CLI command to quickly create a custom `UserModel`, for example if you run the following command in terminal:
+
+```console
+php spark shield:model MyUserModel
+```
+
+You should set the `Config\Auth->userProvider` as below:
 
 ```php
-public $userProvider = 'CodeIgniter\Shield\Models\UserModel';
+public $userProvider = 'App\Models\MyUserModel';
 ```
 
 <a name="identities" />

--- a/src/Commands/Generators/UserModelGenerator.php
+++ b/src/Commands/Generators/UserModelGenerator.php
@@ -74,12 +74,4 @@ class UserModelGenerator extends BaseCommand
         $this->classNameLang = 'CLI.generator.className.model';
         $this->execute($params);
     }
-
-    /**
-     * Prepare options and do the necessary replacements.
-     */
-    protected function prepare(string $class): string
-    {
-        return $this->parseTemplate($class);
-    }
 }

--- a/src/Commands/Generators/UserModelGenerator.php
+++ b/src/Commands/Generators/UserModelGenerator.php
@@ -26,7 +26,7 @@ class UserModelGenerator extends BaseCommand
      *
      * @var string
      */
-    protected $name = 'shield:make';
+    protected $name = 'shield:model';
 
     /**
      * The Command's Description
@@ -40,7 +40,7 @@ class UserModelGenerator extends BaseCommand
      *
      * @var string
      */
-    protected $usage = 'shield:make <name> [options]';
+    protected $usage = 'shield:model <name> [options]';
 
     /**
      * The Command's Arguments

--- a/src/Commands/Generators/UserModelGenerator.php
+++ b/src/Commands/Generators/UserModelGenerator.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Commands\Generators;
+
+use CodeIgniter\CLI\BaseCommand;
+use CodeIgniter\CLI\GeneratorTrait;
+
+/**
+ * Generates a skeleton command file.
+ */
+class UserModelGenerator extends BaseCommand
+{
+    use GeneratorTrait;
+
+    /**
+     * The Command's Group
+     *
+     * @var string
+     */
+    protected $group = 'Shield';
+
+    /**
+     * The Command's Name
+     *
+     * @var string
+     */
+    protected $name = 'shield:make';
+
+    /**
+     * The Command's Description
+     *
+     * @var string
+     */
+    protected $description = 'Generates a new UserModel file.';
+
+    /**
+     * The Command's Usage
+     *
+     * @var string
+     */
+    protected $usage = 'shield:make <name> [options]';
+
+    /**
+     * The Command's Arguments
+     *
+     * @var array
+     */
+    protected $arguments = [
+        'name' => 'The model class name.',
+    ];
+
+    /**
+     * The Command's Options
+     *
+     * @var array
+     */
+    protected $options = [
+        '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',
+        '--suffix'    => 'Append the component title to the class name (e.g. User => UserModel).',
+        '--force'     => 'Force overwrite existing file.',
+    ];
+
+    /**
+     * Actually execute a command.
+     */
+    public function run(array $params): void
+    {
+        $this->component = 'Model';
+        $this->directory = 'Models';
+        $this->template  = 'usermodel.tpl.php';
+
+        $this->classNameLang = 'CLI.generator.className.model';
+        $this->execute($params);
+    }
+
+    /**
+     * Prepare options and do the necessary replacements.
+     */
+    protected function prepare(string $class): string
+    {
+        return $this->parseTemplate($class);
+    }
+}

--- a/src/Commands/Generators/UserModelGenerator.php
+++ b/src/Commands/Generators/UserModelGenerator.php
@@ -45,7 +45,7 @@ class UserModelGenerator extends BaseCommand
     /**
      * The Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'name' => 'The model class name.',

--- a/src/Commands/Generators/UserModelGenerator.php
+++ b/src/Commands/Generators/UserModelGenerator.php
@@ -54,7 +54,7 @@ class UserModelGenerator extends BaseCommand
     /**
      * The Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '--namespace' => 'Set root namespace. Default: "APP_NAMESPACE".',

--- a/src/Commands/Generators/Views/usermodel.tpl.php
+++ b/src/Commands/Generators/Views/usermodel.tpl.php
@@ -1,0 +1,20 @@
+<@php
+
+declare(strict_types=1);
+
+namespace {namespace};
+
+use CodeIgniter\Shield\Models\UserModel;
+
+class {class} extends UserModel
+{
+    protected function initialize(): void
+    {
+        // Merge properties with parent
+        $this->allowedFields = array_merge($this->allowedFields, [
+            // Add here your custom fields
+            // 'first_name',
+        ]);
+    }
+}
+

--- a/src/Commands/Generators/Views/usermodel.tpl.php
+++ b/src/Commands/Generators/Views/usermodel.tpl.php
@@ -10,7 +10,6 @@ class {class} extends UserModel
 {
     protected function initialize(): void
     {
-        // Merge properties with parent
         $this->allowedFields = [
             ...$this->allowedFields,
             // Add here your custom fields

--- a/src/Commands/Generators/Views/usermodel.tpl.php
+++ b/src/Commands/Generators/Views/usermodel.tpl.php
@@ -11,10 +11,11 @@ class {class} extends UserModel
     protected function initialize(): void
     {
         // Merge properties with parent
-        $this->allowedFields = array_merge($this->allowedFields, [
+        $this->allowedFields = [
+            ...$this->allowedFields,
             // Add here your custom fields
             // 'first_name',
-        ]);
+        ];
     }
 }
 

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -50,7 +50,7 @@ class Registrar
     {
         return [
             'views' => [
-                'shield:make' => 'CodeIgniter\Shield\Commands\Generators\Views\usermodel.tpl.php',
+                'shield:model' => 'CodeIgniter\Shield\Commands\Generators\Views\usermodel.tpl.php',
             ],
         ];
     }

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -45,4 +45,13 @@ class Registrar
             ],
         ];
     }
+
+    public static function Generators(): array
+    {
+        return [
+            'views' => [
+                'shield:make' => 'CodeIgniter\Shield\Commands\Generators\Views\usermodel.tpl.php',
+            ],
+        ];
+    }
 }

--- a/tests/Commands/UserModelGeneratorTest.php
+++ b/tests/Commands/UserModelGeneratorTest.php
@@ -16,10 +16,11 @@ final class UserModelGeneratorTest extends CIUnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         CITestStreamFilter::$buffer = '';
         $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
         $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
-        parent::setUp();
     }
 
     protected function tearDown(): void

--- a/tests/Commands/UserModelGeneratorTest.php
+++ b/tests/Commands/UserModelGeneratorTest.php
@@ -97,7 +97,6 @@ final class UserModelGeneratorTest extends CIUnitTestCase
 
         $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
         $this->assertFileExists($filepath);
-
         $this->assertStringContainsString('class MyUserModel extends UserModel', $this->getFileContents($filepath));
     }
 }

--- a/tests/Commands/UserModelGeneratorTest.php
+++ b/tests/Commands/UserModelGeneratorTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+/**
+ * @internal
+ */
+final class UserModelGeneratorTest extends CIUnitTestCase
+{
+    protected $streamFilter;
+
+    protected function setUp(): void
+    {
+        CITestStreamFilter::$buffer = '';
+        $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        $this->streamFilter         = stream_filter_append(STDERR, 'CITestStreamFilter');
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        stream_filter_remove($this->streamFilter);
+        $result = str_replace(["\033[0;32m", "\033[0m", "\n"], '', CITestStreamFilter::$buffer);
+
+        $filepath = str_replace('APPPATH' . DIRECTORY_SEPARATOR, APPPATH, trim(substr($result, 14)));
+        if (is_file($filepath)) {
+            unlink($filepath);
+        }
+    }
+
+    protected function getFileContents(string $filepath): string
+    {
+        if (! file_exists($filepath)) {
+            return '';
+        }
+
+        return file_get_contents($filepath) ?: '';
+    }
+
+    public function testGenerateUserModel(): void
+    {
+        command('shield:model MyUserModel');
+        $filepath = APPPATH . 'Models/MyUserModel.php';
+
+        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertFileExists($filepath);
+
+        $this->assertStringContainsString('namespace App\Models;', $this->getFileContents($filepath));
+        $this->assertStringContainsString('class MyUserModel extends UserModel', $this->getFileContents($filepath));
+        $this->assertStringContainsString('use CodeIgniter\Shield\Models\UserModel;', $this->getFileContents($filepath));
+        $this->assertStringContainsString('protected function initialize(): void', $this->getFileContents($filepath));
+    }
+
+    public function testGenerateUserModelCustomNamespace(): void
+    {
+        command('shield:model MyUserModel --namespace CodeIgniter\\\\Shield');
+        $filepath = HOMEPATH . 'src/Models/MyUserModel.php';
+
+        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertFileExists($filepath);
+
+        $this->assertStringContainsString('namespace CodeIgniter\Shield\Models;', $this->getFileContents($filepath));
+        $this->assertStringContainsString('class MyUserModel extends UserModel', $this->getFileContents($filepath));
+        $this->assertStringContainsString('use CodeIgniter\Shield\Models\UserModel;', $this->getFileContents($filepath));
+        $this->assertStringContainsString('protected function initialize(): void', $this->getFileContents($filepath));
+
+        if (is_file($filepath)) {
+            unlink($filepath);
+        }
+    }
+
+    public function testGenerateUserModelWithForce(): void
+    {
+        command('shield:model MyUserModel');
+
+        command('shield:model MyUserModel --force');
+        $this->assertStringContainsString('File overwritten: ', CITestStreamFilter::$buffer);
+
+        $filepath = APPPATH . 'Models/MyUserModel.php';
+        if (is_file($filepath)) {
+            unlink($filepath);
+        }
+    }
+
+    public function testGenerateUserModelWithSuffix(): void
+    {
+        command('shield:model MyUser --suffix');
+        $filepath = APPPATH . 'Models/MyUserModel.php';
+
+        $this->assertStringContainsString('File created: ', CITestStreamFilter::$buffer);
+        $this->assertFileExists($filepath);
+
+        $this->assertStringContainsString('class MyUserModel extends UserModel', $this->getFileContents($filepath));
+    }
+}

--- a/tests/Commands/UserModelGeneratorTest.php
+++ b/tests/Commands/UserModelGeneratorTest.php
@@ -85,9 +85,7 @@ final class UserModelGeneratorTest extends CIUnitTestCase
         $this->assertStringContainsString('File overwritten: ', CITestStreamFilter::$buffer);
 
         $filepath = APPPATH . 'Models/MyUserModel.php';
-        if (is_file($filepath)) {
-            unlink($filepath);
-        }
+        $this->assertFileExists($filepath);
     }
 
     public function testGenerateUserModelWithSuffix(): void


### PR DESCRIPTION
This command helps to create custom user model.

- `php spark shield:model MyCustomUser`
- `php spark shield:model MyCustomUser --force`
- `php spark shield:model MyCustomUser --suffix`
- `php spark shield:model MyCustomUser --namespace CodeIgniter\Shield` 
## output 
```php 
<?php

declare(strict_types=1);

namespace App\Models;

use CodeIgniter\Shield\Models\UserModel;

class MyCustomUser extends UserModel
{
    protected function initialize(): void
    {
        // Merge properties with parent
        $this->allowedFields = array_merge($this->allowedFields, [
            // Add here your custom fields
            // 'first_name',

        ]);
    }
} 
```
see: #https://github.com/codeigniter4/shield/pull/489#issuecomment-1296417150