### PR TITLE
chore: update minimum CI4 version to 4.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See the [An Official Auth Library](https://codeigniter.com/news/shield) for more
 
 Usage of Shield requires the following:
 
-- A [CodeIgniter 4.2.3+](https://github.com/codeigniter4/CodeIgniter4/) based project
+- A [CodeIgniter 4.2.7+](https://github.com/codeigniter4/CodeIgniter4/) based project
 - [Composer](https://getcomposer.org/) for package management
 - PHP 7.4.3+
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "codeigniter4/devkit": "^1.0",
-        "codeigniter4/framework": "^4.2.3",
+        "codeigniter4/framework": "^4.2.7",
         "mockery/mockery": "^1.0"
     },
     "provide": {

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,7 +17,7 @@ These instructions assume that you have already [installed the CodeIgniter 4 app
 ## Requirements
 
 - [Composer](https://getcomposer.org)
-- Codeigniter **v4.2.3** or later
+- Codeigniter **v4.2.7** or later
 - A created database that you can access via the Spark CLI script
 
 ## Composer Installation


### PR DESCRIPTION
See #516

It requires v4.2.6, but it has the Security Advisory: https://github.com/codeigniter4/CodeIgniter4/security/advisories/GHSA-745p-r637-7vvp
