### PR TITLE
fix: findByCredentials() returns User when email is empty string

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -177,6 +177,10 @@ class UserModel extends Model
         $email = $credentials['email'] ?? null;
         unset($credentials['email']);
 
+        if ($email === null && $credentials === []) {
+            return null;
+        }
+
         // any of the credentials used should be case-insensitive
         foreach ($credentials as $key => $value) {
             $this->where(

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -179,14 +179,22 @@ class UserModel extends Model
 
         // any of the credentials used should be case-insensitive
         foreach ($credentials as $key => $value) {
-            $this->where('LOWER(' . $this->db->protectIdentifiers("users.{$key}") . ')', strtolower($value));
+            $this->where(
+                'LOWER(' . $this->db->protectIdentifiers("users.{$key}") . ')',
+                strtolower($value)
+            );
         }
 
         if (! empty($email)) {
-            $data = $this->select('users.*, auth_identities.secret as email, auth_identities.secret2 as password_hash')
+            $data = $this->select(
+                'users.*, auth_identities.secret as email, auth_identities.secret2 as password_hash'
+            )
                 ->join('auth_identities', 'auth_identities.user_id = users.id')
                 ->where('auth_identities.type', Session::ID_TYPE_EMAIL_PASSWORD)
-                ->where('LOWER(' . $this->db->protectIdentifiers('auth_identities.secret') . ')', strtolower($email))
+                ->where(
+                    'LOWER(' . $this->db->protectIdentifiers('auth_identities.secret') . ')',
+                    strtolower($email)
+                )
                 ->asArray()
                 ->first();
 

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -185,7 +185,7 @@ class UserModel extends Model
             );
         }
 
-        if (! empty($email)) {
+        if ($email !== null) {
             $data = $this->select(
                 'users.*, auth_identities.secret as email, auth_identities.secret2 as password_hash'
             )

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -48,7 +48,7 @@ final class UserModelTest extends TestCase
     /**
      * @see https://github.com/codeigniter4/shield/issues/546
      */
-    public function testfindByCredentialsEmptyEmail(): void
+    public function testFindByCredentialsEmptyEmail(): void
     {
         $users = $this->createUserModel();
         $user  = $this->createNewUser();

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -45,6 +45,20 @@ final class UserModelTest extends TestCase
         ]);
     }
 
+    /**
+     * @see https://github.com/codeigniter4/shield/issues/546
+     */
+    public function testfindByCredentialsEmailEmptyString(): void
+    {
+        $users = $this->createUserModel();
+        $user  = $this->createNewUser();
+        $users->save($user);
+
+        $user = $users->findByCredentials(['email' => '']);
+
+        $this->assertNull($user);
+    }
+
     public function testInsertUserObject(): void
     {
         $users = $this->createUserModel();

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -48,14 +48,16 @@ final class UserModelTest extends TestCase
     /**
      * @see https://github.com/codeigniter4/shield/issues/546
      */
-    public function testfindByCredentialsEmailEmptyString(): void
+    public function testfindByCredentialsEmptyEmail(): void
     {
         $users = $this->createUserModel();
         $user  = $this->createNewUser();
         $users->save($user);
 
         $user = $users->findByCredentials(['email' => '']);
+        $this->assertNull($user);
 
+        $user = $users->findByCredentials([]);
         $this->assertNull($user);
     }
 


### PR DESCRIPTION
Fixes  #546

This is a case that `empty()` causes a bug.