### PR TITLE
refactor: replace deprecated Faker property access

### DIFF
--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -105,9 +105,9 @@ class LoginModel extends Model
     public function fake(Generator &$faker): Login
     {
         return new Login([
-            'ip_address' => $faker->ipv4,
+            'ip_address' => $faker->ipv4(),
             'id_type'    => Session::ID_TYPE_EMAIL_PASSWORD,
-            'identifier' => $faker->email,
+            'identifier' => $faker->email(),
             'user_id'    => null,
             'date'       => Time::parse('-1 day')->format('Y-m-d H:i:s'),
             'success'    => true,

--- a/src/Models/TokenLoginModel.php
+++ b/src/Models/TokenLoginModel.php
@@ -18,7 +18,7 @@ class TokenLoginModel extends LoginModel
     public function fake(Generator &$faker): Login
     {
         return new Login([
-            'ip_address' => $faker->ipv4,
+            'ip_address' => $faker->ipv4(),
             'identifier' => 'token: ' . random_string('crypto', 64),
             'user_id'    => fake(UserModel::class)->id,
             'date'       => Time::parse('-1 day')->format('Y-m-d H:i:s'),

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -368,7 +368,7 @@ class UserIdentityModel extends Model
             'user_id'      => fake(UserModel::class)->id,
             'type'         => Session::ID_TYPE_EMAIL_PASSWORD,
             'name'         => null,
-            'secret'       => $faker->email,
+            'secret'       => $faker->email(),
             'secret2'      => password_hash('secret', PASSWORD_DEFAULT),
             'expires'      => null,
             'extra'        => null,

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -151,7 +151,7 @@ class UserModel extends Model
     public function fake(Generator &$faker): User
     {
         return new User([
-            'username' => $faker->unique()->userName,
+            'username' => $faker->unique()->userName(),
             'active'   => true,
         ]);
     }


### PR DESCRIPTION
E.g. ErrorException: Since fakerphp/faker 1.14: Accessing property "userName" is deprecated, use "userName()" instead.

Try:
```
$ CODEIGNITER_SCREAM_DEPRECATIONS=true composer test
```