### PR TITLE
fix: remove `username` in $validFields by default

### DIFF
--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -223,7 +223,7 @@ class Auth extends BaseConfig
      */
     public array $validFields = [
         'email',
-        'username',
+        // 'username',
     ];
 
     /**

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -79,7 +79,7 @@ class RegisterController extends BaseController
         $allowedPostFields = array_merge(
             setting('Auth.validFields'),
             setting('Auth.personalFields'),
-            ['password']
+            array_keys($rules),
         );
         $user = $this->getUserEntity();
         $user->fill($this->request->getPost($allowedPostFields));

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -118,6 +118,11 @@ final class LoginTest extends TestCase
     {
         Time::setTestNow('March 10, 2017', 'America/Chicago');
 
+        // Add 'username' to $validFields
+        $authConfig                = config('Auth');
+        $authConfig->validFields[] = 'username';
+        Factories::injectMock('config', 'Auth', $authConfig);
+
         // Change the validation rules
         $config = new class () extends Validation {
             public $login = [


### PR DESCRIPTION
The default configuration does not support `username` as login id.
There is no form input for `username`, and no validation rules for it.

But Shield accepts `username` in the login form (attackers can send any field), 
and sends it to the database without validation.

This is not an exploitable vulnerability, but it is undesirable. Unvalidated user input should not be sent to the database.

![Screenshot 2022-11-01 17 28 07](https://user-images.githubusercontent.com/87955/199192076-6ef4e2f3-6d4f-49f1-aa88-3a0f5840636d.png)
