### PR TITLE
Fix: groups and permissions filter redirects

### DIFF
--- a/src/Filters/AbstractAuthFilter.php
+++ b/src/Filters/AbstractAuthFilter.php
@@ -37,12 +37,6 @@ abstract class AbstractAuthFilter implements FilterInterface
             return;
         }
 
-        // If the previous_url is from this site, then
-        // we can redirect back to it.
-        if (strpos(previous_url(), site_url()) === 0) {
-            return redirect()->back()->with('error', lang('Auth.notEnoughPrivilege'));
-        }
-
         // Otherwise, we'll just send them to the home page.
         return redirect()->to('/')->with('error', lang('Auth.notEnoughPrivilege'));
     }

--- a/tests/Authentication/Filters/GroupFilterTest.php
+++ b/tests/Authentication/Filters/GroupFilterTest.php
@@ -63,21 +63,4 @@ final class GroupFilterTest extends AbstractFilterTest
         // Should have error message
         $result->assertSessionHas('error');
     }
-
-    public function testFilterIncorrectGroupWithPrevious(): void
-    {
-        /** @var User $user */
-        $user = fake(UserModel::class);
-        $user->addGroup('beta');
-
-        $result = $this
-            ->actingAs($user)
-            ->withSession(['_ci_previous_url' => site_url('open-route')])
-            ->get('protected-route');
-
-        // Should redirect to the previous url (open-route)
-        $result->assertRedirectTo(site_url('open-route'));
-
-        $result->assertSessionHas('error');
-    }
 }

--- a/tests/Authentication/Filters/PermissionFilterTest.php
+++ b/tests/Authentication/Filters/PermissionFilterTest.php
@@ -63,21 +63,4 @@ final class PermissionFilterTest extends AbstractFilterTest
         // Should have error message
         $result->assertSessionHas('error');
     }
-
-    public function testFilterIncorrectGroupWithPrevious(): void
-    {
-        /** @var User $user */
-        $user = fake(UserModel::class);
-        $user->addPermission('beta.access');
-
-        $result = $this
-            ->actingAs($user)
-            ->withSession(['_ci_previous_url' => site_url('open-route')])
-            ->get('protected-route');
-
-        // Should redirect to the previous url (open-route)
-        $result->assertRedirectTo(site_url('open-route'));
-
-        $result->assertSessionHas('error');
-    }
 }


### PR DESCRIPTION
Steps to reproduce:
1. Create an admin group _(if you don't already have one)_
2. Register a new user and add to the group
3. Create two views that can only be accessible by this group, let's call them A and B
4. Filter these views _(via the route or filter)_
5. Login and visit page A.
6. Change the group of the logged in user, preferrably from the database directly
7. Try to visit page B.

What you'll notice is that the browser dies of too many redirects error.  This happens because the filter is redirecting the user back to the previous page, which at this point, the user no longer has enough privileges to access it.

A real-life scenario:
A forum website with multiple groups and permissions, an admin might decide to remove a certain permission from a user or remove the user from a certain group WHILE that user might be logged in. If this user visits another page that requires the same permission or group that s/he has been stripped of, then it causes the browser to die due to too many redirects.