### PR TITLE
refactor: use `::class` constants

### DIFF
--- a/docs/auth_actions.md
+++ b/docs/auth_actions.md
@@ -17,7 +17,7 @@ Shield ships with two actions you can use, and makes it simple for you to define
 Actions are setup in the `Auth` config file, with the `$actions` variable.
 
 ```php
-public $actions = [
+public array $actions = [
     'register' => null,
     'login'    => null,
 ];
@@ -26,9 +26,9 @@ public $actions = [
 To define an action to happen you will specify the class name as the value for the appropriate task:
 
 ```php
-public $actions = [
-    'register' => 'CodeIgniter\Shield\Authentication\Actions\EmailActivator',
-    'login'    => 'CodeIgniter\Shield\Authentication\Actions\Email2FA',
+public array $actions = [
+    'register' => \CodeIgniter\Shield\Authentication\Actions\EmailActivator::class,
+    'login'    => \CodeIgniter\Shield\Authentication\Actions\Email2FA::class,
 ];
 ```
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -29,7 +29,7 @@ is provided for you at `CodeIgniter\Shield\Models\UserModel`. You can change thi
 The only requirement is that your new class MUST extend the provided `UserModel`.
 
 ```php
-public $userProvider = UserModel::class;
+public string $userProvider = UserModel::class;
 ```
 
 ## User Identities

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -29,7 +29,7 @@ is provided for you at `CodeIgniter\Shield\Models\UserModel`. You can change thi
 The only requirement is that your new class MUST extend the provided `UserModel`.
 
 ```php
-public $userProvider = 'CodeIgniter\Shield\Models\UserModel';
+public $userProvider = UserModel::class;
 ```
 
 ## User Identities
@@ -80,10 +80,10 @@ You can choose which validators are used in `Config\Auth::$passwordValidators`:
 
 ```php
 public $passwordValidators = [
-    'CodeIgniter\Shield\Authentication\Passwords\CompositionValidator',
-    'CodeIgniter\Shield\Authentication\Passwords\NothingPersonalValidator',
-    'CodeIgniter\Shield\Authentication\Passwords\DictionaryValidator',
-    //'CodeIgniter\Shield\Authentication\Passwords\PwnedValidator',
+    CompositionValidator::class,
+    NothingPersonalValidator::class,
+    DictionaryValidator::class,
+    // PwnedValidator::class,
 ];
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -113,7 +113,7 @@ By default, once a user registers they have an active account that can be used. 
 
 ```php
 public array $actions = [
-    'register' => 'CodeIgniter\Shield\Authentication\Actions\EmailActivator',
+    'register' => \CodeIgniter\Shield\Authentication\Actions\EmailActivator::class,
     'login'    => null,
 ];
 ```
@@ -125,7 +125,7 @@ Turned off by default, Shield's Email-based 2FA can be enabled by specifying the
 ```php
 public array $actions = [
     'register' => null,
-    'login'    => 'CodeIgniter\Shield\Authentication\Actions\Email2FA',
+    'login'    => \CodeIgniter\Shield\Authentication\Actions\Email2FA::class,
 ];
 ```
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -9,6 +9,10 @@ use CodeIgniter\Shield\Authentication\Actions\ActionInterface;
 use CodeIgniter\Shield\Authentication\AuthenticatorInterface;
 use CodeIgniter\Shield\Authentication\Authenticators\AccessTokens;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
+use CodeIgniter\Shield\Authentication\Passwords\CompositionValidator;
+use CodeIgniter\Shield\Authentication\Passwords\DictionaryValidator;
+use CodeIgniter\Shield\Authentication\Passwords\NothingPersonalValidator;
+use CodeIgniter\Shield\Authentication\Passwords\PwnedValidator;
 use CodeIgniter\Shield\Authentication\Passwords\ValidatorInterface;
 use CodeIgniter\Shield\Models\UserModel;
 
@@ -57,8 +61,8 @@ class Auth extends BaseConfig
      * You must register actions in the order of the actions to be performed.
      *
      * Available actions with Shield:
-     * - register: 'CodeIgniter\Shield\Authentication\Actions\EmailActivator'
-     * - login:    'CodeIgniter\Shield\Authentication\Actions\Email2FA'
+     * - register: \CodeIgniter\Shield\Authentication\Actions\EmailActivator::class
+     * - login:    \CodeIgniter\Shield\Authentication\Actions\Email2FA::class
      *
      * @var array<string, class-string<ActionInterface>|null>
      */
@@ -209,10 +213,10 @@ class Auth extends BaseConfig
      * @var class-string<ValidatorInterface>[]
      */
     public array $passwordValidators = [
-        'CodeIgniter\Shield\Authentication\Passwords\CompositionValidator',
-        'CodeIgniter\Shield\Authentication\Passwords\NothingPersonalValidator',
-        'CodeIgniter\Shield\Authentication\Passwords\DictionaryValidator',
-        // 'CodeIgniter\Shield\Authentication\Passwords\PwnedValidator',
+        CompositionValidator::class,
+        NothingPersonalValidator::class,
+        DictionaryValidator::class,
+        // PwnedValidator::class,
     ];
 
     /**
@@ -333,7 +337,7 @@ class Auth extends BaseConfig
      *
      * @var class-string<UserModel>
      */
-    public string $userProvider = 'CodeIgniter\Shield\Models\UserModel';
+    public string $userProvider = UserModel::class;
 
     /**
      * Returns the URL that a user should be redirected


### PR DESCRIPTION
To fix psalm issues.

See  #539

Before:
```console
INFO: PropertyTypeCoercion - src/Config/Auth.php:211:40 - $this->passwordValidators expects 'array<array-key, class-string<CodeIgniter\Shield\Authentication\Passwords\ValidatorInterface>>',  parent type 'array{"CodeIgniter\\Shield\\Authentication\\Passwords\\CompositionValidator", "CodeIgniter\\Shield\\Authentication\\Passwords\\NothingPersonalValidator", "CodeIgniter\\Shield\\Authentication\\Passwords\\DictionaryValidator"}' provided (see https://psalm.dev/198)
    public array $passwordValidators = [
        'CodeIgniter\Shield\Authentication\Passwords\CompositionValidator',
        'CodeIgniter\Shield\Authentication\Passwords\NothingPersonalValidator',
        'CodeIgniter\Shield\Authentication\Passwords\DictionaryValidator',
        // 'CodeIgniter\Shield\Authentication\Passwords\PwnedValidator',
    ];


INFO: PropertyTypeCoercion - src/Config/Auth.php:336:35 - $this->userProvider expects 'class-string<CodeIgniter\Shield\Models\UserModel>',  parent type '"CodeIgniter\\Shield\\Models\\UserModel"' provided (see https://psalm.dev/198)
    public string $userProvider = 'CodeIgniter\Shield\Models\UserModel';


------------------------------
                              
       No errors found!       
                              
------------------------------
2 other issues found.
------------------------------
```

After:
```console
$ vendor/bin/psalm --show-info=true src/Config/Auth.php 
Target PHP version: 7.4 (inferred from composer.json)
Scanning files...
Analyzing files...

░
------------------------------
                              
       No errors found!       
                              
------------------------------

Checks took 2.78 seconds and used 347.746MB of memory
Psalm was able to infer types for 93.0133% of the codebase
```
