### PR TITLE
bug: Call to a member function inGroup() on null after logging out

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -102,7 +102,7 @@ class LoginController extends BaseController
     public function logoutAction(): RedirectResponse
     {
         // Capture logout redirect URL before auth logout,
-        // otherwise 'Call to a member function inGroup() on null' is thrown
+        // otherwise you cannot check the user in `logoutRedirect()`.
         $url = config('Auth')->logoutRedirect();
 
         auth()->logout();

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -101,8 +101,12 @@ class LoginController extends BaseController
      */
     public function logoutAction(): RedirectResponse
     {
+        // Capture logout redirect URL before auth logout,
+        // otherwise 'Call to a member function inGroup() on null' is thrown
+        $url = config('Auth')->logoutRedirect();
+
         auth()->logout();
 
-        return redirect()->to(config('Auth')->logoutRedirect())->with('message', lang('Auth.successLogout'));
+        return redirect()->to($url)->with('message', lang('Auth.successLogout'));
     }
 }


### PR DESCRIPTION
I have declared the following under my `Auth.php` file:

```php
public function logoutRedirect(): string
{
    $url = auth()->user()->inGroup('admin')
        ? 'login'
        : setting('Auth.redirects')['logout'];

    return $this->getUrl($url);
}
```

And get a **Call to a member function inGroup() on null** error when navigating to `/logout`.

After some debugging I realized the logout action function under `LoginController.php` logs the user out before redirecting, causing the `redirect()` helper to get an invalid value.

To overcome this, I first capture the URL in a variable and pass it to the redirect function after the auth is logged out:

```php
public function logoutAction(): RedirectResponse
{
    $url = config('Auth')->logoutRedirect();

    auth()->logout();

    return redirect()->to($url)->with('message', lang('Auth.successLogout'));
}
```

This is my first time contributing to CodeIgniter, I'm not sure if I did this correctly so please let me know if I should change something, or even if this should not be considered an issue as it's not something CI Shield sets up out of the box.

Thank you and have a good one!