### PR TITLE
fix: minimum password length check

### DIFF
--- a/src/Authentication/Passwords/CompositionValidator.php
+++ b/src/Authentication/Passwords/CompositionValidator.php
@@ -32,7 +32,7 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
             throw AuthenticationException::forUnsetPasswordLength();
         }
 
-        $passed = strlen($password) >= $this->config->minimumPasswordLength;
+        $passed = mb_strlen($password) >= $this->config->minimumPasswordLength;
 
         if (! $passed) {
             return new Result([

--- a/src/Authentication/Passwords/CompositionValidator.php
+++ b/src/Authentication/Passwords/CompositionValidator.php
@@ -32,7 +32,7 @@ class CompositionValidator extends BaseValidator implements ValidatorInterface
             throw AuthenticationException::forUnsetPasswordLength();
         }
 
-        $passed = mb_strlen($password) >= $this->config->minimumPasswordLength;
+        $passed = mb_strlen($password, 'UTF-8') >= $this->config->minimumPasswordLength;
 
         if (! $passed) {
             return new Result([

--- a/tests/Unit/CompositionValidatorTest.php
+++ b/tests/Unit/CompositionValidatorTest.php
@@ -51,6 +51,19 @@ final class CompositionValidatorTest extends TestCase
         );
     }
 
+    public function testCheckFalseMultibyte(): void
+    {
+        $password = '🍣😀';
+
+        $result = $this->validator->check($password);
+
+        $this->assertFalse($result->isOK());
+        $this->assertSame(
+            lang('Auth.errorPasswordLength', [$this->config->minimumPasswordLength]),
+            $result->reason()
+        );
+    }
+
     public function testCheckTrue(): void
     {
         $password = '1234567890';

--- a/tests/Unit/CompositionValidatorTest.php
+++ b/tests/Unit/CompositionValidatorTest.php
@@ -45,7 +45,10 @@ final class CompositionValidatorTest extends TestCase
         $result = $this->validator->check($password);
 
         $this->assertFalse($result->isOK());
-        $this->assertSame(lang('Auth.errorPasswordLength', [$this->config->minimumPasswordLength]), $result->reason());
+        $this->assertSame(
+            lang('Auth.errorPasswordLength', [$this->config->minimumPasswordLength]),
+            $result->reason()
+        );
     }
 
     public function testCheckTrue(): void


### PR DESCRIPTION
In the current implementation, `$minimumPasswordLength` means bytes, not characters.