### PR TITLE
docs: update guides/mobile_apps.md

### DIFF
--- a/docs/guides/mobile_apps.md
+++ b/docs/guides/mobile_apps.md
@@ -40,8 +40,13 @@ class LoginController extends BaseController
                 ->setStatusCode(422);
         }
 
+        // Get the credentials for login
+        $credentials             = $this->request->getPost(setting('Auth.validFields'));
+        $credentials             = array_filter($credentials);
+        $credentials['password'] = $this->request->getPost('password');
+        
         // Attempt to login
-        $result = auth()->attempt($this->request->getPost(setting('Auth.validFields')));
+        $result = auth()->attempt($credentials);
         if (! $result->isOK()) {
             return $this->response
                 ->setJSON(['error' => $result->reason()])

--- a/docs/guides/mobile_apps.md
+++ b/docs/guides/mobile_apps.md
@@ -32,6 +32,10 @@ class LoginController extends BaseController
                 'label' => 'Auth.password',
                 'rules' => 'required',
             ],
+            'device_name' => [
+                'label' => 'Device Name',
+                'rules' => 'required|string',
+            ],
         ];
 
         if (! $this->validateData($this->request->getPost(), $rules)) {


### PR DESCRIPTION
1. Currently, the documentation on mobile apps does not include the password field for logging in, which makes the request to fail. This PR adds the complete credentials for logging in, as seen below:
https://github.com/codeigniter4/shield/blob/799c6477504dac7dc0dc45e2e9c1d8a063e23ca8/src/Controllers/LoginController.php#L54-L56

2. The `device_name` POST request is required to generate the access token, so, it is supposed to be included in the validation rules. Not passing it returns this error:
```
Argument 1 passed to CodeIgniter\\Shield\\Entities\\User::generateAccessToken() must be of the type string, null given
```