### PR TITLE
fix routes regular expression for windows

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -68,6 +68,22 @@ class Setup extends BaseCommand
     private ContentReplacer $replacer;
 
     /**
+     * Returns the pattern for replacement in routes
+     */
+    final public static function getRoutesPattern(): string
+    {
+        return '/(.*)(\r?\n' . preg_quote('$routes->', '/') . '[^\r\n]+?;\r?\n)/su';
+    }
+
+    /**
+     * Returns the pattern for replacement in BaseController
+     */
+    final public static function getHelperPattern(): string
+    {
+        return '/(' . preg_quote('// Do Not Edit This Line', '/') . ')/u';
+    }
+
+    /**
      * Displays the help for the spark cli script itself.
      */
     public function run(array $params): void
@@ -243,7 +259,7 @@ class Setup extends BaseCommand
         }
 
         // Add helper setup
-        $pattern = '/(' . preg_quote('// Do Not Edit This Line', '/') . ')/u';
+        $pattern = self::getHelperPattern();
         $replace = $check . "\n\n        " . '$1';
 
         $this->add($file, $check, $pattern, $replace);
@@ -254,7 +270,7 @@ class Setup extends BaseCommand
         $file = 'Config/Routes.php';
 
         $check   = 'service(\'auth\')->routes($routes);';
-        $pattern = '/(.*)(\n' . preg_quote('$routes->', '/') . '[^\n]+?;\n)/su';
+        $pattern = self::getRoutesPattern();
         $replace = '$1$2' . "\n" . $check . "\n";
 
         $this->add($file, $check, $pattern, $replace);

--- a/tests/Commands/Setup/ContentReplacerTest.php
+++ b/tests/Commands/Setup/ContentReplacerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Commands\Setup;
 
+use CodeIgniter\Shield\Commands\Setup;
 use CodeIgniter\Shield\Commands\Setup\ContentReplacer;
 use Tests\Support\TestCase;
 
@@ -76,7 +77,7 @@ final class ContentReplacerTest extends TestCase
             FILE;
 
         $text    = 'service(\'auth\')->routes($routes);';
-        $pattern = '/(.*)(\n' . preg_quote('$routes->', '/') . '[^\n]+?;\n)/su';
+        $pattern = Setup::getRoutesPattern();
         $replace = '$1$2' . "\n" . $text . "\n";
         $output  = $replacer->add($content, $text, $pattern, $replace);
 
@@ -128,7 +129,7 @@ final class ContentReplacerTest extends TestCase
             FILE;
 
         $text    = '$this->helpers = array_merge($this->helpers, [\'auth\', \'setting\']);';
-        $pattern = '/(' . preg_quote('// Do Not Edit This Line', '/') . ')/u';
+        $pattern = Setup::getHelperPattern();
         $replace = $text . "\n\n        " . '$1';
         $output  = $replacer->add($content, $text, $pattern, $replace);
 


### PR DESCRIPTION
Hello! I had a problem with change route file while setup Shield on Windows. It was because i have "\r\n", not "\n". Route file has not changed.
This is my fix. What do you thin about this, thank you