### PR TITLE
docs: fix phpdocs for `PHPStan` analyze

### DIFF
--- a/tests/Language/AbstractTranslationTestCase.php
+++ b/tests/Language/AbstractTranslationTestCase.php
@@ -87,7 +87,7 @@ abstract class AbstractTranslationTestCase extends TestCase
      * class and the contained values will be skipped in
      * testAllIncludedLanguageKeysAreTranslated.
      *
-     * @var array<string, string>
+     * @var list<string>
      */
     protected array $excludedLocaleKeyTranslations = [];
 

--- a/tests/Language/AbstractTranslationTestCase.php
+++ b/tests/Language/AbstractTranslationTestCase.php
@@ -87,7 +87,8 @@ abstract class AbstractTranslationTestCase extends TestCase
      * class and the contained values will be skipped in
      * testAllIncludedLanguageKeysAreTranslated.
      *
-     * @var list<string>
+     * @var string[]
+     * @phpstan-var list<string>
      */
     protected array $excludedLocaleKeyTranslations = [];
 


### PR DESCRIPTION
```console 
------ ----------------------------------------------------------------------- 
  Line   tests/Language/ItalianTranslationTest.php                              
 ------ ----------------------------------------------------------------------- 
  12     Property                                                               
         Tests\Language\ItalianTranslationTest::$excludedLocaleKeyTranslations  
         (array<string, string>) does not accept default value of type          
         array<int, string>.                                                    
 ------ ----------------------------------------------------------------------- 
```
https://github.com/codeigniter4/shield/actions/runs/3497594223/jobs/5856927086