### PR TITLE
chore: add `ext-curl` to suggest if use `PwnedValidator::class`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
     "provide": {
         "codeigniter4/authentication-implementation": "1.0"
     },
+    "suggest": {
+        "ext-curl": "Required to use the password validation rule via PwnedValidator class."
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
Codeigniter considers `ext-curl` optional. On the other hand, `PwnedValidator::class` uses  `Services::curlrequest` to connect with API. Therefore, it is better to inform about this matter.