### PR TITLE
fix: add support for all request types when building a user from request.

### DIFF
--- a/docs/guides/strengthen_password.md
+++ b/docs/guides/strengthen_password.md
@@ -17,7 +17,7 @@ The longer the password, the stronger it is. Consider increasing the value.
 
 > **Note**
 >
-> This checking works when you validate passwords with the `strong_password`
+> This checking works when you validate passwords with the `strong_password[]`
 > validation rule.
 >
 > If you disable `CompositionValidator` (enabled by default) in `$passwordValidators`,

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -67,6 +67,7 @@ class ValidationRules
      * Builds a new user instance from the global request.
      * 
      * @deprecated This will be removed soon.
+     * @see https://github.com/codeigniter4/shield/pull/747#discussion_r1198778666
      */
     protected function buildUserFromRequest(): User
     {

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -67,6 +67,8 @@ class ValidationRules
     /**
      * Builds a new user instance from the global request.
      *
+     * @phpstan-ignore-next-line
+     *
      * @deprecated This will be removed soon.
      *
      * @see https://github.com/codeigniter4/shield/pull/747#discussion_r1198778666

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -73,7 +73,7 @@ class ValidationRules
         /** @var IncomingRequest $request */
         $request = service('request');
 
-        $data = $request->getVar($fields);
+        $data = $request->getPost($fields);
 
         return new User($data);
     }

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -65,6 +65,8 @@ class ValidationRules
 
     /**
      * Builds a new user instance from the global request.
+     * 
+     * @deprecated This will be removed soon.
      */
     protected function buildUserFromRequest(): User
     {

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -65,8 +65,9 @@ class ValidationRules
 
     /**
      * Builds a new user instance from the global request.
-     * 
+     *
      * @deprecated This will be removed soon.
+     *
      * @see https://github.com/codeigniter4/shield/pull/747#discussion_r1198778666
      */
     protected function buildUserFromRequest(): User

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -73,7 +73,7 @@ class ValidationRules
         /** @var IncomingRequest $request */
         $request = service('request');
 
-        $data = $request->getPost($fields);
+        $data = $request->getVar($fields);
 
         return new User($data);
     }

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -40,6 +40,7 @@ class ValidationRules
         if (function_exists('auth') && auth()->user()) {
             $user = auth()->user();
         } else {
+            /** @phpstan-ignore-next-line */
             $user = empty($data) ? $this->buildUserFromRequest() : $this->buildUserFromData($data);
         }
 
@@ -66,8 +67,6 @@ class ValidationRules
 
     /**
      * Builds a new user instance from the global request.
-     *
-     * @phpstan-ignore-next-line
      *
      * @deprecated This will be removed soon.
      *

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -197,7 +197,7 @@ class RegisterController extends BaseController
             ],
             'password' => [
                 'label'  => 'Auth.password',
-                'rules'  => 'required|' . Passwords::getMaxLengthRule() . '|strong_password',
+                'rules'  => 'required|' . Passwords::getMaxLengthRule() . '|strong_password[]',
                 'errors' => [
                     'max_byte' => 'Auth.errorPasswordTooLongBytes',
                 ],


### PR DESCRIPTION
Previously, the `ValidationRules::buildUserFromRequest()` only checks for `POST`ed requests.

With this PR, it can now check for any type of request including json requests. 

Fixes #612 