### PR TITLE
fix: only validate data from POST request body

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -47,7 +47,7 @@ class LoginController extends BaseController
         // like the password, can only be validated properly here.
         $rules = $this->getValidationRules();
 
-        if (! $this->validate($rules)) {
+        if (! $this->validateData($this->request->getPost(), $rules)) {
             return redirect()->back()->withInput()->with('errors', $this->validator->getErrors());
         }
 

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -65,7 +65,7 @@ class MagicLinkController extends BaseController
     {
         // Validate email format
         $rules = $this->getValidationRules();
-        if (! $this->validate($rules)) {
+        if (! $this->validateData($this->request->getPost(), $rules)) {
             return redirect()->route('magic-link')->with('errors', $this->validator->getErrors());
         }
 

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -100,7 +100,7 @@ class RegisterController extends BaseController
         // like the password, can only be validated properly here.
         $rules = $this->getValidationRules();
 
-        if (! $this->validate($rules)) {
+        if (! $this->validateData($this->request->getPost(), $rules)) {
             return redirect()->back()->withInput()->with('errors', $this->validator->getErrors());
         }
 


### PR DESCRIPTION
With the current data validation checks in the controllers, an empty POST request with valid GET parameters will cause the validation to pass. Since this data is always later fetched from the POST request body, it will be null and errors will be thrown.