### PR TITLE
chore: fix workflow docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: docs 
+name: docs
 on:
   push:
     branches:
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/codeigniter4/shield/actions/runs/4454434810/jobs/7823617312
```
Run mkdocs gh-deploy --force
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /home/runner/work/shield/shield/site
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - banning_users.md
  - forcing_password_reset.md
INFO     -  Documentation built in 0.46 seconds
WARNING  -  Version check skipped: No version specified in previous deployment.
INFO     -  Copying '/home/runner/work/shield/shield/site' to 'gh-pages' branch and pushing to GitHub.
remote: Permission to codeigniter4/shield.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/codeigniter4/shield/': The requested URL returned error: 403
```

Ref https://squidfunk.github.io/mkdocs-material/publishing-your-site/#github-pages
