### PR TITLE
fix: typo in `getMaxLengthRule()` method name

### DIFF
--- a/src/Authentication/Passwords.php
+++ b/src/Authentication/Passwords.php
@@ -143,7 +143,7 @@ class Passwords
     /**
      * Returns the validation rule for max length.
      */
-    public static function getMaxLenghtRule(): string
+    public static function getMaxLengthRule(): string
     {
         if (config('Auth')->hashAlgorithm === PASSWORD_BCRYPT) {
             return 'max_byte[72]';

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -93,7 +93,7 @@ class LoginController extends BaseController
             ],
             'password' => [
                 'label'  => 'Auth.password',
-                'rules'  => 'required|' . Passwords::getMaxLenghtRule(),
+                'rules'  => 'required|' . Passwords::getMaxLengthRule(),
                 'errors' => [
                     'max_byte' => 'Auth.errorPasswordTooLongBytes',
                 ],

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -197,7 +197,7 @@ class RegisterController extends BaseController
             ],
             'password' => [
                 'label'  => 'Auth.password',
-                'rules'  => 'required|' . Passwords::getMaxLenghtRule() . '|strong_password',
+                'rules'  => 'required|' . Passwords::getMaxLengthRule() . '|strong_password',
                 'errors' => [
                     'max_byte' => 'Auth.errorPasswordTooLongBytes',
                 ],


### PR DESCRIPTION
The getMaxLenghtRule() method name has a typo and should be renamed to getMaxLengthRule() in 3 source files. 