### PR TITLE
fix: cannot register when you remove email from `$validFields`

### DIFF
--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -102,10 +102,9 @@ class ValidationRules
      */
     protected function prepareValidFields(): array
     {
-        $config   = config('Auth');
-        $fields   = array_merge($config->validFields, $config->personalFields);
-        $fields[] = 'password';
+        $config = config('Auth');
+        $fields = array_merge($config->validFields, $config->personalFields, ['email', 'password']);
 
-        return $fields;
+        return array_unique($fields);
     }
 }

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -82,6 +82,16 @@ final class RegisterTest extends DatabaseTestCase
         $this->assertTrue($user->active);
     }
 
+    public function testRegisterActionSuccessWithNoEmailLogin(): void
+    {
+        /** @var Auth $config */
+        $config = config('Auth');
+        // Use `username` for login
+        $config->validFields = ['username'];
+
+        $this->testRegisterActionSuccess();
+    }
+
     public function testRegisterTooLongPasswordDefault(): void
     {
         $result = $this->withSession()->post('/register', [


### PR DESCRIPTION
**Description**
Fixes  #654

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
