### PR TITLE
Fix: Remove unnecessary register action checks

### DIFF
--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -58,6 +58,7 @@ class RegisterController extends BaseController
      */
     public function registerAction(): RedirectResponse
     {
+        // Get the userProvider
         $users = $this->getUserProvider();
 
         // Validate here first, since some things,

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -58,10 +58,6 @@ class RegisterController extends BaseController
      */
     public function registerAction(): RedirectResponse
     {
-        if (auth()->loggedIn()) {
-            return redirect()->to(config('Auth')->registerRedirect());
-        }
-
         // Check if registration is allowed
         if (! setting('Auth.allowRegistration')) {
             return redirect()->back()->withInput()

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -58,12 +58,6 @@ class RegisterController extends BaseController
      */
     public function registerAction(): RedirectResponse
     {
-        // Check if registration is allowed
-        if (! setting('Auth.allowRegistration')) {
-            return redirect()->back()->withInput()
-                ->with('error', lang('Auth.registerDisabled'));
-        }
-
         $users = $this->getUserProvider();
 
         // Validate here first, since some things,


### PR DESCRIPTION
The `registerView()` method of the RegisterController already has the loggedIn and allowRegistration checks, so I don't think (IMO), it is still necessary to have those checks in the `registerAction()` method. Remember that _"under normal circumstance"_, a user cannot arrive at the `POST` request of the registration if it doesn't generate from the `GET` (view), so having the checks in both methods is just overkill.

The `LoginController` has a better sample.