### PR TITLE
fix: update `shield:setup` for correct run in CI4.3.0+

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -267,7 +267,7 @@ class Setup extends BaseCommand
     {
         $file     = 'Config/Security.php';
         $replaces = [
-            'public $csrfProtection = \'cookie\';' => 'public $csrfProtection = \'session\';',
+            '$csrfProtection = \'cookie\';' => '$csrfProtection = \'session\';',
         ];
 
         $path      = $this->distPath . $file;

--- a/tests/Commands/SetupTest.php
+++ b/tests/Commands/SetupTest.php
@@ -61,7 +61,7 @@ final class SetupTest extends TestCase
         $this->assertStringContainsString('service(\'auth\')->routes($routes);', $routes);
 
         $security = file_get_contents($appFolder . 'Config/Security.php');
-        $this->assertStringContainsString('public $csrfProtection = \'session\';', $security);
+        $this->assertStringContainsString('$csrfProtection = \'session\';', $security);
 
         $result = str_replace(["\033[0;32m", "\033[0m"], '', CITestStreamFilter::$buffer);
 


### PR DESCRIPTION
See #596

In version CI 4.3.0+, is used (`string`), 

https://github.com/codeigniter4/CodeIgniter4/blob/758889a19d53d155e62b7d1edb49498e395acf2e/app/Config/Security.php#L13-L19

which makes `setSecurityCSRF()` function not work properly.