### PR TITLE
chore: set `GITHUB_AUTH_TOKEN` for phive

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -72,4 +72,3 @@ jobs:
           deptrac analyze --cache-file=build/deptrac.cache
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -70,3 +70,6 @@ jobs:
         run: |
           sudo phive --no-progress install --global --trust-gpg-keys B8F640134AB1782E,A98E898BB53EB748 qossmic/deptrac
           deptrac analyze --cache-file=build/deptrac.cache
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
ref: https://github.com/codeigniter4/CodeIgniter4/pull/7016
```console
Run sudo phive --no-progress install --global --trust-gpg-keys B8F640134AB1782E,A98E898BB53EB748 qossmic/deptrac
Phive 0.15.2 - Copyright (C) 2015-2023 by Arne Blankerts, Sebastian Heuer and Contributors
Downloading https://api.github.com/rate_limit
Warning:  Github API Rate Limit exceeded - cannot resolve "qossmic/deptrac"
Downloading https://gitlab.com/api/v4/projects/qossmic%2Fdeptrac/releases/
Fetching repository list
Downloading https://phar.io/data/repositories.xml
Error:    Could not resolve requested PHAR qossmic/deptrac

Error: Process completed with exit code 4.
```
see https://github.com/datamweb/shield/actions/runs/3862351738/jobs/6583866759