### PR TITLE
Add returnLink to login view with localizations

### DIFF
--- a/src/Language/de/Auth.php
+++ b/src/Language/de/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Prüfen Sie Ihre E-Mail!',
     'magicLinkDetails'   => 'Wir haben Ihnen gerade eine E-Mail mit einem Login-Link geschickt. Er ist nur für {0} Minuten gültig.',
     'successLogout'      => 'Sie haben sich erfolgreich abgemeldet.',
+    'returnLink'         => 'Zurückkehren zu ➔',
 
     // Passwords
     'errorPasswordLength'       => 'Passwörter müssen mindestens {0, number} Zeichen lang sein.',

--- a/src/Language/en/Auth.php
+++ b/src/Language/en/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Check your email!',
     'magicLinkDetails'   => 'We just sent you an email with a Login link inside. It is only valid for {0} minutes.',
     'successLogout'      => 'You have successfully logged out.',
+    'returnLink'         => 'Return to ➔',
 
     // Passwords
     'errorPasswordLength'       => 'Passwords must be at least {0, number} characters long.',

--- a/src/Language/es/Auth.php
+++ b/src/Language/es/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Comprueba tu email',
     'magicLinkDetails'   => 'Te hemos enviado un email que contiene un enlace para Entrar. Solo es válido durante {0} minutos.',
     'successLogout'      => 'Has salido de forma correcta.',
+    'returnLink'         => 'Volver a ➔',
 
     // Contraseñas
     'errorPasswordLength'       => 'La contraseña debe tener al menos {0, number} caracteres.',

--- a/src/Language/fa/Auth.php
+++ b/src/Language/fa/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'ایمیلتان را بررسی کنید!',
     'magicLinkDetails'   => 'ما فقط یک لینک ورود به ایمیلتان ارسال کردیم. این لینک فقط برای {0} دقیقه معتبر خواهد بود.',
     'successLogout'      => 'با موفقیت خارج شدید.',
+    'returnLink'         => ' ➔',
 
     // Passwords
     'errorPasswordLength'       => 'طول رمز های عبور باید حداقل {0, number} کاراکتر باشد.',

--- a/src/Language/fr/Auth.php
+++ b/src/Language/fr/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Vérifier votre email !',
     'magicLinkDetails'   => 'Nous venons de vous envoyer un email contenant un lien de connexion. Il n\'est valable que {0} minutes.',
     'successLogout'      => 'Vous avez été déconnecté avec succès.',
+    'returnLink'         => 'Retourner à ➔',
 
     // Passwords
     'errorPasswordLength'       => 'Le mot de passe doit contenir au moins {0, number} caractères.',

--- a/src/Language/id/Auth.php
+++ b/src/Language/id/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Periksa email Anda!',
     'magicLinkDetails'   => 'Kami baru saja mengirimi Anda email dengan tautan Masuk di dalamnya. Ini hanya berlaku selama {0} menit.',
     'successLogout'      => 'Anda telah berhasil keluar.',
+    'returnLink'         => ' ➔',
 
     // Passwords
     'errorPasswordLength'       => 'Kata sandi harus setidaknya terdiri dari {0, number} karakter.',

--- a/src/Language/it/Auth.php
+++ b/src/Language/it/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Controlla la tua email!',
     'magicLinkDetails'   => 'Ti abbiamo appena inviato una mail contenente un Login link. È valido solo per {0} minuti.',
     'successLogout'      => 'Hai effettuato il logout con successo.',
+    'returnLink'         => 'Ritornare a ➔',
 
     // Passwords
     'errorPasswordLength'       => 'Le password devono essere lunghe almeno {0, number} ccaratteri.',

--- a/src/Language/ja/Auth.php
+++ b/src/Language/ja/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'メールをチェックしてください！', // 'Check your email!',
     'magicLinkDetails'   => 'ログインリンクが含まれたメールを送信しました。これは {0} 分間だけ有効です。', // 'We just sent you an email with a Login link inside. It is only valid for {0} minutes.',
     'successLogout'      => '正常にログアウトしました。', // 'You have successfully logged out.',
+    'returnLink'         => '戻る ➔', // Return to...
 
     // Passwords
     'errorPasswordLength'       => 'パスワードは最低でも {0, number} 文字でなければなりません。', // 'Passwords must be at least {0, number} characters long.',

--- a/src/Language/pt-BR/Auth.php
+++ b/src/Language/pt-BR/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Verifique seu e-mail!',
     'magicLinkDetails'   => 'Acabamos de enviar um e-mail com um link de Login. Ele é válido apenas por {0} minutos.',
     'successLogout'      => 'Você saiu com sucesso.',
+    'returnLink'         => 'Voltou para ➔',
 
     // Senhas
     'errorPasswordLength'       => 'As senhas devem ter pelo menos {0, number} caracteres.',

--- a/src/Language/sk/Auth.php
+++ b/src/Language/sk/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'Skontrolujte e-mail',
     'magicLinkDetails'   => 'Práve sme vám poslali e-mail s odkazom na prihlásenie. Platí iba {0} minút.',
     'successLogout'      => 'Úspešne ste sa odhlásili.',
+    'returnLink'         => 'Návrat do ➔',
 
     // Passwords
     'errorPasswordLength'       => 'Heslá musia mať aspoň {0, number} znakov.',

--- a/src/Language/tr/Auth.php
+++ b/src/Language/tr/Auth.php
@@ -46,6 +46,7 @@ return [
     'checkYourEmail'     => 'E-postanı kontrol et!',
     'magicLinkDetails'   => 'Az önce size içinde bir Giriş bağlantısı olan bir e-posta gönderdik. Bağlantı {0} dakika için geçerlidir.',
     'successLogout'      => 'Başarıyla çıkış yaptınız.',
+    'returnLink'         => 'Geri vermek ➔',
 
     // Passwords
     'errorPasswordLength'       => 'Şifre en az {0, number} karakter uzunluğunda olmalıdır.',

--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -63,6 +63,8 @@
                         <p class="text-center"><?= lang('Auth.needAccount') ?> <a href="<?= url_to('register') ?>"><?= lang('Auth.register') ?></a></p>
                     <?php endif ?>
 
+                    <p class="text-center"><?= lang('Auth.returnLink') ?> <a href="<?= base_url() ?>"><?= base_url() ?></a></p>
+
                 </form>
             </div>
         </div>


### PR DESCRIPTION
A convenience addition to the login view: a small link back to the base url. Useful especially after a logout if a custom redirect hasn't been defined.

Perhaps needs a setting to enable disable?