### PR TITLE
test: use short classname for `config()`

### DIFF
--- a/tests/Authentication/Authenticators/JWTAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/JWTAuthenticatorTest.php
@@ -105,7 +105,7 @@ final class JWTAuthenticatorTest extends DatabaseTestCase
 
         $this->assertFalse($result->isOK());
         $this->assertSame(
-            \lang('Auth.noToken', [config(AuthJWT::class)->authenticatorHeader]),
+            \lang('Auth.noToken', [config('AuthJWT')->authenticatorHeader]),
             $result->reason()
         );
     }

--- a/tests/Authentication/Filters/JWTFilterTest.php
+++ b/tests/Authentication/Filters/JWTFilterTest.php
@@ -33,7 +33,8 @@ final class JWTFilterTest extends DatabaseTestCase
         $_SESSION = [];
 
         // Add JWT Authenticator
-        $config                        = config(Auth::class);
+        /** @var Auth $config */
+        $config                        = config('Auth');
         $config->authenticators['jwt'] = JWT::class;
 
         // Register our filter

--- a/tests/Unit/Authentication/JWT/Adapters/FirebaseAdapaterTest.php
+++ b/tests/Unit/Authentication/JWT/Adapters/FirebaseAdapaterTest.php
@@ -82,7 +82,8 @@ final class FirebaseAdapaterTest extends TestCase
         $token = $this->generateJWT();
 
         // Change algorithm and it makes the key invalid.
-        $config                            = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                            = config('AuthJWT');
         $config->keys['default'][0]['alg'] = 'ES256';
 
         $adapter = new FirebaseAdapter();
@@ -110,7 +111,8 @@ final class FirebaseAdapaterTest extends TestCase
         $token = $this->generateJWT();
 
         // Set invalid key.
-        $config                     = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                     = config('AuthJWT');
         $config->keys['default'][0] = [
             'alg'    => '',
             'secret' => '',
@@ -128,7 +130,8 @@ final class FirebaseAdapaterTest extends TestCase
         $this->expectExceptionMessage('Cannot encode JWT: Algorithm not supported');
 
         // Set unsupported algorithm.
-        $config                            = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                            = config('AuthJWT');
         $config->keys['default'][0]['alg'] = 'PS256';
 
         $adapter = new FirebaseAdapter();

--- a/tests/Unit/Authentication/JWT/JWTManagerTest.php
+++ b/tests/Unit/Authentication/JWT/JWTManagerTest.php
@@ -55,7 +55,8 @@ final class JWTManagerTest extends TestCase
         $manager = $this->createJWTManager();
         $payload = $manager->parse($token);
 
-        $config   = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config   = config('AuthJWT');
         $expected = [
             'iss' => $config->defaultClaims['iss'],
             'sub' => '1',
@@ -121,7 +122,8 @@ final class JWTManagerTest extends TestCase
         $manager = $this->createJWTManager();
         $payload = $manager->parse($token);
 
-        $config   = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config   = config('AuthJWT');
         $expected = [
             'iss'     => $config->defaultClaims['iss'],
             'user_id' => '1',
@@ -137,7 +139,8 @@ final class JWTManagerTest extends TestCase
         $manager = $this->createJWTManager();
 
         // Set kid
-        $config                            = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                            = config('AuthJWT');
         $config->keys['default'][0]['kid'] = 'Key01';
 
         $payload = [
@@ -181,7 +184,8 @@ final class JWTManagerTest extends TestCase
     {
         $manager = $this->createJWTManager();
 
-        $config                     = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                     = config('AuthJWT');
         $config->keys['default'][0] = [
             'alg'     => 'RS256', // algorithm.
             'public'  => '',      // Public Key
@@ -257,7 +261,8 @@ final class JWTManagerTest extends TestCase
 
     public function testParseCanDecodeTokenSignedByOldKey(): void
     {
-        $config                  = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                  = config('AuthJWT');
         $config->keys['default'] = [
             [
                 'kid'    => 'Key01',
@@ -294,7 +299,8 @@ final class JWTManagerTest extends TestCase
 
     public function testParseCanSpecifyKey(): void
     {
-        $config                 = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                 = config('AuthJWT');
         $config->keys['mobile'] = [
             [
                 'kid'    => 'Key01',
@@ -329,7 +335,8 @@ final class JWTManagerTest extends TestCase
     {
         $manager = $this->createJWTManager();
 
-        $config                     = config(AuthJWT::class);
+        /** @var AuthJWT $config */
+        $config                     = config('AuthJWT');
         $config->keys['default'][0] = [
             'alg'    => 'RS256', // algorithm.
             'public' => <<<'EOD'


### PR DESCRIPTION
Follow-up #796
Ref #802

This PR fixes the following test error with CI v4.4.0:
```
1) Tests\Unit\Authentication\JWT\JWTManagerTest::testParseCanSpecifyKey
ErrorException: Undefined array key "mobile"

/home/runner/work/shield/shield/src/Authentication/JWT/Adapters/FirebaseAdapter.php:145
/home/runner/work/shield/shield/src/Authentication/JWT/Adapters/FirebaseAdapter.php:112
/home/runner/work/shield/shield/src/Authentication/JWT/JWSEncoder.php:62
/home/runner/work/shield/shield/src/Authentication/JWTManager.php:[73](https://github.com/codeigniter4/shield/actions/runs/5984579479/job/16235976345?pr=801#step:11:74)
/home/runner/work/shield/shield/tests/Unit/Authentication/JWT/JWTManagerTest.php:311
```