### PR TITLE
docs: fix typo in `Passwords::getMaxLengthRule()`

### DIFF
--- a/docs/addons/jwt.md
+++ b/docs/addons/jwt.md
@@ -219,7 +219,7 @@ class LoginController extends BaseController
             ],
             'password' => [
                 'label'  => 'Auth.password',
-                'rules'  => 'required|' . Passwords::getMaxLenghtRule(),
+                'rules'  => 'required|' . Passwords::getMaxLengthRule(),
                 'errors' => [
                     'max_byte' => 'Auth.errorPasswordTooLongBytes',
                 ],


### PR DESCRIPTION
fixed #731 