### PR TITLE
docs: change the status code from 422 to 401

### DIFF
--- a/docs/guides/mobile_apps.md
+++ b/docs/guides/mobile_apps.md
@@ -41,14 +41,14 @@ class LoginController extends BaseController
         if (! $this->validateData($this->request->getPost(), $rules)) {
             return $this->response
                 ->setJSON(['errors' => $this->validator->getErrors()])
-                ->setStatusCode(422);
+                ->setStatusCode(401);
         }
 
         // Get the credentials for login
         $credentials             = $this->request->getPost(setting('Auth.validFields'));
         $credentials             = array_filter($credentials);
         $credentials['password'] = $this->request->getPost('password');
-        
+
         // Attempt to login
         $result = auth()->attempt($credentials);
         if (! $result->isOK()) {


### PR DESCRIPTION
There is no need to change the status code since a validation error is still an authentication failure. 
See https://github.com/codeigniter4/shield/pull/195#discussion_r1173193039

> [15.5.21. ](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.21)[422 Unprocessable Content](https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content)
>
> The 422 (Unprocessable Content) status code indicates that the server understands the content type of the request content (hence a [415 (Unsupported Media Type)](https://www.rfc-editor.org/rfc/rfc9110.html#status.415) status code is inappropriate), and the syntax of the request content is correct, but it was unable to process the contained instructions. For example, this status code can be sent if an XML request content contains well-formed (i.e., syntactically correct), but semantically erroneous XML instructions.
>
> http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.21
