### PR TITLE
fix: use short classname for config()

### DIFF
--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -61,7 +61,8 @@ class JWT implements AuthenticatorInterface
      */
     public function attempt(array $credentials): Result
     {
-        $config = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
 
         /** @var IncomingRequest $request */
         $request = service('request');
@@ -142,7 +143,7 @@ class JWT implements AuthenticatorInterface
                 'success' => false,
                 'reason'  => lang(
                     'Auth.noToken',
-                    [config(AuthJWT::class)->authenticatorHeader]
+                    [config('AuthJWT')->authenticatorHeader]
                 ),
             ]);
         }
@@ -196,7 +197,8 @@ class JWT implements AuthenticatorInterface
         /** @var IncomingRequest $request */
         $request = service('request');
 
-        $config = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
 
         return $this->attempt([
             'token' => $request->getHeaderLine($config->authenticatorHeader),

--- a/src/Authentication/JWT/Adapters/FirebaseAdapter.php
+++ b/src/Authentication/JWT/Adapters/FirebaseAdapter.php
@@ -79,7 +79,8 @@ class FirebaseAdapter implements JWSAdapterInterface
      */
     private function createKeysForDecode($keyset)
     {
-        $config = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
 
         $configKeys = $config->keys[$keyset];
 
@@ -127,7 +128,8 @@ class FirebaseAdapter implements JWSAdapterInterface
      */
     private function createKeysForEncode($keyset): array
     {
-        $config = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
 
         if (isset($config->keys[$keyset][0]['secret'])) {
             $key = $config->keys[$keyset][0]['secret'];

--- a/src/Authentication/JWT/JWSEncoder.php
+++ b/src/Authentication/JWT/JWSEncoder.php
@@ -39,7 +39,8 @@ class JWSEncoder
             'Cannot pass $claims[\'exp\'] and $ttl at the same time.'
         );
 
-        $config = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
 
         $payload = array_merge(
             $config->defaultClaims,

--- a/src/Filters/JWTAuth.php
+++ b/src/Filters/JWTAuth.php
@@ -59,7 +59,8 @@ class JWTAuth implements FilterInterface
     {
         assert($request instanceof IncomingRequest);
 
-        $config = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
 
         $tokenHeader = $request->getHeaderLine(
             $config->authenticatorHeader ?? 'Authorization'

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -20,7 +20,7 @@ abstract class BaseModel extends Model
 
     public function __construct()
     {
-        $this->authConfig = config(Auth::class);
+        $this->authConfig = config('Auth');
 
         if ($this->authConfig->DBGroup !== null) {
             $this->DBGroup = $this->authConfig->DBGroup;


### PR DESCRIPTION
Follow-up #762

If FQCN is specified, devs cannot override.
