### PR TITLE
refactor: remove `namespace` from language files

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -97,6 +97,7 @@ return static function (RectorConfig $rectorConfig): void {
         // Ignore files that should not be namespaced to their folder
         NormalizeNamespaceByPSR4ComposerAutoloadRector::class => [
             __DIR__ . '/src/Helpers',
+            __DIR__ . '/src/Language',
             __DIR__ . '/tests/_support',
         ],
 

--- a/src/Language/de/Auth.php
+++ b/src/Language/de/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\de;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} ist kein gültiger Authentifikator.',

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\en;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} is not a valid authenticator.',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\es;
-
 return [
     // Excepciones
     'unknownAuthenticator'  => '{0} no es un handler válido.',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -2,17 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * This file is part of CodeIgniter 4 framework.
- *
- * (c) CodeIgniter Foundation <admin@codeigniter.com>
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- */
-
-namespace CodeIgniter\Shield\Language\fa;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} احراز هویت معتبری نمی باشد.',

--- a/src/Language/fr/Auth.php
+++ b/src/Language/fr/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\fr;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} n\'est pas un authentificateur valide.',

--- a/src/Language/id/Auth.php
+++ b/src/Language/id/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\id;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} bukan otentikator yang sah.',

--- a/src/Language/it/Auth.php
+++ b/src/Language/it/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\it;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} non è un autenticatore valido.',

--- a/src/Language/ja/Auth.php
+++ b/src/Language/ja/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\ja;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} は有効なオーセンティケーターではありません。', // '{0} is not a valid authenticator.',

--- a/src/Language/sk/Auth.php
+++ b/src/Language/sk/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\sk;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} nie je platný autentifikátor.',

--- a/src/Language/tr/Auth.php
+++ b/src/Language/tr/Auth.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace CodeIgniter\Shield\Language\tr;
-
 return [
     // Exceptions
     'unknownAuthenticator'  => '{0} geçerli bir kimlik doğrulayıcı değil.',


### PR DESCRIPTION
 CI4 is built for PHP 7.4+, and everything in the framework is namespaced,
  except for the helper and lang files.

see https://github.com/codeigniter4/CodeIgniter4/pull/7210