### PR TITLE
Update 2020-12-28-223112_create_auth_tables.php

### DIFF
--- a/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
+++ b/src/Database/Migrations/2020-12-28-223112_create_auth_tables.php
@@ -175,6 +175,6 @@ class CreateAuthTables extends Migration
 
     private function createTable(string $tableName): void
     {
-        $this->forge->createTable($tableName, false, $this->attributes);
+        $this->forge->createTable($tableName, true, $this->attributes);
     }
 }


### PR DESCRIPTION
The `$ifNotExists` parameter should be set to `true` to enable overriding.