### PR TITLE
fix: UserModel::assignIdentities() always produces a DB query

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,8 @@ parameters:
 	ignoreErrors:
 		- '#Call to an undefined method CodeIgniter\\Database\\ConnectionInterface::[A-Za-z].+\(\)#'
 		- '#Cannot access property [\$a-z_]+ on (array|object)#'
-		- 
+		- '#Call to an undefined method CodeIgniter\\Shield\\Models\\UserModel::getLastQuery\(\)#'
+		-
 			message: '#Call to deprecated function random_string\(\):#'
 			paths:
 				- src/Authentication/Actions/Email2FA.php

--- a/src/Entities/User.php
+++ b/src/Entities/User.php
@@ -117,6 +117,11 @@ class User extends Entity
         return $identities;
     }
 
+    public function setIdentities(array $identities): void
+    {
+        $this->identities = $identities;
+    }
+
     /**
      * Creates a new identity for this user with an email/password
      * combination.

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -113,7 +113,7 @@ class UserModel extends BaseModel
      */
     private function assignIdentities(array $data, array $identities): array
     {
-        $mappedUsers = [];
+        $mappedUsers    = [];
         $userIdentities = [];
 
         $users = $data['singleton'] ? [$data['data']] : $data['data'];

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -114,6 +114,7 @@ class UserModel extends BaseModel
     private function assignIdentities(array $data, array $identities): array
     {
         $mappedUsers = [];
+        $userIdentities = [];
 
         $users = $data['singleton'] ? [$data['data']] : $data['data'];
 
@@ -122,15 +123,17 @@ class UserModel extends BaseModel
         }
         unset($users);
 
-        // Now assign the identities to the user
+        // Now group the identities by user
         foreach ($identities as $identity) {
-            $userId = $identity->user_id;
-
-            $newIdentities   = $mappedUsers[$userId]->identities;
-            $newIdentities[] = $identity;
-
-            $mappedUsers[$userId]->identities = $newIdentities;
+            $userIdentities[$identity->user_id][] = $identity;
         }
+        unset($identities);
+
+        // Now assign the identities to the user
+        foreach ($userIdentities as $userId => $identityArray) {
+            $mappedUsers[$userId]->identities = $identityArray;
+        }
+        unset($userIdentities);
 
         return $mappedUsers;
     }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -106,7 +106,11 @@ final class UserTest extends DatabaseTestCase
 
             // Check the last query and see if a proper type of query was used
             $query = (string) model(UserModel::class)->getLastQuery();
-            $this->assertMatchesRegularExpression('/WHERE\s+.*\s+IN\s+\([^)]+\)/i', $query, 'Identities were not obtained with the single query (missing "WHERE ... IN" condition)');
+            $this->assertMatchesRegularExpression(
+                '/WHERE\s+.*\s+IN\s+\([^)]+\)/i',
+                $query,
+                'Identities were not obtained with the single query (missing "WHERE ... IN" condition)'
+            );
         }
 
         $this->assertCount(2, $identities);

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -95,7 +95,7 @@ final class UserTest extends DatabaseTestCase
         // Grab the user again, using the model's identity helper
         $users = model(UserModel::class)->withIdentities()->findAll();
 
-        $identities = 0;
+        $identities = [];
 
         foreach ($users as $user) {
             if ($user->id !== $this->user->id) {

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -87,6 +87,31 @@ final class UserTest extends DatabaseTestCase
         $this->assertCount(2, $user->identities);
     }
 
+    public function testModelFindAllWithIdentitiesWhereInQuery(): void
+    {
+        fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'password']);
+        fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'access_token']);
+
+        // Grab the user again, using the model's identity helper
+        $users = model(UserModel::class)->withIdentities()->findAll();
+
+        $identities = 0;
+
+        foreach ($users as $user) {
+            if ($user->id !== $this->user->id) {
+                continue;
+            }
+
+            $identities = $user->identities;
+
+            // Check the last query and see if a proper type of query was used
+            $query = (string) model(UserModel::class)->getLastQuery();
+            $this->assertMatchesRegularExpression('/WHERE\s+.*\s+IN\s+\([^)]+\)/i', $query, 'Identities were not obtained with the single query (missing "WHERE ... IN" condition)');
+        }
+
+        $this->assertCount(2, $identities);
+    }
+
     public function testModelFindByIdWithIdentitiesUserNotExists(): void
     {
         $user = model(UserModel::class)->where('active', 0)->withIdentities()->findById(1);


### PR DESCRIPTION
In the `UserModel` - when we use `withIdentities()` method the query is produced properly. 

The problem occurs in the `assignIdentities()` method, when we're trying to assign identities to the users.
We're working with the `User` entity, and there is a line: 
```
$newIdentities   = $mappedUsers[$userId]->identities;
```

It will call `getIdentities()` method which will produce a query to the DB, since there are no identities assigned yet.

This PR solves this problem.