### PR TITLE
chore: update GA deptrac.yml

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           tools: phive
           extensions: intl, json, mbstring, xml
           coverage: none
@@ -39,13 +39,12 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "COMPOSER_CACHE_FILES_DIR=$(composer config cache-files-dir)" >> $GITHUB_ENV
 
       - name: Cache composer dependencies
         uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ env.COMPOSER_CACHE_FILES_DIR }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 


### PR DESCRIPTION
```
Box Requirements Checker
========================

> Using PHP 8.0.25
> PHP is using the following php.ini file:
  /etc/php/8.0/cli/php.ini

> Checking Box requirements:
  E...

                                                                                
Error: ] Your system is not ready to run the application.                       
                                                                                

Fix the following mandatory requirements:
=========================================

 * The application requires the version "^8.1" or greater.

Error: Process completed with exit code 1.
```
https://github.com/codeigniter4/shield/actions/runs/3374291576/jobs/5599760846