### PR TITLE
feat: add support for multiple permissions check for users

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -119,7 +119,8 @@ permissions (**group-level permissions**) to determine if they are allowed.
 if ($user->can('users.create')) {
     //
 }
-// Or
+
+// If multiple permissions are specified, true is returned if the user has any of them.
 if ($user->can('users.create', 'users.edit')) {
     //
 }

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -119,7 +119,7 @@ permissions (**group-level permissions**) to determine if they are allowed.
 if ($user->can('users.create')) {
     //
 }
-OR
+// Or
 if ($user->can('users.create', 'users.edit')) {
     //
 }

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -111,12 +111,16 @@ The `Authorizable` trait on the `User` entity provides the following methods to 
 
 #### can()
 
-Allows you to check if a user is permitted to do a specific action. The only argument is the permission string. Returns
+Allows you to check if a user is permitted to do a specific action or group or actions. The permission string(s) should be passed as the argument(s). Returns
 boolean `true`/`false`. Will check the user's direct permissions (**user-level permissions**) first, and then check against all of the user's groups
 permissions (**group-level permissions**) to determine if they are allowed.
 
 ```php
 if ($user->can('users.create')) {
+    //
+}
+OR
+if ($user->can('users.create', 'users.edit')) {
     //
 }
 ```

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -226,9 +226,10 @@ trait Authorizable
 
     /**
      * Checks user permissions and their group permissions
-     * to see if the user has a specific permission.
+     * to see if the user has a specific permission or group
+     * of permissions.
      *
-     * @param string $permission string(s) consisting of a scope and action, like `users.create`
+     * @param string $permissions string(s) consisting of a scope and action, like `users.create`
      */
     public function can(string ...$permissions): bool
     {

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -228,47 +228,50 @@ trait Authorizable
      * Checks user permissions and their group permissions
      * to see if the user has a specific permission.
      *
-     * @param string $permission string consisting of a scope and action, like `users.create`
+     * @param string $permission string(s) consisting of a scope and action, like `users.create`
      */
-    public function can(string $permission): bool
+    public function can(string ...$permissions): bool
     {
-        if (strpos($permission, '.') === false) {
-            throw new LogicException(
-                'A permission must be a string consisting of a scope and action, like `users.create`.'
-                . ' Invalid permission: ' . $permission
-            );
-        }
+        foreach ($permissions as $permission) {
+            // Permission must contain a scope and action
+            if (strpos($permission, '.') === false) {
+                throw new LogicException(
+                    'A permission must be a string consisting of a scope and action, like `users.create`.'
+                    . ' Invalid permission: ' . $permission
+                );
+            }
 
-        $this->populatePermissions();
+            $this->populatePermissions();
 
-        $permission = strtolower($permission);
+            $permission = strtolower($permission);
 
-        // Check user's permissions
-        if (in_array($permission, $this->permissionsCache, true)) {
-            return true;
-        }
-
-        // Check the groups the user belongs to
-        $this->populateGroups();
-
-        if (! count($this->groupCache)) {
-            return false;
-        }
-
-        $matrix = function_exists('setting')
-            ? setting('AuthGroups.matrix')
-            : config('AuthGroups')->matrix;
-
-        foreach ($this->groupCache as $group) {
-            // Check exact match
-            if (isset($matrix[$group]) && in_array($permission, $matrix[$group], true)) {
+            // Check user's permissions
+            if (in_array($permission, $this->permissionsCache, true)) {
                 return true;
             }
 
-            // Check wildcard match
-            $check = substr($permission, 0, strpos($permission, '.')) . '.*';
-            if (isset($matrix[$group]) && in_array($check, $matrix[$group], true)) {
-                return true;
+            // Check the groups the user belongs to
+            $this->populateGroups();
+
+            if (! count($this->groupCache)) {
+                return false;
+            }
+
+            $matrix = function_exists('setting')
+                ? setting('AuthGroups.matrix')
+                : config('AuthGroups')->matrix;
+
+            foreach ($this->groupCache as $group) {
+                // Check exact match
+                if (isset($matrix[$group]) && in_array($permission, $matrix[$group], true)) {
+                    return true;
+                }
+
+                // Check wildcard match
+                $check = substr($permission, 0, strpos($permission, '.')) . '.*';
+                if (isset($matrix[$group]) && in_array($check, $matrix[$group], true)) {
+                    return true;
+                }
             }
         }
 

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -233,6 +233,12 @@ trait Authorizable
      */
     public function can(string ...$permissions): bool
     {
+        // Get user's permissions and store in cache
+        $this->populatePermissions();
+
+        // Check the groups the user belongs to
+        $this->populateGroups();
+
         foreach ($permissions as $permission) {
             // Permission must contain a scope and action
             if (strpos($permission, '.') === false) {
@@ -242,17 +248,12 @@ trait Authorizable
                 );
             }
 
-            $this->populatePermissions();
-
             $permission = strtolower($permission);
 
             // Check user's permissions
             if (in_array($permission, $this->permissionsCache, true)) {
                 return true;
             }
-
-            // Check the groups the user belongs to
-            $this->populateGroups();
 
             if (! count($this->groupCache)) {
                 return false;

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -288,13 +288,6 @@ final class AuthorizableTest extends DatabaseTestCase
         $this->assertTrue($this->user->can('admin.access'));
     }
 
-    public function testCanCascadesToGroupsMultiple(): void
-    {
-        $this->user->addGroup('superadmin');
-
-        $this->assertTrue($this->user->can('admin.access', 'users.*'));
-    }
-
     public function testCanCascadesToGroupsWithWildcards(): void
     {
         $this->user->addGroup('superadmin');
@@ -310,6 +303,27 @@ final class AuthorizableTest extends DatabaseTestCase
         $this->user->addGroup('superadmin');
 
         $this->assertTrue($this->user->can('developer'));
+    }
+
+    /**
+     * @see https://github.com/codeigniter4/shield/pull/791#discussion_r1297712860
+     */
+    public function testCanWorksWithMultiplePermissions(): void
+    {
+        // Check for user's direct permissions (user-level permissions)
+        $this->user->addPermission('users.create', 'users.edit');
+
+        $this->assertTrue($this->user->can('users.create', 'users.edit'));
+        $this->assertFalse($this->user->can('beta.access', 'admin.access'));
+
+        $this->user->removePermission('users.create', 'users.edit');
+
+        $this->assertFalse($this->user->can('users.edit', 'users.create'));
+
+        // Check for user's group permissions (group-level permissions)
+        $this->user->addGroup('superadmin');
+
+        $this->assertTrue($this->user->can('admin.access', 'beta.access'));
     }
 
     /**

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -324,6 +324,7 @@ final class AuthorizableTest extends DatabaseTestCase
         $this->user->addGroup('superadmin');
 
         $this->assertTrue($this->user->can('admin.access', 'beta.access'));
+        $this->assertTrue($this->user->can('admin.*', 'users.*'));
     }
 
     /**

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -288,6 +288,13 @@ final class AuthorizableTest extends DatabaseTestCase
         $this->assertTrue($this->user->can('admin.access'));
     }
 
+    public function testCanCascadesToGroupsMultiple(): void
+    {
+        $this->user->addGroup('superadmin');
+
+        $this->assertTrue($this->user->can('admin.access', 'users.*'));
+    }
+
     public function testCanCascadesToGroupsWithWildcards(): void
     {
         $this->user->addGroup('superadmin');


### PR DESCRIPTION
Added support for multiple permissions check for users via the `Authorizable` trait.

With this pull request, instead of writing:
```php
if ($user->can('user.create') || $user->can('user.edit')){
    //
}
```
we use this:
```php
if ($user->can('user.create', 'user.edit')){
    //
}
```