### PR TITLE
fix: protect route `change-password` via `force_reset` if usre not login

### DIFF
--- a/src/Filters/ForcePasswordResetFilter.php
+++ b/src/Filters/ForcePasswordResetFilter.php
@@ -37,6 +37,10 @@ class ForcePasswordResetFilter implements FilterInterface
         /** @var Session $authenticator */
         $authenticator = auth('session')->getAuthenticator();
 
+        if (! $authenticator->loggedIn()) {
+            return redirect()->route('login')->with('error', lang('Auth.notEnoughPrivilege'));
+        }
+
         if ($authenticator->loggedIn() && $authenticator->getUser()->requiresPasswordReset()) {
             return redirect()->to(config('Auth')->forcePasswordResetRedirect());
         }

--- a/src/Filters/ForcePasswordResetFilter.php
+++ b/src/Filters/ForcePasswordResetFilter.php
@@ -41,7 +41,7 @@ class ForcePasswordResetFilter implements FilterInterface
             return redirect()->route('login')->with('error', lang('Auth.notEnoughPrivilege'));
         }
 
-        if ($authenticator->loggedIn() && $authenticator->getUser()->requiresPasswordReset()) {
+        if ($authenticator->getUser()->requiresPasswordReset()) {
             return redirect()->to(config('Auth')->forcePasswordResetRedirect());
         }
     }


### PR DESCRIPTION
Hello,
filter `session `may not be used as `globals`.
So a user should not have access to page **change-password**.
I don't consider it a good practice not to control this issue in filter `force_reset`. 