### PR TITLE
Fix: Unnamed Auth routes returns an error when inside a route group

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -27,7 +27,7 @@ $routes->get('register', '\App\Controllers\Auth\RegisterController::registerView
 ## Custom Redirect URLs
 
 By default, a successful login or register attempt will all redirect to `/`, while a logout action
-will redirect to a [named route](https://codeigniter4.github.io/CodeIgniter4/incoming/routing.html#using-named-routes "See routing docs") `login` or a *URI path* `/login`. You can change the default URLs used within the  `Auth` config file:
+will redirect to a [named route](https://codeigniter.com/user_guide/incoming/routing.html#using-named-routes "See routing docs") `login` or a *URI path* `/login`. You can change the default URLs used within the `Auth` config file:
 
 ```php
 public array $redirects = [

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -24,12 +24,10 @@ $routes->get('login', '\App\Controllers\Auth\LoginController::loginView');
 $routes->get('register', '\App\Controllers\Auth\RegisterController::registerView');
 ```
 
-
-
 ## Custom Redirect URLs
 
 By default, a successful login or register attempt will all redirect to `/`, while a logout action
-will redirect to `/login`. You can change the default URLs used within the `Auth` config file:
+will redirect to a [named route](https://codeigniter4.github.io/CodeIgniter4/incoming/routing.html#using-named-routes "See routing docs") `login` or a *URI path* `/login`. You can change the default URLs used within the  `Auth` config file:
 
 ```php
 public array $redirects = [
@@ -63,13 +61,10 @@ Shield has the following controllers that can be extended to handle
 various parts of the authentication process:
 
 - **ActionController** handles the after-login and after-registration actions, like Two Factor Authentication and Email Verification.
-
 - **LoginController** handles the login process.
-
 - **RegisterController** handles the registration process. Overriding this class allows you to customize the User Provider, the User Entity, and the validation rules.
-
 - **MagicLinkController** handles the "lost password" process that allows a user to login with a link sent to their email. This allows you to
-override the message that is displayed to a user to describe what is happening, if you'd like to provide more information than simply swapping out the view used.
+  override the message that is displayed to a user to describe what is happening, if you'd like to provide more information than simply swapping out the view used.
 
 It is not recommended to copy the entire controller into **app/Controllers** and change its namespace. Instead, you should create a new controller that extends
 the existing controller and then only override the methods needed. This allows the other methods to stay up to date with any security

--- a/docs/install.md
+++ b/docs/install.md
@@ -240,3 +240,24 @@ public $filters = [
     ]
 ];
 ```
+
+> **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the `App/Config/Filter.php` file.
+
+For example, if you configured your routes like so:
+
+```php
+$routes->group('accounts', static function($routes) {
+    service('auth')->routes($routes);
+});
+```
+Then the global `before` filter for `session` should look like so:
+
+```php
+public $globals = [
+    'before' => [
+        // ...
+        'session' => ['except' => ['accounts/login*', 'accounts/register', 'accounts/auth/a/*']]
+    ]
+]
+```
+The same should apply for the Rate Limiting.

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -383,7 +383,7 @@ class Auth extends BaseConfig
                 break;
 
             case route_to($url) !== null: // URL is a named-route
-                $final_url = route_to($url);
+                $final_url = url_to($url);
                 break;
 
             default: // URL is a route (URI path)

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -375,20 +375,22 @@ class Auth extends BaseConfig
     protected function getUrl(string $url): string
     {
         // To accommodate all url patterns
-        $final_url = "";
+        $final_url = '';
+
         switch ($url) {
             case strpos($url, 'http') === 0: // URL begins with 'http'. E.g. http://example.com
                 $final_url = $url;
-            break;
-            
-            case route_to($url) != null: // URL is a named-route
+                break;
+
+            case route_to($url) !== null: // URL is a named-route
                 $final_url = route_to($url);
-            break;
+                break;
 
             default: // URL is a route (URI path)
                 $final_url = rtrim(site_url($url), '/ ');
-            break;
+                break;
         }
+
         return $final_url;
     }
 }

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -385,7 +385,7 @@ class Auth extends BaseConfig
         $final_url = '';
 
         switch (true) {
-            case strpos($url, 'http://') === 0 || strpos($url, 'https://') === 0: // URL begins with 'http'. E.g. http://example.com
+            case strpos($url, 'http://') === 0 || strpos($url, 'https://') === 0: // URL begins with 'http' or 'https'. E.g. http://example.com
                 $final_url = $url;
                 break;
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -45,7 +45,7 @@ class Auth extends BaseConfig
      * auth actions. This can be either of the following:
      *
      * 1. An absolute URL. E.g. http://example.com OR https://example.com
-     * 2. A named route that can be accessed using route_to() or url_to
+     * 2. A named route that can be accessed using route_to() or url_to()
      * 3. A URI path within the application. e.g 'admin', 'login', 'expath'
      *
      * If you need more flexibility you can override the `getUrl()` method

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -39,7 +39,7 @@ class Auth extends BaseConfig
 
     /**
      * --------------------------------------------------------------------
-     * Redirect urLs
+     * Redirect URLs
      * --------------------------------------------------------------------
      * The default URL that a user will be redirected to after
      * various auth actions. If you need more flexibility you can

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -45,7 +45,7 @@ class Auth extends BaseConfig
      * auth actions. This can be either of the following:
      *
      * 1. An absolute URL. E.g. http://example.com OR https://example.com
-     * 2. A named route that can be accessed using route_to() or url_to()
+     * 2. A named route that can be accessed using `route_to()` or `url_to()`
      * 3. A URI path within the application. e.g 'admin', 'login', 'expath'
      *
      * If you need more flexibility you can override the `getUrl()` method

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -382,7 +382,7 @@ class Auth extends BaseConfig
                 $final_url = $url;
                 break;
 
-            case route_to($url) !== null: // URL is a named-route
+            case route_to($url) !== false: // URL is a named-route
                 $final_url = url_to($url);
                 break;
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -372,6 +372,12 @@ class Auth extends BaseConfig
         return $this->getUrl($url);
     }
 
+    /**
+     * Accepts a string which can be an absolute URL or
+     * a named route or just a URI path.
+     * @param string $url
+     * @return string
+     */
     protected function getUrl(string $url): string
     {
         // To accommodate all url patterns

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -385,7 +385,7 @@ class Auth extends BaseConfig
         $final_url = '';
 
         switch (true) {
-            case strpos($url, 'http') === 0: // URL begins with 'http'. E.g. http://example.com
+            case strpos($url, 'http://') === 0 || strpos($url, 'https://'): // URL begins with 'http'. E.g. http://example.com
                 $final_url = $url;
                 break;
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -390,7 +390,7 @@ class Auth extends BaseConfig
                 break;
 
             case route_to($url) !== false: // URL is a named-route
-                $final_url = url_to($url);
+                $final_url = rtrim(url_to($url), '/ ');
                 break;
 
             default: // URL is a route (URI path)

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -374,9 +374,10 @@ class Auth extends BaseConfig
 
     /**
      * Accepts a string which can be an absolute URL or
-     * a named route or just a URI path.
-     * @param string $url
-     * @return string
+     * a named route or just a URI path, and returns the
+     * full path.
+     *
+     * @param string $url an absolute URL or a named route or just URI path
      */
     protected function getUrl(string $url): string
     {

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -41,8 +41,8 @@ class Auth extends BaseConfig
      * --------------------------------------------------------------------
      * Redirect URLs
      * --------------------------------------------------------------------
-     * The default URL that a user will be redirected to after
-     * various auth actions. If you need more flexibility you can
+     * The default URL or a named route that a user will be redirected to
+     * after various auth actions. If you need more flexibility you can
      * override the `getUrl()` method to apply any logic you may need.
      */
     public array $redirects = [

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -41,9 +41,15 @@ class Auth extends BaseConfig
      * --------------------------------------------------------------------
      * Redirect URLs
      * --------------------------------------------------------------------
-     * The default URL or a named route that a user will be redirected to
-     * after various auth actions. If you need more flexibility you can
-     * override the `getUrl()` method to apply any logic you may need.
+     * The default URL that a user will be redirected to after various auth
+     * auth actions. This can be either of the following:
+     * 
+     * 1. An absolute URL. E.g. http://example.com OR https://example.com
+     * 2. A named route that can be accessed using route_to() or url_to
+     * 3. A URI path within the application. e.g 'admin', 'login', 'expath'
+     * 
+     * If you need more flexibility you can override the `getUrl()` method
+     * to apply any logic you may need.
      */
     public array $redirects = [
         'register' => '/',

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -385,7 +385,7 @@ class Auth extends BaseConfig
         $final_url = '';
 
         switch (true) {
-            case strpos($url, 'http://') === 0 || strpos($url, 'https://'): // URL begins with 'http'. E.g. http://example.com
+            case strpos($url, 'http://') === 0 || strpos($url, 'https://') === 0: // URL begins with 'http'. E.g. http://example.com
                 $final_url = $url;
                 break;
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -374,8 +374,21 @@ class Auth extends BaseConfig
 
     protected function getUrl(string $url): string
     {
-        return strpos($url, 'http') === 0
-            ? $url
-            : rtrim(site_url($url), '/ ');
+        // To accommodate all url patterns
+        $final_url = "";
+        switch ($url) {
+            case strpos($url, 'http') === 0: // URL begins with 'http'. E.g. http://example.com
+                $final_url = $url;
+            break;
+            
+            case route_to($url) != null: // URL is a named-route
+                $final_url = route_to($url);
+            break;
+
+            default: // URL is a route (URI path)
+                $final_url = rtrim(site_url($url), '/ ');
+            break;
+        }
+        return $final_url;
     }
 }

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -43,11 +43,11 @@ class Auth extends BaseConfig
      * --------------------------------------------------------------------
      * The default URL that a user will be redirected to after various auth
      * auth actions. This can be either of the following:
-     * 
+     *
      * 1. An absolute URL. E.g. http://example.com OR https://example.com
      * 2. A named route that can be accessed using route_to() or url_to
      * 3. A URI path within the application. e.g 'admin', 'login', 'expath'
-     * 
+     *
      * If you need more flexibility you can override the `getUrl()` method
      * to apply any logic you may need.
      */

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -377,7 +377,7 @@ class Auth extends BaseConfig
         // To accommodate all url patterns
         $final_url = '';
 
-        switch ($url) {
+        switch (true) {
             case strpos($url, 'http') === 0: // URL begins with 'http'. E.g. http://example.com
                 $final_url = $url;
                 break;

--- a/src/Config/AuthRoutes.php
+++ b/src/Config/AuthRoutes.php
@@ -14,6 +14,7 @@ class AuthRoutes extends BaseConfig
                 'get',
                 'register',
                 'RegisterController::registerView',
+                'register', // Route name
             ],
             [
                 'post',
@@ -26,6 +27,7 @@ class AuthRoutes extends BaseConfig
                 'get',
                 'login',
                 'LoginController::loginView',
+                'login', // Route name
             ],
             [
                 'post',
@@ -57,6 +59,7 @@ class AuthRoutes extends BaseConfig
                 'get',
                 'logout',
                 'LoginController::logoutAction',
+                'logout', // Route name
             ],
         ],
         'auth-actions' => [
@@ -64,19 +67,19 @@ class AuthRoutes extends BaseConfig
                 'get',
                 'auth/a/show',
                 'ActionController::show',
-                'auth-action-show',
+                'auth-action-show', // Route name
             ],
             [
                 'post',
                 'auth/a/handle',
                 'ActionController::handle',
-                'auth-action-handle',
+                'auth-action-handle', // Route name
             ],
             [
                 'post',
                 'auth/a/verify',
                 'ActionController::verify',
-                'auth-action-verify',
+                'auth-action-verify', // Route name
             ],
         ],
     ];


### PR DESCRIPTION
In situations when a developer decides to put the routes in a group like so:
```php
$routes->group('accounts', static function($routes) {
    service('auth')->routes($routes);
});
```
Calls to `route_to('login')` and `route_to('register')` will return an error because there isn't any named route for that.

By explicitly setting named routes for each of the auth routes, the routing works well whether in groups or not.