### PR TITLE
Feat: Force password reset

### DIFF
--- a/docs/forcing_password_reset.md
+++ b/docs/forcing_password_reset.md
@@ -1,0 +1,67 @@
+# Forcing Password Reset
+
+Depending on the scope of your application, there may be times when you'll decide that it is absolutely necessary to force user(s) to reset their password. This practice is common when you find out that users of your application do not use strong passwords OR there is a reasonable suspicion that their passwords have been compromised. This guide provides you with ways to achieve this.
+
+- [Forcing Password Reset](#forcing-password-reset)
+  - [Available Methods](#available-methods)
+    - [Check if a User Requires Password Reset](#check-if-a-user-requires-password-reset)
+    - [Force Password Reset On a User](#force-password-reset-on-a-user)
+    - [Removing Password Reset Flag On a User](#removing-password-reset-flag-on-a-user)
+    - [Force Password Reset On Multiple Users](#force-password-reset-on-multiple-users)
+    - [Force Password Reset On All Users](#force-password-reset-on-all-users)
+
+## Available Methods
+
+Shield provides a way to enforce password resets throughout your application. The `Resettable` trait on the `User` entity and the `UserIdentityModel` provides the following methods to do so.
+
+### Check if a User Requires Password Reset
+
+When you need to check if a user requires password reset, you can do so using the `requiresPasswordReset()` method on the `User` entity. Returns boolean `true`/`false`.
+
+```php
+if ($user->requiresPasswordReset()) {
+    //...
+}
+```
+
+### Force Password Reset On a User
+
+To force password reset on a user, you can do so using the `forcePasswordReset()` method on the `User` entity. Returns boolean `true`/`false`.
+
+```php
+$user->forcePasswordReset();
+```
+
+### Remove Force Password Reset Flag On a User
+
+Undoing or removing the force password reset flag on a user can be done using the `undoForcePasswordReset()` method on the `User` entity. Returns boolean `true`/`false`.
+
+```php
+$user->undoForcePasswordReset();
+```
+
+### Force Password Reset On Multiple Users
+
+If you see the need to force password reset for more than one user, the `forceMultiplePasswordReset()` method of the `UserIdentityModel` allows you to do this easily. It accepts an `Array` of user IDs.
+
+```php
+use CodeIgniter\Shield\Models\UserIdentityModel;
+...
+...
+...
+$identities = new UserIdentityModel();
+$identities->forceMultiplePasswordReset([1,2,3,4]);
+```
+
+### Force Password Reset On All Users
+
+If you suspect a security breach or compromise in the passwords of your users, you can easily force password reset on all the users of your application using the `forceGlobalPasswordReset()` method of the `UserIdentityModel`.
+
+```php
+use CodeIgniter\Shield\Models\UserIdentityModel;
+...
+...
+...
+$identities = new UserIdentityModel();
+$identities->forceGlobalPasswordReset();
+```

--- a/docs/forcing_password_reset.md
+++ b/docs/forcing_password_reset.md
@@ -26,7 +26,7 @@ if ($user->requiresPasswordReset()) {
 
 ### Force Password Reset On a User
 
-To force password reset on a user, you can do so using the `forcePasswordReset()` method on the `User` entity. Returns boolean `true`/`false`.
+To force password reset on a user, you can do so using the `forcePasswordReset()` method on the `User` entity.
 
 ```php
 $user->forcePasswordReset();
@@ -34,7 +34,7 @@ $user->forcePasswordReset();
 
 ### Remove Force Password Reset Flag On a User
 
-Undoing or removing the force password reset flag on a user can be done using the `undoForcePasswordReset()` method on the `User` entity. Returns boolean `true`/`false`.
+Undoing or removing the force password reset flag on a user can be done using the `undoForcePasswordReset()` method on the `User` entity.
 
 ```php
 $user->undoForcePasswordReset();

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@
 * [Authentication](authentication.md)
 * [Authorization](authorization.md)
 * [Auth Actions](auth_actions.md)
+* [Forcing Password Reset](forcing_password_reset.md)
 * [Events](events.md)
 * [Testing](testing.md)
 * [Customization](customization.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,6 +11,7 @@
   - [Controller Filters](#controller-filters)
     - [Protect All Pages](#protect-all-pages)
     - [Rate Limiting](#rate-limiting)
+    - [Forcing Password Reset](#forcing-password-reset)
 
 These instructions assume that you have already [installed the CodeIgniter 4 app starter](https://codeigniter.com/user_guide/installation/installing_composer.html) as the basis for your new project, set up your **.env** file, and created a database that you can access via the Spark CLI script.
 
@@ -42,26 +43,35 @@ Require it with an explicit version constraint allowing its desired stability.
 
 1. Run the following commands to change your [minimum-stability](https://getcomposer.org/doc/articles/versions.md#minimum-stability) in your project `composer.json`:
 
-    ```console
-    composer config minimum-stability dev
-    composer config prefer-stable true
-    ```
-
+   ```console
+   composer config minimum-stability dev
+   composer config prefer-stable true
+   ```
 2. Or specify an explicit version:
 
-    ```console
-    composer require codeigniter4/shield:dev-develop
-    ```
+   ```console
+   composer require codeigniter4/shield:dev-develop
+   ```
 
+<<<<<<< HEAD
     The above specifies `develop` branch.
     See <https://getcomposer.org/doc/articles/versions.md#branches>
+=======
+   The above specifies `develop` branch.
+   See https://getcomposer.org/doc/articles/versions.md#branches
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
-    ```console
-    composer require codeigniter4/shield:^1.0.0-beta
-    ```
+   ```console
+   composer require codeigniter4/shield:^1.0.0-beta
+   ```
 
+<<<<<<< HEAD
     The above specifies `v1.0.0-beta` or later and before `v2.0.0`.
     See <https://getcomposer.org/doc/articles/versions.md#caret-version-range->
+=======
+   The above specifies `v1.0.0-beta` or later and before `v2.0.0`.
+   See https://getcomposer.org/doc/articles/versions.md#caret-version-range-
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
 ## Initial Setup
 
@@ -69,34 +79,41 @@ Require it with an explicit version constraint allowing its desired stability.
 
 1. Run the following command. This command handles steps 1-5 of *Manual Setup* and runs the migrations.
 
+<<<<<<< HEAD
     ```console
     php spark shield:setup
     ```
 
 2. Configure **app/Config/Email.php** to allow Shield to send emails with the [Email Class](https://codeigniter.com/user_guide/libraries/email.html).
+=======
+   ```console
+   php spark shield:setup
+   ```
+2. Configure `app/Config/Email.php` to allow Shield to send emails with the [Email Class](https://codeigniter.com/user_guide/libraries/email.html).
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
-    ```php
-    <?php
+   ```php
+   <?php
 
-    namespace Config;
+   namespace Config;
 
-    use CodeIgniter\Config\BaseConfig;
+   use CodeIgniter\Config\BaseConfig;
 
-    class Email extends BaseConfig
-    {
-        /**
-         * @var string
-         */
-        public $fromEmail = 'your_mail@example.com';
+   class Email extends BaseConfig
+   {
+       /**
+        * @var string
+        */
+       public $fromEmail = 'your_mail@example.com';
 
-        /**
-         * @var string
-         */
-        public $fromName = 'your name';
+       /**
+        * @var string
+        */
+       public $fromName = 'your name';
 
-        // ...
-    }
-    ```
+       // ...
+   }
+   ```
 
 ### Manual Setup
 
@@ -105,35 +122,37 @@ your project.
 
 1. Copy the **Auth.php** and  **AuthGroups.php** from **vendor/codeigniter4/shield/src/Config/** into your project's config folder and update the namespace to `Config`. You will also need to have these classes extend the original classes. See the example below. These files contain all of the settings, group, and permission information for your application and will need to be modified to meet the needs of your site.
 
-    ```php
-    // new file - app/Config/Auth.php
-    <?php
+   ```php
+   // new file - app/Config/Auth.php
+   <?php
 
-    namespace Config;
+   namespace Config;
 
-    // ...
-    use CodeIgniter\Shield\Config\Auth as ShieldAuth;
+   // ...
+   use CodeIgniter\Shield\Config\Auth as ShieldAuth;
 
-    class Auth extends ShieldAuth
-    {
-        // ...
-    }
-    ```
-
+<<<<<<< HEAD
 2. **Helper Setup** The `setting` helper needs to be included in almost every page. The simplest way to do this is to add it to the `BaseController::initController()` method:
+=======
+   class Auth extends ShieldAuth
+   {
+       // ...
+   }
+   ```
+2. **Helper Setup** The `setting` helper needs to be included in almost every page. The simplest way to do this is to add it to the `BaseController::initController` method:
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
-    ```php
-    public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
-    {
-        $this->helpers = array_merge($this->helpers, ['setting']);
+   ```php
+   public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
+   {
+       $this->helpers = array_merge($this->helpers, ['setting']);
 
-        // Do Not Edit This Line
-        parent::initController($request, $response, $logger);
-    }
-    ```
+       // Do Not Edit This Line
+       parent::initController($request, $response, $logger);
+   }
+   ```
 
-    This requires that all of your controllers extend the `BaseController`, but that's a good practice anyway.
-
+<<<<<<< HEAD
 3. **Routes Setup** The default auth routes can be setup with a single call in **app/Config/Routes.php**:
 
     ```php
@@ -142,50 +161,69 @@ your project.
 
 4. **Security Setup** Set `Config\Security::$csrfProtection` to `'session'` (or set `security.csrfProtection = session` in your **.env** file) for security reasons, if you use Session Authenticator.
 
+=======
+   This requires that all of your controllers extend the `BaseController`, but that's a good practice anyway.
+3. **Routes Setup** The default auth routes can be setup with a single call in `app/Config/Routes.php`:
+
+   ```php
+   service('auth')->routes($routes);
+   ```
+4. **Security Setup** Set `Config\Security::$csrfProtection` to `'session'` (or set `security.csrfProtection = session` in your `.env` file) for security reasons, if you use Session Authenticator.
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 5. **Migration** Run the migrations.
 
-    ```console
-    php spark migrate --all
-    ```
+   ```console
+   php spark migrate --all
+   ```
 
-    #### Note: migration error
+   #### Note: migration error
 
-    When you run `spark migrate --all`, if you get `Class "SQLite3" not found` error:
+   When you run `spark migrate --all`, if you get `Class "SQLite3" not found` error:
 
+<<<<<<< HEAD
     1. Remove sample migration files in **tests/_support/Database/Migrations/**
     2. Or install `sqlite3` php extension
+=======
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
-    If you get `Specified key was too long` error:
+   1. Remove sample migration files in `tests/_support/Database/Migrations/`
+   2. Or install `sqlite3` php extension
 
-    1. Use InnoDB, not MyISAM.
+   If you get `Specified key was too long` error:
 
+<<<<<<< HEAD
 6. Configure **app/Config/Email.php** to allow Shield to send emails.
+=======
+   1. Use InnoDB, not MyISAM.
+6. Configure `app/Config/Email.php` to allow Shield to send emails.
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
-    ```php
-    <?php
+   ```php
+   <?php
 
-    namespace Config;
+   namespace Config;
 
-    use CodeIgniter\Config\BaseConfig;
+   use CodeIgniter\Config\BaseConfig;
 
-    class Email extends BaseConfig
-    {
-        /**
-         * @var string
-         */
-        public $fromEmail = 'your_mail@example.com';
+   class Email extends BaseConfig
+   {
+       /**
+        * @var string
+        */
+       public $fromEmail = 'your_mail@example.com';
 
-        /**
-         * @var string
-         */
-        public $fromName = 'your name';
+       /**
+        * @var string
+        */
+       public $fromName = 'your name';
 
-        // ...
-    }
-    ```
+       // ...
+   }
+   ```
 
 ## Controller Filters
-The [Controller Filters](https://codeigniter.com/user_guide/incoming/filters.html) you can use to protect your routes the shield provides are:
+
+The [Controller Filters](https://codeigniter.com/user_guide/incoming/filters.html) you can use to pr	otect your routes the shield provides are:
 
 ```php
 public $aliases = [
@@ -196,16 +234,18 @@ public $aliases = [
     'auth-rates' => \CodeIgniter\Shield\Filters\AuthRates::class,
     'group'      => \CodeIgniter\Shield\Filters\GroupFilter::class,
     'permission' => \CodeIgniter\Shield\Filters\PermissionFilter::class,
+    'force-reset' => \CodeIgniter\Shield\Filters\ForcePasswordResetFilter::class,
 ];
 ```
 
-Filters | Description
---- | ---
-session and tokens | The `Session` and `AccessTokens` authenticators, respectively.
-chained | The filter will check both authenticators in sequence to see if the user is logged in through either of authenticators, allowing a single API endpoint to work for both an SPA using session auth, and a mobile app using access tokens.
-auth-rates | Provides a good basis for rate limiting of auth-related routes.
-group | Checks if the user is in one of the groups passed in.
-permission | Checks if the user has the passed permissions.
+| Filters            | Description                                                                                                                                                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| session and tokens | The `Session` and `AccessTokens` authenticators, respectively.                                                                                                                                                                       |
+| chained            | The filter will check both authenticators in sequence to see if the user is logged in through either of authenticators, allowing a single API endpoint to work for both an SPA using session auth, and a mobile app using access tokens. |
+| auth-rates         | Provides a good basis for rate limiting of auth-related routes.                                                                                                                                                                          |
+| group              | Checks if the user is in one of the groups passed in.                                                                                                                                                                                    |
+| permission         | Checks if the user has the passed permissions.                                                                                                                                                                                           |
+| force-reset        | Checks if the user should reset their password.                                                                                                                                                                                          |
 
 These can be used in any of the [normal filter config settings](https://codeigniter.com/user_guide/incoming/filters.html#globals), or [within the routes file](https://codeigniter.com/user_guide/incoming/routing.html#applying-filters).
 
@@ -241,7 +281,27 @@ public $filters = [
 ];
 ```
 
+<<<<<<< HEAD
 > **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the **app/Config/Filter.php** file.
+=======
+### Forcing Password Reset
+
+If your application requires the force password reset functionality, ensure that you exclude the auth pages and the actual password reset page from the `before` global. This will ensure that your users do not run into a *too many redirects* error.
+
+```php
+public $globals = [
+    'before' => [
+        //...
+        //...
+        'force-reset' => ['except' => ['login*', 'register', 'auth*', 'change-password']]
+    ]
+];
+```
+
+In the example above, we assume that the page  you have created for users to change their password is *"change-password"*.
+
+> **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the `App/Config/Filter.php` file.
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
 For example, if you configured your routes like so:
 
@@ -250,6 +310,7 @@ $routes->group('accounts', static function($routes) {
     service('auth')->routes($routes);
 });
 ```
+
 Then the global `before` filter for `session` should look like so:
 
 ```php
@@ -260,4 +321,9 @@ public $globals = [
     ]
 ]
 ```
+<<<<<<< HEAD
 The same should apply for the Rate Limiting.
+=======
+
+The same should apply for the Rate Limiting and Forcing Password Reset.
+>>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,25 +53,15 @@ Require it with an explicit version constraint allowing its desired stability.
    composer require codeigniter4/shield:dev-develop
    ```
 
-<<<<<<< HEAD
     The above specifies `develop` branch.
     See <https://getcomposer.org/doc/articles/versions.md#branches>
-=======
-   The above specifies `develop` branch.
-   See https://getcomposer.org/doc/articles/versions.md#branches
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
    ```console
    composer require codeigniter4/shield:^1.0.0-beta
    ```
 
-<<<<<<< HEAD
     The above specifies `v1.0.0-beta` or later and before `v2.0.0`.
     See <https://getcomposer.org/doc/articles/versions.md#caret-version-range->
-=======
-   The above specifies `v1.0.0-beta` or later and before `v2.0.0`.
-   See https://getcomposer.org/doc/articles/versions.md#caret-version-range-
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
 ## Initial Setup
 
@@ -79,18 +69,11 @@ Require it with an explicit version constraint allowing its desired stability.
 
 1. Run the following command. This command handles steps 1-5 of *Manual Setup* and runs the migrations.
 
-<<<<<<< HEAD
     ```console
     php spark shield:setup
     ```
 
 2. Configure **app/Config/Email.php** to allow Shield to send emails with the [Email Class](https://codeigniter.com/user_guide/libraries/email.html).
-=======
-   ```console
-   php spark shield:setup
-   ```
-2. Configure `app/Config/Email.php` to allow Shield to send emails with the [Email Class](https://codeigniter.com/user_guide/libraries/email.html).
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
    ```php
    <?php
@@ -131,16 +114,7 @@ your project.
    // ...
    use CodeIgniter\Shield\Config\Auth as ShieldAuth;
 
-<<<<<<< HEAD
 2. **Helper Setup** The `setting` helper needs to be included in almost every page. The simplest way to do this is to add it to the `BaseController::initController()` method:
-=======
-   class Auth extends ShieldAuth
-   {
-       // ...
-   }
-   ```
-2. **Helper Setup** The `setting` helper needs to be included in almost every page. The simplest way to do this is to add it to the `BaseController::initController` method:
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
    ```php
    public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
@@ -152,7 +126,6 @@ your project.
    }
    ```
 
-<<<<<<< HEAD
 3. **Routes Setup** The default auth routes can be setup with a single call in **app/Config/Routes.php**:
 
     ```php
@@ -161,15 +134,6 @@ your project.
 
 4. **Security Setup** Set `Config\Security::$csrfProtection` to `'session'` (or set `security.csrfProtection = session` in your **.env** file) for security reasons, if you use Session Authenticator.
 
-=======
-   This requires that all of your controllers extend the `BaseController`, but that's a good practice anyway.
-3. **Routes Setup** The default auth routes can be setup with a single call in `app/Config/Routes.php`:
-
-   ```php
-   service('auth')->routes($routes);
-   ```
-4. **Security Setup** Set `Config\Security::$csrfProtection` to `'session'` (or set `security.csrfProtection = session` in your `.env` file) for security reasons, if you use Session Authenticator.
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 5. **Migration** Run the migrations.
 
    ```console
@@ -180,23 +144,15 @@ your project.
 
    When you run `spark migrate --all`, if you get `Class "SQLite3" not found` error:
 
-<<<<<<< HEAD
     1. Remove sample migration files in **tests/_support/Database/Migrations/**
     2. Or install `sqlite3` php extension
-=======
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
    1. Remove sample migration files in `tests/_support/Database/Migrations/`
    2. Or install `sqlite3` php extension
 
    If you get `Specified key was too long` error:
 
-<<<<<<< HEAD
 6. Configure **app/Config/Email.php** to allow Shield to send emails.
-=======
-   1. Use InnoDB, not MyISAM.
-6. Configure `app/Config/Email.php` to allow Shield to send emails.
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
 
    ```php
    <?php
@@ -281,9 +237,6 @@ public $filters = [
 ];
 ```
 
-<<<<<<< HEAD
-> **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the **app/Config/Filter.php** file.
-=======
 ### Forcing Password Reset
 
 If your application requires the force password reset functionality, ensure that you exclude the auth pages and the actual password reset page from the `before` global. This will ensure that your users do not run into a *too many redirects* error.
@@ -300,8 +253,7 @@ public $globals = [
 
 In the example above, we assume that the page  you have created for users to change their password is *"change-password"*.
 
-> **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the `App/Config/Filter.php` file.
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)
+> **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the **App/Config/Filter.php** file.
 
 For example, if you configured your routes like so:
 
@@ -321,9 +273,5 @@ public $globals = [
     ]
 ]
 ```
-<<<<<<< HEAD
-The same should apply for the Rate Limiting.
-=======
 
 The same should apply for the Rate Limiting and Forcing Password Reset.
->>>>>>> b73ce5a (updated docs:install.md, added force password reset explanation)

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,22 +43,23 @@ Require it with an explicit version constraint allowing its desired stability.
 
 1. Run the following commands to change your [minimum-stability](https://getcomposer.org/doc/articles/versions.md#minimum-stability) in your project `composer.json`:
 
-   ```console
-   composer config minimum-stability dev
-   composer config prefer-stable true
-   ```
+    ```console
+    composer config minimum-stability dev
+    composer config prefer-stable true
+    ```
+
 2. Or specify an explicit version:
 
-   ```console
-   composer require codeigniter4/shield:dev-develop
-   ```
+    ```console
+    composer require codeigniter4/shield:dev-develop
+    ```
 
     The above specifies `develop` branch.
     See <https://getcomposer.org/doc/articles/versions.md#branches>
 
-   ```console
-   composer require codeigniter4/shield:^1.0.0-beta
-   ```
+    ```console
+    composer require codeigniter4/shield:^1.0.0-beta
+    ```
 
     The above specifies `v1.0.0-beta` or later and before `v2.0.0`.
     See <https://getcomposer.org/doc/articles/versions.md#caret-version-range->
@@ -75,28 +76,28 @@ Require it with an explicit version constraint allowing its desired stability.
 
 2. Configure **app/Config/Email.php** to allow Shield to send emails with the [Email Class](https://codeigniter.com/user_guide/libraries/email.html).
 
-   ```php
-   <?php
+    ```php
+    <?php
 
-   namespace Config;
+    namespace Config;
 
-   use CodeIgniter\Config\BaseConfig;
+    use CodeIgniter\Config\BaseConfig;
 
-   class Email extends BaseConfig
-   {
-       /**
-        * @var string
-        */
-       public $fromEmail = 'your_mail@example.com';
+    class Email extends BaseConfig
+    {
+        /**
+         * @var string
+         */
+        public $fromEmail = 'your_mail@example.com';
 
-       /**
-        * @var string
-        */
-       public $fromName = 'your name';
+        /**
+         * @var string
+         */
+        public $fromName = 'your name';
 
-       // ...
-   }
-   ```
+        // ...
+    }
+    ```
 
 ### Manual Setup
 
@@ -105,26 +106,34 @@ your project.
 
 1. Copy the **Auth.php** and  **AuthGroups.php** from **vendor/codeigniter4/shield/src/Config/** into your project's config folder and update the namespace to `Config`. You will also need to have these classes extend the original classes. See the example below. These files contain all of the settings, group, and permission information for your application and will need to be modified to meet the needs of your site.
 
-   ```php
-   // new file - app/Config/Auth.php
-   <?php
+    ```php
+    // new file - app/Config/Auth.php
+    <?php
 
-   namespace Config;
+    namespace Config;
 
-   // ...
-   use CodeIgniter\Shield\Config\Auth as ShieldAuth;
+    // ...
+    use CodeIgniter\Shield\Config\Auth as ShieldAuth;
+
+    class Auth extends ShieldAuth
+    {
+        // ...
+    }
+    ```
 
 2. **Helper Setup** The `setting` helper needs to be included in almost every page. The simplest way to do this is to add it to the `BaseController::initController()` method:
 
-   ```php
-   public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
-   {
-       $this->helpers = array_merge($this->helpers, ['setting']);
+    ```php
+    public function initController(RequestInterface $request, ResponseInterface $response, LoggerInterface $logger)
+    {
+        $this->helpers = array_merge($this->helpers, ['setting']);
 
-       // Do Not Edit This Line
-       parent::initController($request, $response, $logger);
-   }
-   ```
+        // Do Not Edit This Line
+        parent::initController($request, $response, $logger);
+    }
+    ```
+
+    This requires that all of your controllers extend the `BaseController`, but that's a good practice anyway.
 
 3. **Routes Setup** The default auth routes can be setup with a single call in **app/Config/Routes.php**:
 
@@ -136,50 +145,48 @@ your project.
 
 5. **Migration** Run the migrations.
 
-   ```console
-   php spark migrate --all
-   ```
+    ```console
+    php spark migrate --all
+    ```
 
-   #### Note: migration error
+    #### Note: migration error
 
-   When you run `spark migrate --all`, if you get `Class "SQLite3" not found` error:
+    When you run `spark migrate --all`, if you get `Class "SQLite3" not found` error:
 
     1. Remove sample migration files in **tests/_support/Database/Migrations/**
     2. Or install `sqlite3` php extension
 
-   1. Remove sample migration files in `tests/_support/Database/Migrations/`
-   2. Or install `sqlite3` php extension
+    If you get `Specified key was too long` error:
 
-   If you get `Specified key was too long` error:
+    1. Use InnoDB, not MyISAM.
 
 6. Configure **app/Config/Email.php** to allow Shield to send emails.
 
-   ```php
-   <?php
+    ```php
+    <?php
 
-   namespace Config;
+    namespace Config;
 
-   use CodeIgniter\Config\BaseConfig;
+    use CodeIgniter\Config\BaseConfig;
 
-   class Email extends BaseConfig
-   {
-       /**
-        * @var string
-        */
-       public $fromEmail = 'your_mail@example.com';
+    class Email extends BaseConfig
+    {
+        /**
+         * @var string
+         */
+        public $fromEmail = 'your_mail@example.com';
 
-       /**
-        * @var string
-        */
-       public $fromName = 'your name';
+        /**
+         * @var string
+         */
+        public $fromName = 'your name';
 
-       // ...
-   }
-   ```
+        // ...
+    }
+    ```
 
 ## Controller Filters
-
-The [Controller Filters](https://codeigniter.com/user_guide/incoming/filters.html) you can use to pr	otect your routes the shield provides are:
+The [Controller Filters](https://codeigniter.com/user_guide/incoming/filters.html) you can use to protect your routes the shield provides are:
 
 ```php
 public $aliases = [
@@ -194,14 +201,14 @@ public $aliases = [
 ];
 ```
 
-| Filters            | Description                                                                                                                                                                                                                              |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| session and tokens | The `Session` and `AccessTokens` authenticators, respectively.                                                                                                                                                                       |
-| chained            | The filter will check both authenticators in sequence to see if the user is logged in through either of authenticators, allowing a single API endpoint to work for both an SPA using session auth, and a mobile app using access tokens. |
-| auth-rates         | Provides a good basis for rate limiting of auth-related routes.                                                                                                                                                                          |
-| group              | Checks if the user is in one of the groups passed in.                                                                                                                                                                                    |
-| permission         | Checks if the user has the passed permissions.                                                                                                                                                                                           |
-| force-reset        | Checks if the user should reset their password.                                                                                                                                                                                          |
+Filters | Description
+--- | ---
+session and tokens | The `Session` and `AccessTokens` authenticators, respectively.
+chained | The filter will check both authenticators in sequence to see if the user is logged in through either of authenticators, allowing a single API endpoint to work for both an SPA using session auth, and a mobile app using access tokens.
+auth-rates | Provides a good basis for rate limiting of auth-related routes.
+group | Checks if the user is in one of the groups passed in.
+permission | Checks if the user has the passed permissions.
+force-reset | Checks if the user requires a password reset.
 
 These can be used in any of the [normal filter config settings](https://codeigniter.com/user_guide/incoming/filters.html#globals), or [within the routes file](https://codeigniter.com/user_guide/incoming/routing.html#applying-filters).
 
@@ -239,7 +246,7 @@ public $filters = [
 
 ### Forcing Password Reset
 
-If your application requires the force password reset functionality, ensure that you exclude the auth pages and the actual password reset page from the `before` global. This will ensure that your users do not run into a *too many redirects* error.
+If your application requires a force password reset functionality, ensure that you exclude the auth pages and the actual password reset page from the `before` global. This will ensure that your users do not run into a *too many redirects* error. See:
 
 ```php
 public $globals = [
@@ -250,10 +257,9 @@ public $globals = [
     ]
 ];
 ```
+In the example above, it is assumed that the page you have created for users to change their password after successful login is **change-password**.
 
-In the example above, we assume that the page  you have created for users to change their password is *"change-password"*.
-
-> **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the **App/Config/Filter.php** file.
+> **Note** If you have grouped or changed the default format of the routes, ensure that your code matches the new format(s) in the **app/Config/Filter.php** file.
 
 For example, if you configured your routes like so:
 
@@ -262,7 +268,6 @@ $routes->group('accounts', static function($routes) {
     service('auth')->routes($routes);
 });
 ```
-
 Then the global `before` filter for `session` should look like so:
 
 ```php
@@ -273,5 +278,4 @@ public $globals = [
     ]
 ]
 ```
-
 The same should apply for the Rate Limiting and Forcing Password Reset.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,6 +30,12 @@ Learning any new authentication system can be difficult, especially as they get 
     - [Creating Users](#creating-users)
     - [Deleting Users](#deleting-users)
     - [Editing a User](#editing-a-user)
+  - [Forcing Password Reset](#forcing-password-reset)
+    - [requiresPasswordReset()](#requirespasswordreset)
+    - [forcePaswordReset()](#forcepasswordreset)
+    - [undoForcePasswordReset()](#undoforcepasswordreset)
+    - [forceMultiplePasswordReset()](#forcemultiplepasswordreset)
+    - [forceGlobalPasswordReset()](#forceglobalpasswordreset)
 
 ## Authentication Flow
 
@@ -311,4 +317,62 @@ $user->fill([
     'password' => 'secret123'
 ]);
 $users->save($user);
+```
+
+## Forcing Password Reset
+
+Shield provides a way to enforce password resets throughout your application. The `Resettable` trait on the `User` entity provides the following utility methods to do so.
+
+#### requiresPasswordReset()
+
+Allows you to check if a user requires password reset. Returns boolean `true`/`false`.
+
+```php
+if ($user->requiresPasswordReset()) {
+    //...
+}
+```
+
+#### forcePasswordReset()
+
+Allows you to force password reset on a user. Returns boolean `true`/`false`.
+
+```php
+$user->forcePasswordReset();
+```
+
+#### undoForcePasswordReset()
+
+Allows you to undo or remove the force password reset flag on a user. Returns boolean `true`/`false`.
+
+```php
+$user->undoForcePasswordReset();
+```
+
+There are times when you might want to force password reset on multiple users or for all users in your application, maybe due to security breach. The `UserIdentityModel` provides methods to do this easily.
+
+#### forceMultiplePasswordReset()
+
+This allows you to force password reset for multiple users. Accepts an array of user IDs.
+
+```php
+use CodeIgniter\Shield\Models\UserIdentityModel;
+...
+...
+...
+$identities = new UserIdentityModel();
+$identities->forceMultiplePasswordReset([1,2,3,4]);
+```
+
+#### forceGlobalPasswordReset()
+
+This allows you to force password reset all the users in your application.
+
+```php
+use CodeIgniter\Shield\Models\UserIdentityModel;
+...
+...
+...
+$identities = new UserIdentityModel();
+$identities->forceGlobalPasswordReset();
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,12 +30,6 @@ Learning any new authentication system can be difficult, especially as they get 
     - [Creating Users](#creating-users)
     - [Deleting Users](#deleting-users)
     - [Editing a User](#editing-a-user)
-  - [Forcing Password Reset](#forcing-password-reset)
-    - [requiresPasswordReset()](#requirespasswordreset)
-    - [forcePaswordReset()](#forcepasswordreset)
-    - [undoForcePasswordReset()](#undoforcepasswordreset)
-    - [forceMultiplePasswordReset()](#forcemultiplepasswordreset)
-    - [forceGlobalPasswordReset()](#forceglobalpasswordreset)
 
 ## Authentication Flow
 
@@ -317,62 +311,4 @@ $user->fill([
     'password' => 'secret123'
 ]);
 $users->save($user);
-```
-
-## Forcing Password Reset
-
-Shield provides a way to enforce password resets throughout your application. The `Resettable` trait on the `User` entity provides the following utility methods to do so.
-
-#### requiresPasswordReset()
-
-Allows you to check if a user requires password reset. Returns boolean `true`/`false`.
-
-```php
-if ($user->requiresPasswordReset()) {
-    //...
-}
-```
-
-#### forcePasswordReset()
-
-Allows you to force password reset on a user. Returns boolean `true`/`false`.
-
-```php
-$user->forcePasswordReset();
-```
-
-#### undoForcePasswordReset()
-
-Allows you to undo or remove the force password reset flag on a user. Returns boolean `true`/`false`.
-
-```php
-$user->undoForcePasswordReset();
-```
-
-There are times when you might want to force password reset on multiple users or for all users in your application, maybe due to security breach. The `UserIdentityModel` provides methods to do this easily.
-
-#### forceMultiplePasswordReset()
-
-This allows you to force password reset for multiple users. Accepts an array of user IDs.
-
-```php
-use CodeIgniter\Shield\Models\UserIdentityModel;
-...
-...
-...
-$identities = new UserIdentityModel();
-$identities->forceMultiplePasswordReset([1,2,3,4]);
-```
-
-#### forceGlobalPasswordReset()
-
-This allows you to force password reset all the users in your application.
-
-```php
-use CodeIgniter\Shield\Models\UserIdentityModel;
-...
-...
-...
-$identities = new UserIdentityModel();
-$identities->forceGlobalPasswordReset();
 ```

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -52,9 +52,10 @@ class Auth extends BaseConfig
      * to apply any logic you may need.
      */
     public array $redirects = [
-        'register' => '/',
-        'login'    => '/',
-        'logout'   => 'login',
+        'register'    => '/',
+        'login'       => '/',
+        'logout'      => 'login',
+        'force_reset' => '/',
     ];
 
     /**
@@ -374,6 +375,17 @@ class Auth extends BaseConfig
     public function registerRedirect(): string
     {
         $url = setting('Auth.redirects')['register'];
+
+        return $this->getUrl($url);
+    }
+
+    /**
+     * Returns the URL the user should be redirected to
+     * if force_reset identity is set to true.
+     */
+    public function forcePasswordResetRedirect()
+    {
+        $url = setting('Auth.redirects')['force_reset'];
 
         return $this->getUrl($url);
     }

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -383,7 +383,7 @@ class Auth extends BaseConfig
      * Returns the URL the user should be redirected to
      * if force_reset identity is set to true.
      */
-    public function forcePasswordResetRedirect()
+    public function forcePasswordResetRedirect(): string
     {
         $url = setting('Auth.redirects')['force_reset'];
 

--- a/src/Config/Registrar.php
+++ b/src/Config/Registrar.php
@@ -8,6 +8,7 @@ use CodeIgniter\Shield\Authentication\Passwords\ValidationRules as PasswordRules
 use CodeIgniter\Shield\Collectors\Auth;
 use CodeIgniter\Shield\Filters\AuthRates;
 use CodeIgniter\Shield\Filters\ChainAuth;
+use CodeIgniter\Shield\Filters\ForcePasswordResetFilter;
 use CodeIgniter\Shield\Filters\GroupFilter;
 use CodeIgniter\Shield\Filters\PermissionFilter;
 use CodeIgniter\Shield\Filters\SessionAuth;
@@ -22,12 +23,13 @@ class Registrar
     {
         return [
             'aliases' => [
-                'session'    => SessionAuth::class,
-                'tokens'     => TokenAuth::class,
-                'chain'      => ChainAuth::class,
-                'auth-rates' => AuthRates::class,
-                'group'      => GroupFilter::class,
-                'permission' => PermissionFilter::class,
+                'session'     => SessionAuth::class,
+                'tokens'      => TokenAuth::class,
+                'chain'       => ChainAuth::class,
+                'auth-rates'  => AuthRates::class,
+                'group'       => GroupFilter::class,
+                'permission'  => PermissionFilter::class,
+                'force-reset' => ForcePasswordResetFilter::class,
             ],
         ];
     }

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -11,6 +11,7 @@ use CodeIgniter\Shield\Authentication\Traits\HasAccessTokens;
 use CodeIgniter\Shield\Authorization\Traits\Authorizable;
 use CodeIgniter\Shield\Models\LoginModel;
 use CodeIgniter\Shield\Models\UserIdentityModel;
+use CodeIgniter\Shield\Traits\Resettable;
 
 /**
  * @property string|null         $email
@@ -25,6 +26,7 @@ class User extends Entity
 {
     use Authorizable;
     use HasAccessTokens;
+    use Resettable;
 
     /**
      * @var UserIdentity[]|null

--- a/src/Filters/ForcePasswordResetFilter.php
+++ b/src/Filters/ForcePasswordResetFilter.php
@@ -42,10 +42,8 @@ class ForcePasswordResetFilter implements FilterInterface
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
-        if ($authenticator->loggedIn()) {
-            if (auth()->user()->requiresPasswordReset()) {
-                return redirect()->to(config('Auth')->forcePasswordResetRedirect());
-            }
+        if ($authenticator->loggedIn() && auth()->user()->requiresPasswordReset()) {
+            return redirect()->to(config('Auth')->forcePasswordResetRedirect());
         }
     }
 

--- a/src/Filters/ForcePasswordResetFilter.php
+++ b/src/Filters/ForcePasswordResetFilter.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Filters;
+
+use CodeIgniter\Filters\FilterInterface;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RedirectResponse;
+use CodeIgniter\HTTP\RequestInterface;
+use CodeIgniter\HTTP\Response;
+use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
+
+/**
+ * Force Password Reset Filter.
+ */
+class ForcePasswordResetFilter implements FilterInterface
+{
+    /**
+     * Do whatever processing this filter needs to do.
+     * By default it should not return anything during
+     * normal execution. However, when an abnormal state
+     * is found, it should return an instance of
+     * CodeIgniter\HTTP\Response. If it does, script
+     * execution will end and that Response will be
+     * sent back to the client, allowing for error pages,
+     * redirects, etc.
+     *
+     * @param array|null $arguments
+     *
+     * @return RedirectResponse|void
+     */
+    public function before(RequestInterface $request, $arguments = null)
+    {
+        if (! $request instanceof IncomingRequest) {
+            return;
+        }
+
+        helper('setting');
+
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        if ($authenticator->loggedIn()) {
+            if (auth()->user()->requiresPasswordReset()) {
+                return redirect()->to(config('Auth')->forcePasswordResetRedirect());
+            }
+        }
+    }
+
+    /**
+     * We don't have anything to do here.
+     *
+     * @param Response|ResponseInterface $response
+     * @param array|null                 $arguments
+     */
+    public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void
+    {
+    }
+}

--- a/src/Filters/ForcePasswordResetFilter.php
+++ b/src/Filters/ForcePasswordResetFilter.php
@@ -18,14 +18,9 @@ use CodeIgniter\Shield\Authentication\Authenticators\Session;
 class ForcePasswordResetFilter implements FilterInterface
 {
     /**
-     * Do whatever processing this filter needs to do.
-     * By default it should not return anything during
-     * normal execution. However, when an abnormal state
-     * is found, it should return an instance of
-     * CodeIgniter\HTTP\Response. If it does, script
-     * execution will end and that Response will be
-     * sent back to the client, allowing for error pages,
-     * redirects, etc.
+     * Checks if a logged in user should reset their
+     * password, and then redirect to the appropriate
+     * page.
      *
      * @param array|null $arguments
      *
@@ -42,7 +37,7 @@ class ForcePasswordResetFilter implements FilterInterface
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
-        if ($authenticator->loggedIn() && auth()->user()->requiresPasswordReset()) {
+        if ($authenticator->loggedIn() && $authenticator->getUser()->requiresPasswordReset()) {
             return redirect()->to(config('Auth')->forcePasswordResetRedirect());
         }
     }

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -333,26 +333,23 @@ class UserIdentityModel extends Model
      * Force password reset for multiple users.
      *
      * @param int[]|string[] $userIds
-     *
-     * @return mixed
      */
-    public function forceMultiplePasswordReset(array $userIds)
+    public function forceMultiplePasswordReset(array $userIds): void
     {
         $this->where(['type' => Session::ID_TYPE_EMAIL_PASSWORD, 'force_reset' => 0]);
         $this->whereIn('user_id', $userIds);
         $this->set('force_reset', 1);
+        $return = $this->update();
 
-        return $this->update();
+        return $this->checkQueryReturn($return);
     }
 
     /**
      * Force global password reset.
      * This is useful for enforcing a password reset
      * for ALL users incase of a security breach.
-     *
-     * @return mixed
      */
-    public function forceGlobalPasswordReset()
+    public function forceGlobalPasswordReset(): void
     {
         $whereFilter = [
             'type'        => Session::ID_TYPE_EMAIL_PASSWORD,
@@ -360,8 +357,9 @@ class UserIdentityModel extends Model
         ];
         $this->where($whereFilter);
         $this->set('force_reset', 1);
+        $return = $this->update();
 
-        return $this->update();
+        return $this->checkQueryReturn($return);
     }
 
     public function fake(Generator &$faker): UserIdentity

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -350,16 +350,11 @@ class UserIdentityModel extends Model
      * This is useful for enforcing a password reset
      * for ALL users incase of a security breach.
      *
-     * The logged in user's ID is ommitted as it is
-     * assummed that this is the admin (or superadmin)
-     * account.
-     *
      * @return mixed
      */
     public function forceGlobalPasswordReset()
     {
         $whereFilter = [
-            'user_id !='  => user_id(),
             'type'        => Session::ID_TYPE_EMAIL_PASSWORD,
             'force_reset' => 0,
         ];

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -329,13 +329,53 @@ class UserIdentityModel extends Model
         $this->checkQueryReturn($return);
     }
 
+    /**
+     * Force password reset for multiple users.
+     *
+     * @param int[]|string[] $userIds
+     *
+     * @return mixed
+     */
+    public function forceMultiplePasswordReset(array $userIds)
+    {
+        $this->where(['type' => Session::ID_TYPE_EMAIL_PASSWORD, 'force_reset' => false]);
+        $this->whereIn('user_id', $userIds);
+        $this->set('force_reset', true);
+
+        return $this->update();
+    }
+
+    /**
+     * Force global password reset.
+     * This is useful for enforcing a password reset
+     * for ALL users incase of a security breach.
+     *
+     * The logged in user's ID is ommitted as it is
+     * assummed that this is the admin (or superadmin)
+     * account.
+     *
+     * @return mixed
+     */
+    public function forceGlobalPasswordReset()
+    {
+        $whereFilter = [
+            'user_id !='  => user_id(),
+            'type'        => Session::ID_TYPE_EMAIL_PASSWORD,
+            'force_reset' => false,
+        ];
+        $this->where($whereFilter);
+        $this->set('force_reset', true);
+
+        return $this->update();
+    }
+
     public function fake(Generator &$faker): UserIdentity
     {
         return new UserIdentity([
             'user_id'      => fake(UserModel::class)->id,
             'type'         => Session::ID_TYPE_EMAIL_PASSWORD,
             'name'         => null,
-            'secret'       => 'info@example.com',
+            'secret'       => $faker->email,
             'secret2'      => password_hash('secret', PASSWORD_DEFAULT),
             'expires'      => null,
             'extra'        => null,

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -341,7 +341,7 @@ class UserIdentityModel extends Model
         $this->set('force_reset', 1);
         $return = $this->update();
 
-        return $this->checkQueryReturn($return);
+        $this->checkQueryReturn($return);
     }
 
     /**
@@ -359,7 +359,7 @@ class UserIdentityModel extends Model
         $this->set('force_reset', 1);
         $return = $this->update();
 
-        return $this->checkQueryReturn($return);
+        $this->checkQueryReturn($return);
     }
 
     public function fake(Generator &$faker): UserIdentity

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -338,7 +338,7 @@ class UserIdentityModel extends Model
      */
     public function forceMultiplePasswordReset(array $userIds)
     {
-        $this->where(['type' => Session::ID_TYPE_EMAIL_PASSWORD, 'force_reset' => false]);
+        $this->where(['type' => Session::ID_TYPE_EMAIL_PASSWORD, 'force_reset' => 0]);
         $this->whereIn('user_id', $userIds);
         $this->set('force_reset', 1);
 

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -340,7 +340,7 @@ class UserIdentityModel extends Model
     {
         $this->where(['type' => Session::ID_TYPE_EMAIL_PASSWORD, 'force_reset' => false]);
         $this->whereIn('user_id', $userIds);
-        $this->set('force_reset', true);
+        $this->set('force_reset', 1);
 
         return $this->update();
     }
@@ -361,10 +361,10 @@ class UserIdentityModel extends Model
         $whereFilter = [
             'user_id !='  => user_id(),
             'type'        => Session::ID_TYPE_EMAIL_PASSWORD,
-            'force_reset' => false,
+            'force_reset' => 0,
         ];
         $this->where($whereFilter);
-        $this->set('force_reset', true);
+        $this->set('force_reset', 1);
 
         return $this->update();
     }

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -151,7 +151,7 @@ class UserModel extends Model
     public function fake(Generator &$faker): User
     {
         return new User([
-            'username' => $faker->userName,
+            'username' => $faker->unique()->userName,
             'active'   => true,
         ]);
     }

--- a/src/Traits/Resettable.php
+++ b/src/Traits/Resettable.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Traits;
+
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
+use CodeIgniter\Shield\Models\UserIdentityModel;
+
+/**
+ * Reusable methods to help the
+ * enforcing of password resets
+ */
+trait Resettable
+{
+    /**
+     * Returns true|false based on the value of the
+     * force reset column of the user's identity.
+     */
+    public function requiresPasswordReset(): bool
+    {
+        $identity_model = model(UserIdentityModel::class);
+        $identity       = $identity_model->getIdentityByType($this, Session::ID_TYPE_EMAIL_PASSWORD);
+
+        return $identity->force_reset;
+    }
+
+    /**
+     * Force password reset
+     */
+    public function forcePasswordReset(): bool
+    {
+        // Do nothing if user already requires reset
+        if ($this->requiresPasswordReset()) {
+            return true;
+        }
+
+        // Set force_reset to true
+        $identity_model = model(UserIdentityModel::class);
+        $identity_model->set('force_reset', true);
+        $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
+
+        return $identity_model->update();
+    }
+
+    /**
+     * Undo Force password reset
+     */
+    public function undoForcePasswordReset(): bool
+    {
+        // If user doesn't require password reset, do nothing
+        if ($this->requiresPasswordReset() === false) {
+            return true;
+        }
+
+        // Set force_reset to false
+        $identity_model = model(UserIdentityModel::class);
+        $identity_model->set('force_reset', false);
+        $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
+
+        return $identity_model->update();
+    }
+}

--- a/src/Traits/Resettable.php
+++ b/src/Traits/Resettable.php
@@ -39,9 +39,7 @@ trait Resettable
         $identity_model = model(UserIdentityModel::class);
         $identity_model->set('force_reset', 1);
         $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
-        $result = $identity_model->update();
-
-        return $this->checkQueryReturn($result);
+        $identity_model->update();
     }
 
     /**
@@ -58,8 +56,6 @@ trait Resettable
         $identity_model = model(UserIdentityModel::class);
         $identity_model->set('force_reset', 0);
         $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
-        $return = $identity_model->update();
-
-        return $this->checkQueryReturn($return);
+        $identity_model->update();
     }
 }

--- a/src/Traits/Resettable.php
+++ b/src/Traits/Resettable.php
@@ -28,36 +28,38 @@ trait Resettable
     /**
      * Force password reset
      */
-    public function forcePasswordReset(): bool
+    public function forcePasswordReset(): void
     {
         // Do nothing if user already requires reset
         if ($this->requiresPasswordReset()) {
-            return true;
+            return;
         }
 
         // Set force_reset to true
         $identity_model = model(UserIdentityModel::class);
         $identity_model->set('force_reset', 1);
         $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
+        $result = $identity_model->update();
 
-        return $identity_model->update();
+        return $this->checkQueryReturn($result);
     }
 
     /**
      * Undo Force password reset
      */
-    public function undoForcePasswordReset(): bool
+    public function undoForcePasswordReset(): void
     {
         // If user doesn't require password reset, do nothing
         if ($this->requiresPasswordReset() === false) {
-            return true;
+            return;
         }
 
         // Set force_reset to false
         $identity_model = model(UserIdentityModel::class);
         $identity_model->set('force_reset', 0);
         $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
+        $return = $identity_model->update();
 
-        return $identity_model->update();
+        return $this->checkQueryReturn($return);
     }
 }

--- a/src/Traits/Resettable.php
+++ b/src/Traits/Resettable.php
@@ -37,7 +37,7 @@ trait Resettable
 
         // Set force_reset to true
         $identity_model = model(UserIdentityModel::class);
-        $identity_model->set('force_reset', true);
+        $identity_model->set('force_reset', 1);
         $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
 
         return $identity_model->update();
@@ -55,7 +55,7 @@ trait Resettable
 
         // Set force_reset to false
         $identity_model = model(UserIdentityModel::class);
-        $identity_model->set('force_reset', false);
+        $identity_model->set('force_reset', 0);
         $identity_model->where(['user_id' => $this->id, 'type' => Session::ID_TYPE_EMAIL_PASSWORD]);
 
         return $identity_model->update();

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -44,15 +44,11 @@ final class ForcePasswordResetTest extends TestCase
 
     public function testUserRequiresPasswordReset(): void
     {
-        /**
-         * @phpstan-var User
-         */
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
 
-        /**
-         * @phpstan-var UserIdentityModel
-         */
+        /** @var UserIdentityModel $identity */
         $identity = model(UserIdentityModel::class);
         $identity->set('force_reset', 1);
         $identity->where('user_id', $user->id);
@@ -63,9 +59,7 @@ final class ForcePasswordResetTest extends TestCase
 
     public function testForcePasswordResetOnUser(): void
     {
-        /**
-         * @phpstan-var User
-         */
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
         $user->forcePasswordReset();
@@ -75,9 +69,7 @@ final class ForcePasswordResetTest extends TestCase
 
     public function testUndoForcePasswordResetOnUser(): void
     {
-        /**
-         * @phpstan-var User
-         */
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
         $user->forcePasswordReset();
@@ -88,9 +80,7 @@ final class ForcePasswordResetTest extends TestCase
 
     public function testRequiresPasswordResetRedirect(): void
     {
-        /**
-         * @phpstan-var User
-         */
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
         $user->forcePasswordReset();
@@ -104,22 +94,16 @@ final class ForcePasswordResetTest extends TestCase
 
     public function testForceGlobalPasswordReset(): void
     {
-        /**
-         * @phpstan-var User
-         */
+        /** @var User $user */
         $user = fake(UserModel::class);
         $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
         $this->actingAs($user);
 
-        /**
-         * @phpstan-var Fabricator
-         */
+        /** @var Fabricator $fabricator */
         $fabricator = new Fabricator(UserIdentityModel::class);
         $fabricator->create(50);
 
-        /**
-         * @phpstan-var UserIdentityModel
-         */
+        /** @var UserIdentityModel $identities */
         $identities = model(UserIdentityModel::class);
         $identities->forceGlobalPasswordReset();
 

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -121,8 +121,8 @@ final class ForcePasswordResetTest extends TestCase
          * @phpstan-var UserIdentityModel
          */
         $identities = model(UserIdentityModel::class);
+        $identities->forceGlobalPasswordReset();
 
-        $this->assertNotFalse($identities->forceGlobalPasswordReset());
         $this->assertTrue($user->requiresPasswordReset());
     }
 }

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -115,7 +115,7 @@ final class ForcePasswordResetTest extends TestCase
          * @phpstan-var Fabricator
          */
         $fabricator = new Fabricator(UserIdentityModel::class);
-        $fabricator->create(100);
+        $fabricator->create(50);
 
         /**
          * @phpstan-var UserIdentityModel

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Authentication;
+
+use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Models\UserIdentityModel;
+use CodeIgniter\Shield\Models\UserModel;
+use CodeIgniter\Shield\Test\AuthenticationTesting;
+use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\FeatureTestTrait;
+use Config\Services;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class ForcePasswordResetTest extends TestCase
+{
+    use DatabaseTestTrait;
+    use FeatureTestTrait;
+    use AuthenticationTesting;
+
+    protected $refresh = true;
+    protected $namespace;
+    protected $routeFilter = 'force-reset';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Load our Auth routes in the collection
+        $routeCollection = service('routes');
+        auth()->routes($routeCollection);
+
+        $routeCollection->get('profile', static function (): void {
+            echo 'Profile';
+        }, ['filter' => $this->routeFilter]);
+
+        Services::injectMock('routes', $routeCollection);
+    }
+
+    public function testUserRequiresPasswordReset(): void
+    {
+        /**
+         * @phpstan-var User
+         */
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+
+        /**
+         * @phpstan-var UserIdentityModel
+         */
+        $identity = model(UserIdentityModel::class);
+        $identity->set('force_reset', true);
+        $identity->where('user_id', $user->id);
+        $identity->update();
+
+        $this->assertTrue($user->requiresPasswordReset());
+    }
+
+    public function testForcePasswordResetOnUser(): void
+    {
+        /**
+         * @phpstan-var User
+         */
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+        $user->forcePasswordReset();
+
+        $this->assertTrue($user->requiresPasswordReset());
+    }
+
+    public function testUndoForcePasswordResetOnUser(): void
+    {
+        /**
+         * @phpstan-var User
+         */
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+        $user->forcePasswordReset();
+        $user->undoForcePasswordReset();
+
+        $this->assertFalse($user->requiresPasswordReset());
+    }
+
+    public function testRequiresPasswordResetRedirect(): void
+    {
+        /**
+         * @phpstan-var User
+         */
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+        $user->forcePasswordReset();
+
+        $result = $this->actingAs($user)->get('profile');
+
+        // This should redirect to the stated url in Auth redirects
+        $result->assertStatus(302);
+        $result->assertRedirectTo(config('Auth')->forcePasswordResetRedirect());
+    }
+}

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -122,8 +122,7 @@ final class ForcePasswordResetTest extends TestCase
          */
         $identities = model(UserIdentityModel::class);
 
-        $response = $identities->forceGlobalPasswordReset();
-        $this->assertTrue($response);
+        $this->assertNotFalse($identities->forceGlobalPasswordReset());
         $this->assertTrue($user->requiresPasswordReset());
     }
 }

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -9,6 +9,7 @@ use CodeIgniter\Shield\Models\UserIdentityModel;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Test\AuthenticationTesting;
 use CodeIgniter\Test\DatabaseTestTrait;
+use CodeIgniter\Test\Fabricator;
 use CodeIgniter\Test\FeatureTestTrait;
 use Config\Services;
 use Tests\Support\TestCase;
@@ -99,5 +100,30 @@ final class ForcePasswordResetTest extends TestCase
         // This should redirect to the stated url in Auth redirects
         $result->assertStatus(302);
         $result->assertRedirectTo(config('Auth')->forcePasswordResetRedirect());
+    }
+
+    public function testForceGlobalPasswordReset(): void
+    {
+        /**
+         * @phpstan-var User
+         */
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+        $this->actingAs($user);
+
+        /**
+         * @phpstan-var Fabricator
+         */
+        $fabricator = new Fabricator(UserIdentityModel::class);
+        $fabricator->create(100);
+
+        /**
+         * @phpstan-var UserIdentityModel
+         */
+        $identities = model(UserIdentityModel::class);
+
+        $response = $identities->forceGlobalPasswordReset();
+        $this->assertTrue($response);
+        $this->assertFalse($user->requiresPasswordReset());
     }
 }

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -54,7 +54,7 @@ final class ForcePasswordResetTest extends TestCase
          * @phpstan-var UserIdentityModel
          */
         $identity = model(UserIdentityModel::class);
-        $identity->set('force_reset', true);
+        $identity->set('force_reset', 1);
         $identity->where('user_id', $user->id);
         $identity->update();
 

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -124,6 +124,6 @@ final class ForcePasswordResetTest extends TestCase
 
         $response = $identities->forceGlobalPasswordReset();
         $this->assertTrue($response);
-        $this->assertFalse($user->requiresPasswordReset());
+        $this->assertTrue($user->requiresPasswordReset());
     }
 }

--- a/tests/Authentication/ForcePasswordResetTest.php
+++ b/tests/Authentication/ForcePasswordResetTest.php
@@ -25,7 +25,7 @@ final class ForcePasswordResetTest extends TestCase
 
     protected $refresh = true;
     protected $namespace;
-    protected $routeFilter = 'force-reset';
+    private string $routeFilter = 'force-reset';
 
     protected function setUp(): void
     {

--- a/tests/Unit/UserIdentityModelTest.php
+++ b/tests/Unit/UserIdentityModelTest.php
@@ -93,7 +93,6 @@ final class UserIdentityModelTest extends TestCase
             $userIds[] = $row->user_id;
         }
 
-        $response = $identities->forceMultiplePasswordReset($userIds);
-        $this->assertTrue($response);
+        $this->assertNotFalse($identities->forceMultiplePasswordReset($userIds));
     }
 }

--- a/tests/Unit/UserIdentityModelTest.php
+++ b/tests/Unit/UserIdentityModelTest.php
@@ -93,6 +93,16 @@ final class UserIdentityModelTest extends TestCase
             $userIds[] = $row->user_id;
         }
 
-        $this->assertNotFalse($identities->forceMultiplePasswordReset($userIds));
+        $identities->forceMultiplePasswordReset($userIds);
+
+        /**
+         * @phpstan-var UserModel
+         */
+        $users      = model(UserModel::class);
+        $first_user = $users->findById($userIds[0]);
+        $last_user  = $users->findById($userIds[9]);
+
+        $this->assertTrue($first_user->requiresPasswordReset());
+        $this->assertTrue($last_user->requiresPasswordReset());
     }
 }

--- a/tests/Unit/UserIdentityModelTest.php
+++ b/tests/Unit/UserIdentityModelTest.php
@@ -9,7 +9,6 @@ use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\DatabaseException;
 use CodeIgniter\Shield\Models\UserIdentityModel;
 use CodeIgniter\Shield\Models\UserModel;
-use CodeIgniter\Shield\Test\AuthenticationTesting;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\Fabricator;
 use Tests\Support\TestCase;
@@ -20,7 +19,6 @@ use Tests\Support\TestCase;
 final class UserIdentityModelTest extends TestCase
 {
     use DatabaseTestTrait;
-    use AuthenticationTesting;
 
     protected $namespace;
     protected $refresh = true;
@@ -97,30 +95,5 @@ final class UserIdentityModelTest extends TestCase
 
         $response = $identities->forceMultiplePasswordReset($userIds);
         $this->assertTrue($response);
-    }
-
-    public function testforceGlobalPasswordReset(): void
-    {
-        /**
-         * @phpstan-var User
-         */
-        $user = fake(UserModel::class);
-        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
-        $this->actingAs($user);
-
-        /**
-         * @phpstan-var Fabricator
-         */
-        $fabricator = new Fabricator(UserIdentityModel::class);
-        $fabricator->create(100);
-
-        /**
-         * @phpstan-var UserIdentityModel
-         */
-        $identities = model(UserIdentityModel::class);
-
-        $response = $identities->forceGlobalPasswordReset();
-        $this->assertTrue($response);
-        $this->assertFalse($user->requiresPasswordReset());
     }
 }

--- a/tests/Unit/UserIdentityModelTest.php
+++ b/tests/Unit/UserIdentityModelTest.php
@@ -76,15 +76,11 @@ final class UserIdentityModelTest extends TestCase
 
     public function testForceMultiplePasswordReset(): void
     {
-        /**
-         * @phpstan-var Fabricator
-         */
+        /** @var Fabricator $fabricator */
         $fabricator = new Fabricator(UserIdentityModel::class);
         $fabricator->create(10);
 
-        /**
-         * @phpstan-var UserIdentityModel
-         */
+        /** @var UserIdentityModel $identities */
         $identities = model(UserIdentityModel::class);
         $result     = $identities->select('user_id')->findAll();
         $userIds    = [];
@@ -95,9 +91,7 @@ final class UserIdentityModelTest extends TestCase
 
         $identities->forceMultiplePasswordReset($userIds);
 
-        /**
-         * @phpstan-var UserModel
-         */
+        /** @var UserModel $users */
         $users      = model(UserModel::class);
         $first_user = $users->findById($userIds[0]);
         $last_user  = $users->findById($userIds[9]);


### PR DESCRIPTION
Fixes #522 

Implemented the force password reset functionality with the following highlights:
- Added a new `Resettable` trait that is used on the `User` entity. This provides a couple of methods to check if a user requires a password reset or not, forcing a password reset and undoing the forced password reset. Thanks @lonnieezell 
- Updated the `UserIdentityModel` with methods to force a password reset for multiple users and globally, i.e., all the users.
- Added a filter `ForcePasswordResetFilter` to check and redirect appropriately after a user is logged in.
- Updated the `Registrar` config.
- Updated `Auth` config to allow devs to specify a `force_reset` redirect.
- Updated `quickstart.md` and `install.md` docs.
- And of course, created and updated tests.