### PR TITLE
feat: add CLI command to manage users

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -101,11 +101,13 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
             __DIR__ . '/tests/Controllers/LoginTest.php',
             __DIR__ . '/tests/Commands/SetupTest.php',
+            __DIR__ . '/tests/Commands/UserTest.php',
         ],
         RemoveUnusedPrivatePropertyRector::class => [
             __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
             __DIR__ . '/tests/Controllers/LoginTest.php',
             __DIR__ . '/tests/Commands/SetupTest.php',
+            __DIR__ . '/tests/Commands/UserTest.php',
         ],
     ]);
 

--- a/rector.php
+++ b/rector.php
@@ -98,15 +98,15 @@ return static function (RectorConfig $rectorConfig): void {
 
         // Ignore tests that use CodeIgniter::CI_VERSION
         UnwrapFutureCompatibleIfPhpVersionRector::class => [
+            __DIR__ . '/src/Test/MockInputOutput.php',
             __DIR__ . '/tests/Commands/SetupTest.php',
             __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
-            __DIR__ . '/tests/Commands/UserTest.php',
             __DIR__ . '/tests/Controllers/LoginTest.php',
         ],
         RemoveUnusedPrivatePropertyRector::class => [
+            __DIR__ . '/src/Test/MockInputOutput.php',
             __DIR__ . '/tests/Commands/SetupTest.php',
             __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
-            __DIR__ . '/tests/Commands/UserTest.php',
             __DIR__ . '/tests/Controllers/LoginTest.php',
         ],
     ]);

--- a/rector.php
+++ b/rector.php
@@ -98,16 +98,16 @@ return static function (RectorConfig $rectorConfig): void {
 
         // Ignore tests that use CodeIgniter::CI_VERSION
         UnwrapFutureCompatibleIfPhpVersionRector::class => [
-            __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
-            __DIR__ . '/tests/Controllers/LoginTest.php',
             __DIR__ . '/tests/Commands/SetupTest.php',
+            __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
             __DIR__ . '/tests/Commands/UserTest.php',
+            __DIR__ . '/tests/Controllers/LoginTest.php',
         ],
         RemoveUnusedPrivatePropertyRector::class => [
-            __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
-            __DIR__ . '/tests/Controllers/LoginTest.php',
             __DIR__ . '/tests/Commands/SetupTest.php',
+            __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
             __DIR__ . '/tests/Commands/UserTest.php',
+            __DIR__ . '/tests/Controllers/LoginTest.php',
         ],
     ]);
 

--- a/src/Commands/Exceptions/BadInputException.php
+++ b/src/Commands/Exceptions/BadInputException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Commands\Exceptions;
+
+use CodeIgniter\Shield\Exceptions\RuntimeException;
+
+class BadInputException extends RuntimeException
+{
+}

--- a/src/Commands/Exceptions/CancelException.php
+++ b/src/Commands/Exceptions/CancelException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Commands\Exceptions;
+
+use CodeIgniter\Shield\Exceptions\RuntimeException;
+
+class CancelException extends RuntimeException
+{
+}

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -56,12 +56,12 @@ class User extends BaseCommand
      * @var array
      */
     protected $options = [
-        '-i'  => 'User id',
-        '-u'  => 'User name',
-        '-e'  => 'User email',
-        '-nu' => 'New username',
-        '-ne' => 'New email',
-        '-g'  => 'Group name',
+        '-i' => 'User id',
+        '-u' => 'User name',
+        '-e' => 'User email',
+        '-n' => 'New username',
+        '-m' => 'New email',
+        '-g' => 'Group name',
     ];
 
     /**
@@ -83,8 +83,8 @@ class User extends BaseCommand
             $userid       = (int) CLI::getOption('i');
             $username     = CLI::getOption('u');
             $email        = CLI::getOption('e');
-            $new_username = CLI::getOption('nu');
-            $new_email    = CLI::getOption('ne');
+            $new_username = CLI::getOption('n');
+            $new_email    = CLI::getOption('m');
             $group        = CLI::getOption('g');
 
             switch ($action) {
@@ -364,7 +364,7 @@ class User extends BaseCommand
      * @param $username User name to search for (optional)
      * @param $email User email to search for (optional)
      */
-    private function list($username = null, $email = null): void
+    private function list(?string $username = null, ?string $email = null): void
     {
         $users = model('CodeIgniter\Shield\Models\UserModel');
         $users = $users->join('auth_identities', 'auth_identities.user_id = users.id');

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -121,25 +121,14 @@ class User extends BaseCommand
                     break;
 
                 case 'addgroup':
-                    if(!$group) {
-                        CLI::write('Group option is missing', 'red');
-                    }
-                    else {
-                        $this->addgroup($group, $username, $email);
-                    }
+                    $this->addgroup($group, $username, $email);
                     break;
 
                 case 'removegroup':
-                    if(!$group) {
-                        CLI::write('Group option is missing', 'red');
-                    }
-                    else {
-                        $this->removegroup($group, $username, $email);
-                    }
+                    $this->removegroup($group, $username, $email);
                     break;
             }
-        }
-        else {
+        } else {
             CLI::write('Specify a valid action : ' . implode(',', $this->valid_actions), 'red');
         }
     }
@@ -400,8 +389,12 @@ class User extends BaseCommand
      * @param $username User name to search for (optional)
      * @param $email User email to search for (optional)
      */
-    private function addgroup(string $group, $username = null, $email = null): void
+    private function addgroup($group = null, $username = null, $email = null): void
     {
+        if (! $group) {
+            $group = CLI::prompt('Group', null, 'required');
+        }
+
         $user = $this->findUser('Add user to group', $username, $email);
 
         $confirm = CLI::prompt('Add the user: ' . $user->username . ' to the group: ' . $group . ' ?', ['y', 'n']);
@@ -420,8 +413,12 @@ class User extends BaseCommand
      * @param $username User name to search for (optional)
      * @param $email User email to search for (optional)
      */
-    private function removegroup(string $group, $username = null, $email = null): void
+    private function removegroup($group = null, $username = null, $email = null): void
     {
+        if (! $group) {
+            $group = CLI::prompt('Group', null, 'required');
+        }
+
         $user = $this->findUser('Remove user from group', $username, $email);
 
         $confirm = CLI::prompt('Remove the user: ' . $user->username . ' fromt the group: ' . $group . ' ?', ['y', 'n']);

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -137,7 +137,7 @@ class User extends BaseCommand
      * Create a new user
      *
      * @param $username User name to create (optional)
-     * @param $email User email to create (optional)
+     * @param $email    User email to create (optional)
      */
     private function create(?string $username = null, ?string $email = null): void
     {
@@ -185,7 +185,7 @@ class User extends BaseCommand
      * Activate an existing user by username or email
      *
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function activate(?string $username = null, ?string $email = null): void
     {
@@ -205,7 +205,7 @@ class User extends BaseCommand
      * Deactivate an existing user by username or email
      *
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function deactivate(?string $username = null, ?string $email = null): void
     {
@@ -224,8 +224,8 @@ class User extends BaseCommand
     /**
      * Change the name of an existing user by username or email
      *
-     * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $username     User name to search for (optional)
+     * @param $email        User email to search for (optional)
      * @param $new_username User new name (optional)
      */
     private function changename(?string $username = null, ?string $email = null, ?string $new_username = null): void
@@ -265,8 +265,8 @@ class User extends BaseCommand
     /**
      * Change the email of an existing user by username or email
      *
-     * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $username  User name to search for (optional)
+     * @param $email     User email to search for (optional)
      * @param $new_email User new email (optional)
      */
     private function changeemail(?string $username = null, ?string $email = null, ?string $new_email = null): void
@@ -300,9 +300,9 @@ class User extends BaseCommand
     /**
      * Delete an existing user by username or email
      *
-     * @param $userid User id to delete (optional)
+     * @param $userid   User id to delete (optional)
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function delete(int $userid = 0, ?string $username = null, ?string $email = null): void
     {
@@ -331,7 +331,7 @@ class User extends BaseCommand
      * Change the password of an existing user by username or email
      *
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function password($username = null, $email = null): void
     {
@@ -362,7 +362,7 @@ class User extends BaseCommand
      * List users searching by username or email
      *
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function list(?string $username = null, ?string $email = null): void
     {
@@ -385,9 +385,9 @@ class User extends BaseCommand
     /**
      * Add a user by username or email to a group
      *
-     * @param $group Group to add user to
+     * @param $group    Group to add user to
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function addgroup($group = null, $username = null, $email = null): void
     {
@@ -409,9 +409,9 @@ class User extends BaseCommand
     /**
      * Remove a user by username or email from a group
      *
-     * @param $group Group to remove user from
+     * @param $group    Group to remove user from
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function removegroup($group = null, $username = null, $email = null): void
     {
@@ -435,7 +435,7 @@ class User extends BaseCommand
      *
      * @param $question Initial question at user prompt
      * @param $username User name to search for (optional)
-     * @param $email User email to search for (optional)
+     * @param $email    User email to search for (optional)
      */
     private function findUser($question = '', $username = null, $email = null): \CodeIgniter\Shield\Entities\User
     {

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -6,6 +6,7 @@ namespace CodeIgniter\Shield\Commands;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Shield\Models\UserModel;
 use Config\Services;
 
 class User extends BaseCommand
@@ -223,9 +224,11 @@ class User extends BaseCommand
             exit;
         }
 
-        $userModel = model('CodeIgniter\Shield\Models\UserModel');
-        $user      = new \CodeIgniter\Shield\Entities\User($data);
+        $userModel = model(UserModel::class);
+
+        $user = new \CodeIgniter\Shield\Entities\User($data);
         $userModel->save($user);
+
         CLI::write('User ' . $username . ' created', 'green');
     }
 
@@ -240,9 +243,11 @@ class User extends BaseCommand
         $user    = $this->findUser('Activate user', $username, $email);
         $confirm = CLI::prompt('Activate the user ' . $user->username . ' ?', ['y', 'n']);
         if ($confirm === 'y') {
-            $userModel    = model('CodeIgniter\Shield\Models\UserModel');
+            $userModel = model(UserModel::class);
+
             $user->active = 1;
             $userModel->save($user);
+
             CLI::write('User ' . $user->username . ' activated', 'green');
         } else {
             CLI::write('User ' . $user->username . ' activation cancelled', 'yellow');
@@ -260,9 +265,11 @@ class User extends BaseCommand
         $user    = $this->findUser('Deactivate user', $username, $email);
         $confirm = CLI::prompt('Deactivate the user ' . $username . ' ?', ['y', 'n']);
         if ($confirm === 'y') {
-            $userModel    = model('CodeIgniter\Shield\Models\UserModel');
+            $userModel = model(UserModel::class);
+
             $user->active = 0;
             $userModel->save($user);
+
             CLI::write('User ' . $user->username . ' deactivated', 'green');
         } else {
             CLI::write('User ' . $user->username . ' deactivation cancelled', 'yellow');
@@ -303,10 +310,12 @@ class User extends BaseCommand
             }
         }
 
-        $userModel      = model('CodeIgniter\Shield\Models\UserModel');
+        $userModel = model(UserModel::class);
+
         $old_username   = $user->username;
         $user->username = $new_username;
         $userModel->save($user);
+
         CLI::write('Username ' . $old_username . ' changed to ' . $new_username, 'green');
     }
 
@@ -339,9 +348,11 @@ class User extends BaseCommand
             }
         }
 
-        $userModel   = model('CodeIgniter\Shield\Models\UserModel');
+        $userModel = model(UserModel::class);
+
         $user->email = $new_email;
         $userModel->save($user);
+
         CLI::write('Email for the user : ' . $user->username . ' changed to ' . $new_email, 'green');
     }
 
@@ -354,7 +365,8 @@ class User extends BaseCommand
      */
     private function delete(int $userid = 0, ?string $username = null, ?string $email = null): void
     {
-        $userModel = model('CodeIgniter\Shield\Models\UserModel');
+        $userModel = model(UserModel::class);
+
         if ($userid) {
             $user = $userModel->findById($userid);
             if (! $user) {
@@ -396,7 +408,8 @@ class User extends BaseCommand
                 exit;
             }
 
-            $userModel      = model('CodeIgniter\Shield\Models\UserModel');
+            $userModel = model(UserModel::class);
+
             $user->password = $password;
             $userModel->save($user);
 
@@ -414,8 +427,10 @@ class User extends BaseCommand
      */
     private function list(?string $username = null, ?string $email = null): void
     {
-        $userModel = model('CodeIgniter\Shield\Models\UserModel');
-        $users     = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
+        $userModel = model(UserModel::class);
+
+        $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
+
         if ($username) {
             $users = $users->like('username', $username);
         }
@@ -496,9 +511,11 @@ class User extends BaseCommand
             }
         }
 
-        $user      = new \CodeIgniter\Shield\Entities\User();
-        $userModel = model('CodeIgniter\Shield\Models\UserModel');
-        $users     = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
+        $userModel = model(UserModel::class);
+
+        $user = new \CodeIgniter\Shield\Entities\User();
+
+        $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
 
         if ($username) {
             $user = $users->where('username', $username)->first();

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -204,12 +204,12 @@ class User extends BaseCommand
     {
         $data = [];
 
-        if (! $username) {
+        if ($username === null) {
             $username = CLI::prompt('Username', null, $this->validationRules['username']);
         }
         $data['username'] = $username;
 
-        if (! $email) {
+        if ($email === null) {
             $email = CLI::prompt('Email', null, $this->validationRules['email']);
         }
         $data['email'] = $email;
@@ -317,7 +317,7 @@ class User extends BaseCommand
 
         $user = $this->findUser('Change username', $username, $email);
 
-        if (! $newUsername) {
+        if ($newUsername === null) {
             $newUsername = CLI::prompt('New username', null, $this->validationRules['username']);
         } else {
             // Run validation if the user has passed username and/or email via command line
@@ -360,7 +360,7 @@ class User extends BaseCommand
     ): void {
         $user = $this->findUser('Change email', $username, $email);
 
-        if (! $newEmail) {
+        if ($newEmail === null) {
             $newEmail = CLI::prompt('New email', null, $this->validationRules['email']);
         } else {
             // Run validation if the user has passed username and/or email via command line
@@ -398,10 +398,10 @@ class User extends BaseCommand
     {
         $userModel = model(UserModel::class);
 
-        if ($userid) {
+        if ($userid !== 0) {
             $user = $userModel->findById($userid);
 
-            if (! $user) {
+            if ($user === null) {
                 CLI::write("User doesn't exist", 'red');
 
                 throw new RuntimeException("User doesn't exis");
@@ -467,10 +467,10 @@ class User extends BaseCommand
     {
         $userModel = model(UserModel::class);
 
-        if ($username) {
+        if ($username !== null) {
             $userModel->like('username', $username);
         }
-        if ($email) {
+        if ($email !== null) {
             $userModel->like('secret', $email);
         }
 
@@ -490,7 +490,7 @@ class User extends BaseCommand
      */
     private function addgroup($group = null, $username = null, $email = null): void
     {
-        if (! $group) {
+        if ($group === null) {
             $group = CLI::prompt('Group', null, 'required');
         }
 
@@ -522,7 +522,7 @@ class User extends BaseCommand
      */
     private function removegroup($group = null, $username = null, $email = null): void
     {
-        if (! $group) {
+        if ($group === null) {
             $group = CLI::prompt('Group', null, 'required');
         }
 
@@ -551,7 +551,7 @@ class User extends BaseCommand
      */
     private function findUser($question = '', $username = null, $email = null): \CodeIgniter\Shield\Entities\User
     {
-        if (! $username && ! $email) {
+        if ($username === null && $email === null) {
             $choice = CLI::prompt($question . ' by username or email ?', ['u', 'e']);
 
             if ($choice === 'u') {
@@ -567,13 +567,13 @@ class User extends BaseCommand
 
         $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
 
-        if ($username) {
+        if ($username !== null) {
             $user = $users->where('username', $username)->first();
-        } elseif ($email) {
+        } elseif ($email !== null) {
             $user = $users->where('secret', $email)->first();
         }
 
-        if (! $user) {
+        if ($user === null) {
             CLI::write("User doesn't exist", 'red');
 
             throw new RuntimeException("User doesn't exist");

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -219,6 +219,19 @@ class User extends BaseCommand
 
         $rules = $validationRules->get();
 
+        // Remove strong_password because it only supports use cases
+        // to check the user's own password.
+        $rules['password']['rules'] = str_replace(
+            '|strong_password[]',
+            '',
+            $rules['password']['rules']
+        );
+
+        /** @var Auth $config */
+        $config = config('Auth');
+
+        $rules['password']['rules'] .= '|min_length[' . $config->minimumPasswordLength . ']';
+
         $this->validationRules = [
             'username' => $rules['username'],
             'email'    => $rules['email'],
@@ -271,7 +284,11 @@ class User extends BaseCommand
         }
         $data['email'] = $email;
 
-        $password        = $this->prompt('Password', null, $this->validationRules['password']['rules']);
+        $password = $this->prompt(
+            'Password',
+            null,
+            $this->validationRules['password']['rules']
+        );
         $passwordConfirm = $this->prompt(
             'Password confirmation',
             null,
@@ -497,8 +514,16 @@ class User extends BaseCommand
         $confirm = $this->prompt('Set the password for "' . $user->username . '" ?', ['y', 'n']);
 
         if ($confirm === 'y') {
-            $password        = $this->prompt('Password', null, 'required');
-            $passwordConfirm = $this->prompt('Password confirmation', null, $this->validationRules['password']['rules']);
+            $password = $this->prompt(
+                'Password',
+                null,
+                $this->validationRules['password']['rules']
+            );
+            $passwordConfirm = $this->prompt(
+                'Password confirmation',
+                null,
+                $this->validationRules['password']['rules']
+            );
 
             if ($password !== $passwordConfirm) {
                 $this->write("The passwords don't match", 'red');

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -6,6 +6,7 @@ namespace CodeIgniter\Shield\Commands;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Models\UserModel;
 use Config\Services;
 
@@ -429,7 +430,9 @@ class User extends BaseCommand
     {
         $userModel = model(UserModel::class);
 
-        $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
+        $users = $userModel
+            ->join('auth_identities', 'auth_identities.user_id = users.id')
+            ->where('auth_identities.type', Session::ID_TYPE_EMAIL_PASSWORD);
 
         if ($username) {
             $users = $users->like('username', $username);

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -121,13 +121,26 @@ class User extends BaseCommand
                     break;
 
                 case 'addgroup':
-                    $this->addgroup($group, $username, $email);
+                    if(!$group) {
+                        CLI::write('Group option is missing', 'red');
+                    }
+                    else {
+                        $this->addgroup($group, $username, $email);
+                    }
                     break;
 
                 case 'removegroup':
-                    $this->removegroup($group, $username, $email);
+                    if(!$group) {
+                        CLI::write('Group option is missing', 'red');
+                    }
+                    else {
+                        $this->removegroup($group, $username, $email);
+                    }
                     break;
             }
+        }
+        else {
+            CLI::write('Specify a valid action : ' . implode(',', $this->valid_actions), 'red');
         }
     }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -6,10 +6,12 @@ namespace CodeIgniter\Shield\Commands;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
+use CodeIgniter\Shield\Commands\Exceptions\BadInputException;
+use CodeIgniter\Shield\Commands\Exceptions\CancelException;
 use CodeIgniter\Shield\Commands\Utils\InputOutput;
 use CodeIgniter\Shield\Config\Auth;
 use CodeIgniter\Shield\Entities\User as UserEntity;
-use CodeIgniter\Shield\Exceptions\RuntimeException;
+use CodeIgniter\Shield\Exceptions\UserNotFoundException;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Validation\RegistrationValidationRules;
 use Config\Services;
@@ -199,7 +201,7 @@ class User extends BaseCommand
                     $this->removegroup($group, $username, $email);
                     break;
             }
-        } catch (RuntimeException $e) {
+        } catch (BadInputException|CancelException|UserNotFoundException $e) {
             return EXIT_ERROR;
         }
 
@@ -303,7 +305,7 @@ class User extends BaseCommand
         if ($password !== $passwordConfirm) {
             $this->write("The passwords don't match", 'red');
 
-            throw new RuntimeException("The passwords don't match");
+            throw new BadInputException("The passwords don't match");
         }
         $data['password'] = $password;
 
@@ -318,7 +320,7 @@ class User extends BaseCommand
 
             $this->write('User creation aborted', 'red');
 
-            throw new RuntimeException('User creation aborted');
+            throw new CancelException('User creation aborted');
         }
 
         $userModel = model(UserModel::class);
@@ -407,7 +409,7 @@ class User extends BaseCommand
 
                 $this->write('User name change aborted', 'red');
 
-                throw new RuntimeException('User name change aborted');
+                throw new CancelException('User name change aborted');
             }
         }
 
@@ -449,7 +451,7 @@ class User extends BaseCommand
                 }
                 $this->write('User email change aborted', 'red');
 
-                throw new RuntimeException('User email change aborted');
+                throw new CancelException('User email change aborted');
             }
         }
 
@@ -502,7 +504,7 @@ class User extends BaseCommand
         if ($user === null) {
             $this->write("User doesn't exist", 'red');
 
-            throw new RuntimeException("User doesn't exis");
+            throw new UserNotFoundException("User doesn't exist");
         }
     }
 
@@ -533,7 +535,7 @@ class User extends BaseCommand
             if ($password !== $passwordConfirm) {
                 $this->write("The passwords don't match", 'red');
 
-                throw new RuntimeException("The passwords don't match");
+                throw new BadInputException("The passwords don't match");
             }
 
             $userModel = model(UserModel::class);

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -656,7 +656,11 @@ class User extends BaseCommand
             if ($choice === 'u') {
                 $username = $this->prompt('Username', null, 'required');
             } elseif ($choice === 'e') {
-                $email = $this->prompt('Email', null, $this->validationRules['email']['rules']);
+                $email = $this->prompt(
+                    'Email',
+                    null,
+                    'required'
+                );
             }
         }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -175,9 +175,9 @@ class User extends BaseCommand
             exit;
         }
 
-        $users = model('CodeIgniter\Shield\Models\UserModel');
+        $userModel = model('CodeIgniter\Shield\Models\UserModel');
         $user  = new \CodeIgniter\Shield\Entities\User($data);
-        $users->save($user);
+        $userModel->save($user);
         CLI::write('User ' . $username . ' created', 'green');
     }
 
@@ -306,8 +306,9 @@ class User extends BaseCommand
      */
     private function delete(int $userid = 0, ?string $username = null, ?string $email = null): void
     {
+        $userModel = model('CodeIgniter\Shield\Models\UserModel');
         if ($userid) {
-            $user = model('CodeIgniter\Shield\Models\UserModel')->findById($userid);
+            $user = $userModel->findById($userid);
             if (! $user) {
                 CLI::write("User doesn't exist", 'red');
 
@@ -319,7 +320,6 @@ class User extends BaseCommand
 
         $confirm = CLI::prompt('Delete the user ' . $user->username . ' (' . $user->email . ') ?', ['y', 'n']);
         if ($confirm === 'y') {
-            $userModel = model('CodeIgniter\Shield\Models\UserModel');
             $userModel->delete($user->id, true);
             CLI::write('User ' . $user->username . ' deleted', 'green');
         } else {
@@ -366,8 +366,8 @@ class User extends BaseCommand
      */
     private function list(?string $username = null, ?string $email = null): void
     {
-        $users = model('CodeIgniter\Shield\Models\UserModel');
-        $users = $users->join('auth_identities', 'auth_identities.user_id = users.id');
+        $userModel = model('CodeIgniter\Shield\Models\UserModel');
+        $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
         if ($username) {
             $users = $users->like('username', $username);
         }
@@ -449,8 +449,8 @@ class User extends BaseCommand
         }
 
         $user  = new \CodeIgniter\Shield\Entities\User();
-        $users = model('CodeIgniter\Shield\Models\UserModel');
-        $users = $users->join('auth_identities', 'auth_identities.user_id = users.id');
+        $userModel = model('CodeIgniter\Shield\Models\UserModel');
+        $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
 
         if ($username) {
             $user = $users->where('username', $username)->first();

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -202,6 +202,8 @@ class User extends BaseCommand
                     break;
             }
         } catch (BadInputException|CancelException|UserNotFoundException $e) {
+            $this->write($e->getMessage(), 'red');
+
             return EXIT_ERROR;
         }
 
@@ -303,8 +305,6 @@ class User extends BaseCommand
         );
 
         if ($password !== $passwordConfirm) {
-            $this->write("The passwords don't match", 'red');
-
             throw new BadInputException("The passwords don't match");
         }
         $data['password'] = $password;
@@ -317,8 +317,6 @@ class User extends BaseCommand
             foreach ($validation->getErrors() as $message) {
                 $this->write($message, 'red');
             }
-
-            $this->write('User creation aborted', 'red');
 
             throw new CancelException('User creation aborted');
         }
@@ -407,8 +405,6 @@ class User extends BaseCommand
                     $this->write($message, 'red');
                 }
 
-                $this->write('User name change aborted', 'red');
-
                 throw new CancelException('User name change aborted');
             }
         }
@@ -449,7 +445,6 @@ class User extends BaseCommand
                 foreach ($validation->getErrors() as $message) {
                     $this->write($message, 'red');
                 }
-                $this->write('User email change aborted', 'red');
 
                 throw new CancelException('User email change aborted');
             }
@@ -502,8 +497,6 @@ class User extends BaseCommand
     private function checkUserExists($user): void
     {
         if ($user === null) {
-            $this->write("User doesn't exist", 'red');
-
             throw new UserNotFoundException("User doesn't exist");
         }
     }
@@ -533,8 +526,6 @@ class User extends BaseCommand
             );
 
             if ($password !== $passwordConfirm) {
-                $this->write("The passwords don't match", 'red');
-
                 throw new BadInputException("The passwords don't match");
             }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -276,7 +276,7 @@ class User extends BaseCommand
         $user = new \CodeIgniter\Shield\Entities\User($data);
         $userModel->save($user);
 
-        $this->write('User ' . $username . ' created', 'green');
+        $this->write('User "' . $username . '" created', 'green');
     }
 
     /**
@@ -297,9 +297,9 @@ class User extends BaseCommand
             $user->active = 1;
             $userModel->save($user);
 
-            $this->write('User ' . $user->username . ' activated', 'green');
+            $this->write('User "' . $user->username . '" activated', 'green');
         } else {
-            $this->write('User ' . $user->username . ' activation cancelled', 'yellow');
+            $this->write('User "' . $user->username . '" activation cancelled', 'yellow');
         }
     }
 
@@ -313,7 +313,7 @@ class User extends BaseCommand
     {
         $user = $this->findUser('Deactivate user', $username, $email);
 
-        $confirm = $this->prompt('Deactivate the user ' . $username . ' ?', ['y', 'n']);
+        $confirm = $this->prompt('Deactivate the user "' . $username . '" ?', ['y', 'n']);
 
         if ($confirm === 'y') {
             $userModel = model(UserModel::class);
@@ -321,9 +321,9 @@ class User extends BaseCommand
             $user->active = 0;
             $userModel->save($user);
 
-            $this->write('User ' . $user->username . ' deactivated', 'green');
+            $this->write('User "' . $user->username . '" deactivated', 'green');
         } else {
-            $this->write('User ' . $user->username . ' deactivation cancelled', 'yellow');
+            $this->write('User "' . $user->username . '" deactivation cancelled', 'yellow');
         }
     }
 
@@ -372,7 +372,7 @@ class User extends BaseCommand
         $user->username = $newUsername;
         $userModel->save($user);
 
-        $this->write('Username ' . $oldUsername . ' changed to ' . $newUsername, 'green');
+        $this->write('Username "' . $oldUsername . '" changed to "' . $newUsername . '"', 'green');
     }
 
     /**
@@ -413,7 +413,7 @@ class User extends BaseCommand
         $user->email = $newEmail;
         $userModel->save($user);
 
-        $this->write('Email for the user : ' . $user->username . ' changed to ' . $newEmail, 'green');
+        $this->write('Email for "' . $user->username . '" changed to ' . $newEmail, 'green');
     }
 
     /**
@@ -440,16 +440,16 @@ class User extends BaseCommand
         }
 
         $confirm = $this->prompt(
-            'Delete the user ' . $user->username . ' (' . $user->email . ') ?',
+            'Delete the user "' . $user->username . '" (' . $user->email . ') ?',
             ['y', 'n']
         );
 
         if ($confirm === 'y') {
             $userModel->delete($user->id, true);
 
-            $this->write('User ' . $user->username . ' deleted', 'green');
+            $this->write('User "' . $user->username . '" deleted', 'green');
         } else {
-            $this->write('User ' . $user->username . ' deletion cancelled', 'yellow');
+            $this->write('User "' . $user->username . '" deletion cancelled', 'yellow');
         }
     }
 
@@ -463,7 +463,7 @@ class User extends BaseCommand
     {
         $user = $this->findUser('Change user password', $username, $email);
 
-        $confirm = $this->prompt('Set the password for the user ' . $user->username . ' ?', ['y', 'n']);
+        $confirm = $this->prompt('Set the password for "' . $user->username . '" ?', ['y', 'n']);
 
         if ($confirm === 'y') {
             $password        = $this->prompt('Password', null, 'required');
@@ -480,9 +480,9 @@ class User extends BaseCommand
             $user->password = $password;
             $userModel->save($user);
 
-            $this->write('Password for the user ' . $user->username . ' set', 'green');
+            $this->write('Password for "' . $user->username . '" set', 'green');
         } else {
-            $this->write('Password setting for the user : ' . $user->username . ', cancelled', 'yellow');
+            $this->write('Password setting for "' . $user->username . '" cancelled', 'yellow');
         }
     }
 
@@ -526,17 +526,17 @@ class User extends BaseCommand
         $user = $this->findUser('Add user to group', $username, $email);
 
         $confirm = $this->prompt(
-            'Add the user: ' . $user->username . ' to the group: ' . $group . ' ?',
+            'Add the user "' . $user->username . '" to the group "' . $group . '" ?',
             ['y', 'n']
         );
 
         if ($confirm === 'y') {
             $user->addGroup($group);
 
-            $this->write('User ' . $user->username . ' added to group ' . $group, 'green');
+            $this->write('User "' . $user->username . '" added to group "' . $group . '"', 'green');
         } else {
             $this->write(
-                'Addition of the user: ' . $user->username . ' to the group: ' . $group . ' cancelled',
+                'Addition of the user "' . $user->username . '" to the group "' . $group . '" cancelled',
                 'yellow'
             );
         }
@@ -558,16 +558,16 @@ class User extends BaseCommand
         $user = $this->findUser('Remove user from group', $username, $email);
 
         $confirm = $this->prompt(
-            'Remove the user: ' . $user->username . ' fromt the group: ' . $group . ' ?',
+            'Remove the user "' . $user->username . '" from the group "' . $group . '" ?',
             ['y', 'n']
         );
 
         if ($confirm === 'y') {
             $user->removeGroup($group);
 
-            $this->write('User ' . $user->username . ' removed from group ' . $group, 'green');
+            $this->write('User "' . $user->username . '" removed from group "' . $group . '"', 'green');
         } else {
-            $this->write('Removal of the user: ' . $user->username . ' from the group: ' . $group . ' cancelled', 'yellow');
+            $this->write('Removal of the user "' . $user->username . '" from the group "' . $group . '" cancelled', 'yellow');
         }
     }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -139,7 +139,7 @@ class User extends BaseCommand
      */
     public function run(array $params): int
     {
-        $this->ensureInput();
+        $this->ensureInputOutput();
         $this->setTables();
         $this->setValidationRules();
 
@@ -668,7 +668,7 @@ class User extends BaseCommand
         return $userModel->findById($user['id']);
     }
 
-    private function ensureInput(): void
+    private function ensureInputOutput(): void
     {
         if (self::$io === null) {
             self::$io = new InputOutput();

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -219,18 +219,23 @@ class User extends BaseCommand
 
         $rules = $validationRules->get();
 
-        // Remove strong_password because it only supports use cases
+        // Remove `strong_password` because it only supports use cases
         // to check the user's own password.
-        $rules['password']['rules'] = str_replace(
-            '|strong_password[]',
-            '',
-            $rules['password']['rules']
-        );
+        $passwordRules = $rules['password']['rules'];
+        if (is_string($passwordRules)) {
+            $passwordRules = explode('|', $passwordRules);
+        }
+        if (($key = array_search('strong_password[]', $passwordRules, true)) !== false) {
+            unset($passwordRules[$key]);
+        }
 
         /** @var Auth $config */
         $config = config('Auth');
 
-        $rules['password']['rules'] .= '|min_length[' . $config->minimumPasswordLength . ']';
+        // Add `min_length`
+        $passwordRules[] = 'min_length[' . $config->minimumPasswordLength . ']';
+
+        $rules['password']['rules'] = $passwordRules;
 
         $this->validationRules = [
             'username' => $rules['username'],

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -195,6 +195,20 @@ class User extends BaseCommand
     }
 
     /**
+     * Asks the user for input.
+     *
+     * @param string       $field      Output "field" question
+     * @param array|string $options    String to a default value, array to a list of options (the first option will be the default value)
+     * @param array|string $validation Validation rules
+     *
+     * @return string The user input
+     */
+    private function prompt(string $field, $options = null, $validation = null): string
+    {
+        return CLI::prompt($field, $options, $validation);
+    }
+
+    /**
      * Create a new user
      *
      * @param string|null $username User name to create (optional)
@@ -205,17 +219,17 @@ class User extends BaseCommand
         $data = [];
 
         if ($username === null) {
-            $username = CLI::prompt('Username', null, $this->validationRules['username']);
+            $username = $this->prompt('Username', null, $this->validationRules['username']);
         }
         $data['username'] = $username;
 
         if ($email === null) {
-            $email = CLI::prompt('Email', null, $this->validationRules['email']);
+            $email = $this->prompt('Email', null, $this->validationRules['email']);
         }
         $data['email'] = $email;
 
-        $password        = CLI::prompt('Password', null, $this->validationRules['password']);
-        $passwordConfirm = CLI::prompt(
+        $password        = $this->prompt('Password', null, $this->validationRules['password']);
+        $passwordConfirm = $this->prompt(
             'Password confirmation',
             null,
             $this->validationRules['password']
@@ -260,7 +274,7 @@ class User extends BaseCommand
     {
         $user = $this->findUser('Activate user', $username, $email);
 
-        $confirm = CLI::prompt('Activate the user ' . $user->username . ' ?', ['y', 'n']);
+        $confirm = $this->prompt('Activate the user ' . $user->username . ' ?', ['y', 'n']);
 
         if ($confirm === 'y') {
             $userModel = model(UserModel::class);
@@ -284,7 +298,7 @@ class User extends BaseCommand
     {
         $user = $this->findUser('Deactivate user', $username, $email);
 
-        $confirm = CLI::prompt('Deactivate the user ' . $username . ' ?', ['y', 'n']);
+        $confirm = $this->prompt('Deactivate the user ' . $username . ' ?', ['y', 'n']);
 
         if ($confirm === 'y') {
             $userModel = model(UserModel::class);
@@ -318,7 +332,7 @@ class User extends BaseCommand
         $user = $this->findUser('Change username', $username, $email);
 
         if ($newUsername === null) {
-            $newUsername = CLI::prompt('New username', null, $this->validationRules['username']);
+            $newUsername = $this->prompt('New username', null, $this->validationRules['username']);
         } else {
             // Run validation if the user has passed username and/or email via command line
             $validation = Services::validation();
@@ -361,7 +375,7 @@ class User extends BaseCommand
         $user = $this->findUser('Change email', $username, $email);
 
         if ($newEmail === null) {
-            $newEmail = CLI::prompt('New email', null, $this->validationRules['email']);
+            $newEmail = $this->prompt('New email', null, $this->validationRules['email']);
         } else {
             // Run validation if the user has passed username and/or email via command line
             $validation = Services::validation();
@@ -410,7 +424,7 @@ class User extends BaseCommand
             $user = $this->findUser('Delete user', $username, $email);
         }
 
-        $confirm = CLI::prompt(
+        $confirm = $this->prompt(
             'Delete the user ' . $user->username . ' (' . $user->email . ') ?',
             ['y', 'n']
         );
@@ -434,11 +448,11 @@ class User extends BaseCommand
     {
         $user = $this->findUser('Change user password', $username, $email);
 
-        $confirm = CLI::prompt('Set the password for the user ' . $user->username . ' ?', ['y', 'n']);
+        $confirm = $this->prompt('Set the password for the user ' . $user->username . ' ?', ['y', 'n']);
 
         if ($confirm === 'y') {
-            $password        = CLI::prompt('Password', null, 'required');
-            $passwordConfirm = CLI::prompt('Password confirmation', null, $this->validationRules['password']);
+            $password        = $this->prompt('Password', null, 'required');
+            $passwordConfirm = $this->prompt('Password confirmation', null, $this->validationRules['password']);
 
             if ($password !== $passwordConfirm) {
                 CLI::write("The passwords don't match", 'red');
@@ -491,12 +505,12 @@ class User extends BaseCommand
     private function addgroup($group = null, $username = null, $email = null): void
     {
         if ($group === null) {
-            $group = CLI::prompt('Group', null, 'required');
+            $group = $this->prompt('Group', null, 'required');
         }
 
         $user = $this->findUser('Add user to group', $username, $email);
 
-        $confirm = CLI::prompt(
+        $confirm = $this->prompt(
             'Add the user: ' . $user->username . ' to the group: ' . $group . ' ?',
             ['y', 'n']
         );
@@ -523,12 +537,12 @@ class User extends BaseCommand
     private function removegroup($group = null, $username = null, $email = null): void
     {
         if ($group === null) {
-            $group = CLI::prompt('Group', null, 'required');
+            $group = $this->prompt('Group', null, 'required');
         }
 
         $user = $this->findUser('Remove user from group', $username, $email);
 
-        $confirm = CLI::prompt(
+        $confirm = $this->prompt(
             'Remove the user: ' . $user->username . ' fromt the group: ' . $group . ' ?',
             ['y', 'n']
         );
@@ -552,12 +566,12 @@ class User extends BaseCommand
     private function findUser($question = '', $username = null, $email = null): \CodeIgniter\Shield\Entities\User
     {
         if ($username === null && $email === null) {
-            $choice = CLI::prompt($question . ' by username or email ?', ['u', 'e']);
+            $choice = $this->prompt($question . ' by username or email ?', ['u', 'e']);
 
             if ($choice === 'u') {
-                $username = CLI::prompt('Username', null, 'required');
+                $username = $this->prompt('Username', null, 'required');
             } elseif ($choice === 'e') {
-                $email = CLI::prompt('Email', null, 'required|valid_email');
+                $email = $this->prompt('Email', null, 'required|valid_email');
             }
         }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -215,7 +215,11 @@ class User extends BaseCommand
         $data['email'] = $email;
 
         $password        = CLI::prompt('Password', null, $this->validationRules['password']);
-        $passwordConfirm = CLI::prompt('Password confirmation', null, $this->validationRules['password']);
+        $passwordConfirm = CLI::prompt(
+            'Password confirmation',
+            null,
+            $this->validationRules['password']
+        );
 
         if ($password !== $passwordConfirm) {
             CLI::write("The passwords don't match", 'red');
@@ -301,8 +305,11 @@ class User extends BaseCommand
      * @param string|null $email       User email to search for (optional)
      * @param string|null $newUsername User new name (optional)
      */
-    private function changename(?string $username = null, ?string $email = null, ?string $newUsername = null): void
-    {
+    private function changename(
+        ?string $username = null,
+        ?string $email = null,
+        ?string $newUsername = null
+    ): void {
         $validation = Services::validation();
         $validation->setRules([
             'username' => 'required|is_unique[users.username]',
@@ -346,8 +353,11 @@ class User extends BaseCommand
      * @param string|null $email    User email to search for (optional)
      * @param string|null $newEmail User new email (optional)
      */
-    private function changeemail(?string $username = null, ?string $email = null, ?string $newEmail = null): void
-    {
+    private function changeemail(
+        ?string $username = null,
+        ?string $email = null,
+        ?string $newEmail = null
+    ): void {
         $user = $this->findUser('Change email', $username, $email);
 
         if (! $newEmail) {
@@ -400,7 +410,10 @@ class User extends BaseCommand
             $user = $this->findUser('Delete user', $username, $email);
         }
 
-        $confirm = CLI::prompt('Delete the user ' . $user->username . ' (' . $user->email . ') ?', ['y', 'n']);
+        $confirm = CLI::prompt(
+            'Delete the user ' . $user->username . ' (' . $user->email . ') ?',
+            ['y', 'n']
+        );
 
         if ($confirm === 'y') {
             $userModel->delete($user->id, true);
@@ -483,14 +496,20 @@ class User extends BaseCommand
 
         $user = $this->findUser('Add user to group', $username, $email);
 
-        $confirm = CLI::prompt('Add the user: ' . $user->username . ' to the group: ' . $group . ' ?', ['y', 'n']);
+        $confirm = CLI::prompt(
+            'Add the user: ' . $user->username . ' to the group: ' . $group . ' ?',
+            ['y', 'n']
+        );
 
         if ($confirm === 'y') {
             $user->addGroup($group);
 
             CLI::write('User ' . $user->username . ' added to group ' . $group, 'green');
         } else {
-            CLI::write('Addition of the user: ' . $user->username . ' to the group: ' . $group . ' cancelled', 'yellow');
+            CLI::write(
+                'Addition of the user: ' . $user->username . ' to the group: ' . $group . ' cancelled',
+                'yellow'
+            );
         }
     }
 
@@ -509,7 +528,10 @@ class User extends BaseCommand
 
         $user = $this->findUser('Remove user from group', $username, $email);
 
-        $confirm = CLI::prompt('Remove the user: ' . $user->username . ' fromt the group: ' . $group . ' ?', ['y', 'n']);
+        $confirm = CLI::prompt(
+            'Remove the user: ' . $user->username . ' fromt the group: ' . $group . ' ?',
+            ['y', 'n']
+        );
 
         if ($confirm === 'y') {
             $user->removeGroup($group);

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -462,11 +462,7 @@ class User extends BaseCommand
         if ($userid !== 0) {
             $user = $userModel->findById($userid);
 
-            if ($user === null) {
-                $this->write("User doesn't exist", 'red');
-
-                throw new RuntimeException("User doesn't exis");
-            }
+            $this->checkUserExists($user);
         } else {
             $user = $this->findUser('Delete user', $username, $email);
         }
@@ -482,6 +478,18 @@ class User extends BaseCommand
             $this->write('User "' . $user->username . '" deleted', 'green');
         } else {
             $this->write('User "' . $user->username . '" deletion cancelled', 'yellow');
+        }
+    }
+
+    /**
+     * @param UserEntity|null $user
+     */
+    private function checkUserExists($user): void
+    {
+        if ($user === null) {
+            $this->write("User doesn't exist", 'red');
+
+            throw new RuntimeException("User doesn't exis");
         }
     }
 
@@ -659,11 +667,7 @@ class User extends BaseCommand
             $user = $userModel->where('secret', $email)->first();
         }
 
-        if ($user === null) {
-            $this->write("User doesn't exist", 'red');
-
-            throw new RuntimeException("User doesn't exist");
-        }
+        $this->checkUserExists($user);
 
         return $userModel->findById($user['id']);
     }

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -12,7 +12,7 @@ use Config\Services;
 
 class User extends BaseCommand
 {
-    private array $valid_actions = [
+    private array $validActions = [
         'create', 'activate', 'deactivate', 'changename', 'changeemail',
         'delete', 'password', 'list', 'addgroup', 'removegroup',
     ];
@@ -116,7 +116,7 @@ class User extends BaseCommand
     /**
      * Validation rules for user fields
      */
-    private array $validation_rules = [
+    private array $validationRules = [
         'username' => 'required|is_unique[users.username]',
         'email'    => 'required|valid_email|is_unique[auth_identities.secret]',
         'password' => 'required|min_length[10]',
@@ -129,13 +129,13 @@ class User extends BaseCommand
     {
         $action = CLI::getSegment(2);
 
-        if ($action && in_array($action, $this->valid_actions, true)) {
-            $userid       = (int) CLI::getOption('i');
-            $username     = CLI::getOption('n');
-            $email        = CLI::getOption('e');
-            $new_username = CLI::getOption('new-name');
-            $new_email    = CLI::getOption('new-email');
-            $group        = CLI::getOption('g');
+        if ($action && in_array($action, $this->validActions, true)) {
+            $userid      = (int) CLI::getOption('i');
+            $username    = CLI::getOption('n');
+            $email       = CLI::getOption('e');
+            $newUsername = CLI::getOption('new-name');
+            $newEmail    = CLI::getOption('new-email');
+            $group       = CLI::getOption('g');
 
             switch ($action) {
                 case 'create':
@@ -151,11 +151,11 @@ class User extends BaseCommand
                     break;
 
                 case 'changename':
-                    $this->changename($username, $email, $new_username);
+                    $this->changename($username, $email, $newUsername);
                     break;
 
                 case 'changeemail':
-                    $this->changeemail($username, $email, $new_email);
+                    $this->changeemail($username, $email, $newEmail);
                     break;
 
                 case 'delete':
@@ -179,7 +179,7 @@ class User extends BaseCommand
                     break;
             }
         } else {
-            CLI::write('Specify a valid action : ' . implode(',', $this->valid_actions), 'red');
+            CLI::write('Specify a valid action : ' . implode(',', $this->validActions), 'red');
         }
     }
 
@@ -194,19 +194,19 @@ class User extends BaseCommand
         $data = [];
 
         if (! $username) {
-            $username = CLI::prompt('Username', null, $this->validation_rules['username']);
+            $username = CLI::prompt('Username', null, $this->validationRules['username']);
         }
         $data['username'] = $username;
 
         if (! $email) {
-            $email = CLI::prompt('Email', null, $this->validation_rules['email']);
+            $email = CLI::prompt('Email', null, $this->validationRules['email']);
         }
         $data['email'] = $email;
 
-        $password         = CLI::prompt('Password', null, $this->validation_rules['password']);
-        $password_confirm = CLI::prompt('Password confirmation', null, $this->validation_rules['password']);
+        $password        = CLI::prompt('Password', null, $this->validationRules['password']);
+        $passwordConfirm = CLI::prompt('Password confirmation', null, $this->validationRules['password']);
 
-        if ($password !== $password_confirm) {
+        if ($password !== $passwordConfirm) {
             CLI::write("The passwords don't match", 'red');
 
             exit;
@@ -215,7 +215,7 @@ class User extends BaseCommand
 
         // Run validation if the user has passed username and/or email via command line
         $validation = Services::validation();
-        $validation->setRules($this->validation_rules);
+        $validation->setRules($this->validationRules);
         if (! $validation->run($data)) {
             foreach ($validation->getErrors() as $message) {
                 CLI::write($message, 'red');
@@ -280,11 +280,11 @@ class User extends BaseCommand
     /**
      * Change the name of an existing user by username or email
      *
-     * @param string|null $username     User name to search for (optional)
-     * @param string|null $email        User email to search for (optional)
-     * @param string|null $new_username User new name (optional)
+     * @param string|null $username    User name to search for (optional)
+     * @param string|null $email       User email to search for (optional)
+     * @param string|null $newUsername User new name (optional)
      */
-    private function changename(?string $username = null, ?string $email = null, ?string $new_username = null): void
+    private function changename(?string $username = null, ?string $email = null, ?string $newUsername = null): void
     {
         $validation = Services::validation();
         $validation->setRules([
@@ -293,15 +293,15 @@ class User extends BaseCommand
 
         $user = $this->findUser('Change username', $username, $email);
 
-        if (! $new_username) {
-            $new_username = CLI::prompt('New username', null, $this->validation_rules['username']);
+        if (! $newUsername) {
+            $newUsername = CLI::prompt('New username', null, $this->validationRules['username']);
         } else {
             // Run validation if the user has passed username and/or email via command line
             $validation = Services::validation();
             $validation->setRules([
-                'username' => $this->validation_rules['username'],
+                'username' => $this->validationRules['username'],
             ]);
-            if (! $validation->run(['username' => $new_username])) {
+            if (! $validation->run(['username' => $newUsername])) {
                 foreach ($validation->getErrors() as $message) {
                     CLI::write($message, 'red');
                 }
@@ -313,33 +313,33 @@ class User extends BaseCommand
 
         $userModel = model(UserModel::class);
 
-        $old_username   = $user->username;
-        $user->username = $new_username;
+        $oldUsername    = $user->username;
+        $user->username = $newUsername;
         $userModel->save($user);
 
-        CLI::write('Username ' . $old_username . ' changed to ' . $new_username, 'green');
+        CLI::write('Username ' . $oldUsername . ' changed to ' . $newUsername, 'green');
     }
 
     /**
      * Change the email of an existing user by username or email
      *
-     * @param string|null $username  User name to search for (optional)
-     * @param string|null $email     User email to search for (optional)
-     * @param string|null $new_email User new email (optional)
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
+     * @param string|null $newEmail User new email (optional)
      */
-    private function changeemail(?string $username = null, ?string $email = null, ?string $new_email = null): void
+    private function changeemail(?string $username = null, ?string $email = null, ?string $newEmail = null): void
     {
         $user = $this->findUser('Change email', $username, $email);
 
-        if (! $new_email) {
-            $new_email = CLI::prompt('New email', null, $this->validation_rules['email']);
+        if (! $newEmail) {
+            $newEmail = CLI::prompt('New email', null, $this->validationRules['email']);
         } else {
             // Run validation if the user has passed username and/or email via command line
             $validation = Services::validation();
             $validation->setRules([
-                'email' => $this->validation_rules['email'],
+                'email' => $this->validationRules['email'],
             ]);
-            if (! $validation->run(['email' => $new_email])) {
+            if (! $validation->run(['email' => $newEmail])) {
                 foreach ($validation->getErrors() as $message) {
                     CLI::write($message, 'red');
                 }
@@ -351,10 +351,10 @@ class User extends BaseCommand
 
         $userModel = model(UserModel::class);
 
-        $user->email = $new_email;
+        $user->email = $newEmail;
         $userModel->save($user);
 
-        CLI::write('Email for the user : ' . $user->username . ' changed to ' . $new_email, 'green');
+        CLI::write('Email for the user : ' . $user->username . ' changed to ' . $newEmail, 'green');
     }
 
     /**
@@ -400,10 +400,10 @@ class User extends BaseCommand
 
         $confirm = CLI::prompt('Set the password for the user ' . $user->username . ' ?', ['y', 'n']);
         if ($confirm === 'y') {
-            $password         = CLI::prompt('Password', null, 'required');
-            $password_confirm = CLI::prompt('Password confirmation', null, $this->validation_rules['password']);
+            $password        = CLI::prompt('Password', null, 'required');
+            $passwordConfirm = CLI::prompt('Password confirmation', null, $this->validationRules['password']);
 
-            if ($password !== $password_confirm) {
+            if ($password !== $passwordConfirm) {
                 CLI::write("The passwords don't match", 'red');
 
                 exit;

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -227,10 +227,12 @@ class User extends BaseCommand
         // Run validation if the user has passed username and/or email via command line
         $validation = Services::validation();
         $validation->setRules($this->validationRules);
+
         if (! $validation->run($data)) {
             foreach ($validation->getErrors() as $message) {
                 CLI::write($message, 'red');
             }
+
             CLI::write('User creation aborted', 'red');
 
             throw new RuntimeException('User creation aborted');
@@ -276,8 +278,10 @@ class User extends BaseCommand
      */
     private function deactivate(?string $username = null, ?string $email = null): void
     {
-        $user    = $this->findUser('Deactivate user', $username, $email);
+        $user = $this->findUser('Deactivate user', $username, $email);
+
         $confirm = CLI::prompt('Deactivate the user ' . $username . ' ?', ['y', 'n']);
+
         if ($confirm === 'y') {
             $userModel = model(UserModel::class);
 
@@ -314,10 +318,12 @@ class User extends BaseCommand
             $validation->setRules([
                 'username' => $this->validationRules['username'],
             ]);
+
             if (! $validation->run(['username' => $newUsername])) {
                 foreach ($validation->getErrors() as $message) {
                     CLI::write($message, 'red');
                 }
+
                 CLI::write('User name change aborted', 'red');
 
                 throw new RuntimeException('User name change aborted');
@@ -352,6 +358,7 @@ class User extends BaseCommand
             $validation->setRules([
                 'email' => $this->validationRules['email'],
             ]);
+
             if (! $validation->run(['email' => $newEmail])) {
                 foreach ($validation->getErrors() as $message) {
                     CLI::write($message, 'red');
@@ -383,6 +390,7 @@ class User extends BaseCommand
 
         if ($userid) {
             $user = $userModel->findById($userid);
+
             if (! $user) {
                 CLI::write("User doesn't exist", 'red');
 
@@ -393,8 +401,10 @@ class User extends BaseCommand
         }
 
         $confirm = CLI::prompt('Delete the user ' . $user->username . ' (' . $user->email . ') ?', ['y', 'n']);
+
         if ($confirm === 'y') {
             $userModel->delete($user->id, true);
+
             CLI::write('User ' . $user->username . ' deleted', 'green');
         } else {
             CLI::write('User ' . $user->username . ' deletion cancelled', 'yellow');
@@ -412,6 +422,7 @@ class User extends BaseCommand
         $user = $this->findUser('Change user password', $username, $email);
 
         $confirm = CLI::prompt('Set the password for the user ' . $user->username . ' ?', ['y', 'n']);
+
         if ($confirm === 'y') {
             $password        = CLI::prompt('Password', null, 'required');
             $passwordConfirm = CLI::prompt('Password confirmation', null, $this->validationRules['password']);
@@ -473,8 +484,10 @@ class User extends BaseCommand
         $user = $this->findUser('Add user to group', $username, $email);
 
         $confirm = CLI::prompt('Add the user: ' . $user->username . ' to the group: ' . $group . ' ?', ['y', 'n']);
+
         if ($confirm === 'y') {
             $user->addGroup($group);
+
             CLI::write('User ' . $user->username . ' added to group ' . $group, 'green');
         } else {
             CLI::write('Addition of the user: ' . $user->username . ' to the group: ' . $group . ' cancelled', 'yellow');
@@ -497,8 +510,10 @@ class User extends BaseCommand
         $user = $this->findUser('Remove user from group', $username, $email);
 
         $confirm = CLI::prompt('Remove the user: ' . $user->username . ' fromt the group: ' . $group . ' ?', ['y', 'n']);
+
         if ($confirm === 'y') {
             $user->removeGroup($group);
+
             CLI::write('User ' . $user->username . ' removed from group ' . $group, 'green');
         } else {
             CLI::write('Removal of the user: ' . $user->username . ' from the group: ' . $group . ' cancelled', 'yellow');

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -262,20 +262,20 @@ class User extends BaseCommand
         $data = [];
 
         if ($username === null) {
-            $username = $this->prompt('Username', null, $this->validationRules['username']);
+            $username = $this->prompt('Username', null, $this->validationRules['username']['rules']);
         }
         $data['username'] = $username;
 
         if ($email === null) {
-            $email = $this->prompt('Email', null, $this->validationRules['email']);
+            $email = $this->prompt('Email', null, $this->validationRules['email']['rules']);
         }
         $data['email'] = $email;
 
-        $password        = $this->prompt('Password', null, $this->validationRules['password']);
+        $password        = $this->prompt('Password', null, $this->validationRules['password']['rules']);
         $passwordConfirm = $this->prompt(
             'Password confirmation',
             null,
-            $this->validationRules['password']
+            $this->validationRules['password']['rules']
         );
 
         if ($password !== $passwordConfirm) {
@@ -370,7 +370,7 @@ class User extends BaseCommand
         $user = $this->findUser('Change username', $username, $email);
 
         if ($newUsername === null) {
-            $newUsername = $this->prompt('New username', null, $this->validationRules['username']);
+            $newUsername = $this->prompt('New username', null, $this->validationRules['username']['rules']);
         } else {
             // Run validation if the user has passed username and/or email via command line
             $validation = Services::validation();
@@ -413,7 +413,7 @@ class User extends BaseCommand
         $user = $this->findUser('Change email', $username, $email);
 
         if ($newEmail === null) {
-            $newEmail = $this->prompt('New email', null, $this->validationRules['email']);
+            $newEmail = $this->prompt('New email', null, $this->validationRules['email']['rules']);
         } else {
             // Run validation if the user has passed username and/or email via command line
             $validation = Services::validation();
@@ -498,7 +498,7 @@ class User extends BaseCommand
 
         if ($confirm === 'y') {
             $password        = $this->prompt('Password', null, 'required');
-            $passwordConfirm = $this->prompt('Password confirmation', null, $this->validationRules['password']);
+            $passwordConfirm = $this->prompt('Password confirmation', null, $this->validationRules['password']['rules']);
 
             if ($password !== $passwordConfirm) {
                 $this->write("The passwords don't match", 'red');
@@ -631,7 +631,7 @@ class User extends BaseCommand
             if ($choice === 'u') {
                 $username = $this->prompt('Username', null, 'required');
             } elseif ($choice === 'e') {
-                $email = $this->prompt('Email', null, 'required|valid_email');
+                $email = $this->prompt('Email', null, $this->validationRules['email']['rules']);
             }
         }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -6,6 +6,7 @@ namespace CodeIgniter\Shield\Commands;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Shield\Exceptions\RuntimeException;
 use CodeIgniter\Shield\Models\UserModel;
 use Config\Services;
 
@@ -144,46 +145,50 @@ class User extends BaseCommand
         $newEmail    = $params['new-email'] ?? null;
         $group       = $params['g'] ?? null;
 
-        switch ($action) {
-            case 'create':
-                $this->create($username, $email);
-                break;
+        try {
+            switch ($action) {
+                case 'create':
+                    $this->create($username, $email);
+                    break;
 
-            case 'activate':
-                $this->activate($username, $email);
-                break;
+                case 'activate':
+                    $this->activate($username, $email);
+                    break;
 
-            case 'deactivate':
-                $this->deactivate($username, $email);
-                break;
+                case 'deactivate':
+                    $this->deactivate($username, $email);
+                    break;
 
-            case 'changename':
-                $this->changename($username, $email, $newUsername);
-                break;
+                case 'changename':
+                    $this->changename($username, $email, $newUsername);
+                    break;
 
-            case 'changeemail':
-                $this->changeemail($username, $email, $newEmail);
-                break;
+                case 'changeemail':
+                    $this->changeemail($username, $email, $newEmail);
+                    break;
 
-            case 'delete':
-                $this->delete($userid, $username, $email);
-                break;
+                case 'delete':
+                    $this->delete($userid, $username, $email);
+                    break;
 
-            case 'password':
-                $this->password($username, $email);
-                break;
+                case 'password':
+                    $this->password($username, $email);
+                    break;
 
-            case 'list':
-                $this->list($username, $email);
-                break;
+                case 'list':
+                    $this->list($username, $email);
+                    break;
 
-            case 'addgroup':
-                $this->addgroup($group, $username, $email);
-                break;
+                case 'addgroup':
+                    $this->addgroup($group, $username, $email);
+                    break;
 
-            case 'removegroup':
-                $this->removegroup($group, $username, $email);
-                break;
+                case 'removegroup':
+                    $this->removegroup($group, $username, $email);
+                    break;
+            }
+        } catch (RuntimeException $e) {
+            return EXIT_ERROR;
         }
 
         return EXIT_SUCCESS;
@@ -215,7 +220,7 @@ class User extends BaseCommand
         if ($password !== $passwordConfirm) {
             CLI::write("The passwords don't match", 'red');
 
-            exit;
+            throw new RuntimeException("The passwords don't match");
         }
         $data['password'] = $password;
 
@@ -228,7 +233,7 @@ class User extends BaseCommand
             }
             CLI::write('User creation aborted', 'red');
 
-            exit;
+            throw new RuntimeException('User creation aborted');
         }
 
         $userModel = model(UserModel::class);
@@ -247,8 +252,10 @@ class User extends BaseCommand
      */
     private function activate(?string $username = null, ?string $email = null): void
     {
-        $user    = $this->findUser('Activate user', $username, $email);
+        $user = $this->findUser('Activate user', $username, $email);
+
         $confirm = CLI::prompt('Activate the user ' . $user->username . ' ?', ['y', 'n']);
+
         if ($confirm === 'y') {
             $userModel = model(UserModel::class);
 
@@ -313,7 +320,7 @@ class User extends BaseCommand
                 }
                 CLI::write('User name change aborted', 'red');
 
-                exit;
+                throw new RuntimeException('User name change aborted');
             }
         }
 
@@ -351,7 +358,7 @@ class User extends BaseCommand
                 }
                 CLI::write('User email change aborted', 'red');
 
-                exit;
+                throw new RuntimeException('User email change aborted');
             }
         }
 
@@ -379,7 +386,7 @@ class User extends BaseCommand
             if (! $user) {
                 CLI::write("User doesn't exist", 'red');
 
-                exit;
+                throw new RuntimeException("User doesn't exis");
             }
         } else {
             $user = $this->findUser('Delete user', $username, $email);
@@ -412,7 +419,7 @@ class User extends BaseCommand
             if ($password !== $passwordConfirm) {
                 CLI::write("The passwords don't match", 'red');
 
-                exit;
+                throw new RuntimeException("The passwords don't match");
             }
 
             $userModel = model(UserModel::class);
@@ -499,7 +506,7 @@ class User extends BaseCommand
     }
 
     /**
-     * Find an existing user by username or email. Exit if a user is not found
+     * Find an existing user by username or email.
      *
      * @param string      $question Initial question at user prompt
      * @param string|null $username User name to search for (optional)
@@ -509,6 +516,7 @@ class User extends BaseCommand
     {
         if (! $username && ! $email) {
             $choice = CLI::prompt($question . ' by username or email ?', ['u', 'e']);
+
             if ($choice === 'u') {
                 $username = CLI::prompt('Username', null, 'required');
             } elseif ($choice === 'e') {
@@ -531,7 +539,7 @@ class User extends BaseCommand
         if (! $user) {
             CLI::write("User doesn't exist", 'red');
 
-            exit;
+            throw new RuntimeException("User doesn't exist");
         }
 
         return $user;

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -11,6 +11,7 @@ use CodeIgniter\Shield\Config\Auth;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
 use CodeIgniter\Shield\Models\UserModel;
+use CodeIgniter\Shield\Validation\RegistrationValidationRules;
 use Config\Services;
 
 class User extends BaseCommand
@@ -140,6 +141,7 @@ class User extends BaseCommand
     {
         $this->ensureInput();
         $this->setTables();
+        $this->setValidationRules();
 
         $action = $params[0] ?? null;
 
@@ -213,6 +215,19 @@ class User extends BaseCommand
         /** @var Auth $config */
         $config       = config('Auth');
         $this->tables = $config->tables;
+    }
+
+    private function setValidationRules(): void
+    {
+        $validationRules = new RegistrationValidationRules();
+
+        $rules = $validationRules->get();
+
+        $this->validationRules = [
+            'username' => $rules['username'],
+            'email'    => $rules['email'],
+            'password' => $rules['password'],
+        ];
     }
 
     /**

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -6,7 +6,6 @@ namespace CodeIgniter\Shield\Commands;
 
 use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Models\UserModel;
 use Config\Services;
 
@@ -430,21 +429,17 @@ class User extends BaseCommand
     {
         $userModel = model(UserModel::class);
 
-        $users = $userModel
-            ->join('auth_identities', 'auth_identities.user_id = users.id')
-            ->where('auth_identities.type', Session::ID_TYPE_EMAIL_PASSWORD);
-
         if ($username) {
-            $users = $users->like('username', $username);
+            $userModel->like('username', $username);
         }
         if ($email) {
-            $users = $users->like('secret', $email);
+            $userModel->like('secret', $email);
         }
 
         CLI::write("Id\tUser");
 
-        foreach ($users->findAll() as $user) {
-            CLI::write($user->id . "\t" . $user->username . ' (' . $user->secret . ')');
+        foreach ($userModel->findAll() as $user) {
+            CLI::write($user->id . "\t" . $user->username . ' (' . $user->email . ')');
         }
     }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -126,15 +126,15 @@ class User extends BaseCommand
      */
     public function run(array $params): void
     {
-        $action = CLI::getSegment(2);
+        $action = $params[0] ?? null;
 
         if ($action && in_array($action, $this->validActions, true)) {
-            $userid      = (int) CLI::getOption('i');
-            $username    = CLI::getOption('n');
-            $email       = CLI::getOption('e');
-            $newUsername = CLI::getOption('new-name');
-            $newEmail    = CLI::getOption('new-email');
-            $group       = CLI::getOption('g');
+            $userid      = (int) ($params['i'] ?? 0);
+            $username    = $params['n'] ?? null;
+            $email       = $params['e'] ?? null;
+            $newUsername = $params['new-name'] ?? null;
+            $newEmail    = $params['new-email'] ?? null;
+            $group       = $params['g'] ?? null;
 
             switch ($action) {
                 case 'create':

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -42,7 +42,39 @@ class User extends BaseCommand
      *
      * @var string
      */
-    protected $usage = 'shield:user <action>';
+    protected $usage = <<<'EOL'
+        shield:user <action> options
+
+            shield:user create -n newusername -e newuser@example.com
+
+            shield:user activate -n username
+            shield:user activate -e user@example.com
+
+            shield:user deactivate -n username
+            shield:user deactivate -e user@example.com
+
+            shield:user changename -n username --new-name newusername
+            shield:user changename -e user@example.com --new-name newusername
+
+            shield:user changeemail -n username --new-email newuseremail@example.com
+            shield:user changeemail -e user@example.com --new-email newuseremail@example.com
+
+            shield:user delete -i 123
+            shield:user delete -n username
+            shield:user delete -e user@example.com
+
+            shield:user password -n username
+            shield:user password -e user@example.com
+
+            shield:user list
+            shield:user list -n username -e user@example.com
+
+            shield:user addgroup -n username -g mygroup
+            shield:user addgroup -e user@example.com -g mygroup
+
+            shield:user removegroup -n username -g mygroup
+            shield:user removegroup -e user@example.com -g mygroup
+        EOL;
 
     /**
      * Command's Arguments
@@ -50,7 +82,19 @@ class User extends BaseCommand
      * @var array
      */
     protected $arguments = [
-        'action' => 'Valid actions: create, activate, deactivate, changename, changeemail, delete, password, list, addgroup, removegroup',
+        'action' => <<<'EOL'
+
+                create:      Create a new user
+                activate:    Activate a user
+                deactivate:  Deactivate a user
+                changename:  Change user name
+                changeemail: Change user email
+                delete:      Delete a user
+                password:    Change a user password
+                list:        List users
+                addgroup:    Add a user to a group
+                removegroup: Remove a user from a group
+            EOL,
     ];
 
     /**
@@ -59,12 +103,12 @@ class User extends BaseCommand
      * @var array
      */
     protected $options = [
-        '-i' => 'User id',
-        '-u' => 'User name',
-        '-e' => 'User email',
-        '-n' => 'New username',
-        '-m' => 'New email',
-        '-g' => 'Group name',
+        '-i'          => 'User id',
+        '-n'          => 'User name',
+        '-e'          => 'User email',
+        '--new-name'  => 'New username',
+        '--new-email' => 'New email',
+        '-g'          => 'Group name',
     ];
 
     /**
@@ -85,10 +129,10 @@ class User extends BaseCommand
 
         if ($action && in_array($action, $this->valid_actions, true)) {
             $userid       = (int) CLI::getOption('i');
-            $username     = CLI::getOption('u');
+            $username     = CLI::getOption('n');
             $email        = CLI::getOption('e');
-            $new_username = CLI::getOption('n');
-            $new_email    = CLI::getOption('m');
+            $new_username = CLI::getOption('new-name');
+            $new_email    = CLI::getOption('new-email');
             $group        = CLI::getOption('g');
 
             switch ($action) {

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -121,11 +121,7 @@ class User extends BaseCommand
     /**
      * Validation rules for user fields
      */
-    private array $validationRules = [
-        'username' => 'required|is_unique[users.username]',
-        'email'    => 'required|valid_email|is_unique[auth_identities.secret]',
-        'password' => 'required|min_length[10]',
-    ];
+    private array $validationRules = [];
 
     /**
      * Auth Table names

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -124,62 +124,69 @@ class User extends BaseCommand
     /**
      * Displays the help for the spark cli script itself.
      */
-    public function run(array $params): void
+    public function run(array $params): int
     {
         $action = $params[0] ?? null;
 
-        if ($action && in_array($action, $this->validActions, true)) {
-            $userid      = (int) ($params['i'] ?? 0);
-            $username    = $params['n'] ?? null;
-            $email       = $params['e'] ?? null;
-            $newUsername = $params['new-name'] ?? null;
-            $newEmail    = $params['new-email'] ?? null;
-            $group       = $params['g'] ?? null;
+        if ($action === null || ! in_array($action, $this->validActions, true)) {
+            CLI::write(
+                'Specify a valid action: ' . implode(',', $this->validActions),
+                'red'
+            );
 
-            switch ($action) {
-                case 'create':
-                    $this->create($username, $email);
-                    break;
-
-                case 'activate':
-                    $this->activate($username, $email);
-                    break;
-
-                case 'deactivate':
-                    $this->deactivate($username, $email);
-                    break;
-
-                case 'changename':
-                    $this->changename($username, $email, $newUsername);
-                    break;
-
-                case 'changeemail':
-                    $this->changeemail($username, $email, $newEmail);
-                    break;
-
-                case 'delete':
-                    $this->delete($userid, $username, $email);
-                    break;
-
-                case 'password':
-                    $this->password($username, $email);
-                    break;
-
-                case 'list':
-                    $this->list($username, $email);
-                    break;
-
-                case 'addgroup':
-                    $this->addgroup($group, $username, $email);
-                    break;
-
-                case 'removegroup':
-                    $this->removegroup($group, $username, $email);
-                    break;
-            }
-        } else {
-            CLI::write('Specify a valid action: ' . implode(',', $this->validActions), 'red');
+            return EXIT_ERROR;
         }
+
+        $userid      = (int) ($params['i'] ?? 0);
+        $username    = $params['n'] ?? null;
+        $email       = $params['e'] ?? null;
+        $newUsername = $params['new-name'] ?? null;
+        $newEmail    = $params['new-email'] ?? null;
+        $group       = $params['g'] ?? null;
+
+        switch ($action) {
+            case 'create':
+                $this->create($username, $email);
+                break;
+
+            case 'activate':
+                $this->activate($username, $email);
+                break;
+
+            case 'deactivate':
+                $this->deactivate($username, $email);
+                break;
+
+            case 'changename':
+                $this->changename($username, $email, $newUsername);
+                break;
+
+            case 'changeemail':
+                $this->changeemail($username, $email, $newEmail);
+                break;
+
+            case 'delete':
+                $this->delete($userid, $username, $email);
+                break;
+
+            case 'password':
+                $this->password($username, $email);
+                break;
+
+            case 'list':
+                $this->list($username, $email);
+                break;
+
+            case 'addgroup':
+                $this->addgroup($group, $username, $email);
+                break;
+
+            case 'removegroup':
+                $this->removegroup($group, $username, $email);
+                break;
+        }
+
+        return EXIT_SUCCESS;
     }
 
     /**

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -216,7 +216,7 @@ class User extends BaseCommand
     /**
      * Outputs a string to the cli on its own line.
      */
-    private static function write(
+    private function write(
         string $text = '',
         ?string $foreground = null,
         ?string $background = null

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -179,7 +179,7 @@ class User extends BaseCommand
                     break;
             }
         } else {
-            CLI::write('Specify a valid action : ' . implode(',', $this->validActions), 'red');
+            CLI::write('Specify a valid action: ' . implode(',', $this->validActions), 'red');
         }
     }
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -136,8 +136,8 @@ class User extends BaseCommand
     /**
      * Create a new user
      *
-     * @param $username User name to create (optional)
-     * @param $email    User email to create (optional)
+     * @param string|null $username User name to create (optional)
+     * @param string|null $email    User email to create (optional)
      */
     private function create(?string $username = null, ?string $email = null): void
     {
@@ -184,8 +184,8 @@ class User extends BaseCommand
     /**
      * Activate an existing user by username or email
      *
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function activate(?string $username = null, ?string $email = null): void
     {
@@ -204,8 +204,8 @@ class User extends BaseCommand
     /**
      * Deactivate an existing user by username or email
      *
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function deactivate(?string $username = null, ?string $email = null): void
     {
@@ -224,9 +224,9 @@ class User extends BaseCommand
     /**
      * Change the name of an existing user by username or email
      *
-     * @param $username     User name to search for (optional)
-     * @param $email        User email to search for (optional)
-     * @param $new_username User new name (optional)
+     * @param string|null $username     User name to search for (optional)
+     * @param string|null $email        User email to search for (optional)
+     * @param string|null $new_username User new name (optional)
      */
     private function changename(?string $username = null, ?string $email = null, ?string $new_username = null): void
     {
@@ -265,9 +265,9 @@ class User extends BaseCommand
     /**
      * Change the email of an existing user by username or email
      *
-     * @param $username  User name to search for (optional)
-     * @param $email     User email to search for (optional)
-     * @param $new_email User new email (optional)
+     * @param string|null $username  User name to search for (optional)
+     * @param string|null $email     User email to search for (optional)
+     * @param string|null $new_email User new email (optional)
      */
     private function changeemail(?string $username = null, ?string $email = null, ?string $new_email = null): void
     {
@@ -300,9 +300,9 @@ class User extends BaseCommand
     /**
      * Delete an existing user by username or email
      *
-     * @param $userid   User id to delete (optional)
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param int         $userid   User id to delete (optional)
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function delete(int $userid = 0, ?string $username = null, ?string $email = null): void
     {
@@ -330,8 +330,8 @@ class User extends BaseCommand
     /**
      * Change the password of an existing user by username or email
      *
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function password($username = null, $email = null): void
     {
@@ -361,8 +361,8 @@ class User extends BaseCommand
     /**
      * List users searching by username or email
      *
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function list(?string $username = null, ?string $email = null): void
     {
@@ -385,9 +385,9 @@ class User extends BaseCommand
     /**
      * Add a user by username or email to a group
      *
-     * @param $group    Group to add user to
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param string|null $group    Group to add user to
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function addgroup($group = null, $username = null, $email = null): void
     {
@@ -409,9 +409,9 @@ class User extends BaseCommand
     /**
      * Remove a user by username or email from a group
      *
-     * @param $group    Group to remove user from
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param string|null $group    Group to remove user from
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function removegroup($group = null, $username = null, $email = null): void
     {
@@ -433,9 +433,9 @@ class User extends BaseCommand
     /**
      * Find an existing user by username or email. Exit if a user is not found
      *
-     * @param $question Initial question at user prompt
-     * @param $username User name to search for (optional)
-     * @param $email    User email to search for (optional)
+     * @param string      $question Initial question at user prompt
+     * @param string|null $username User name to search for (optional)
+     * @param string|null $email    User email to search for (optional)
      */
     private function findUser($question = '', $username = null, $email = null): \CodeIgniter\Shield\Entities\User
     {

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -367,11 +367,6 @@ class User extends BaseCommand
         ?string $email = null,
         ?string $newUsername = null
     ): void {
-        $validation = Services::validation();
-        $validation->setRules([
-            'username' => 'required|is_unique[users.username]',
-        ]);
-
         $user = $this->findUser('Change username', $username, $email);
 
         if ($newUsername === null) {

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -42,7 +42,7 @@ class User extends BaseCommand
      *
      * @var string
      */
-    protected $description = 'Manage Shield users';
+    protected $description = 'Manage Shield users.';
 
     /**
      * Command's usage

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -176,7 +176,7 @@ class User extends BaseCommand
         }
 
         $userModel = model('CodeIgniter\Shield\Models\UserModel');
-        $user  = new \CodeIgniter\Shield\Entities\User($data);
+        $user      = new \CodeIgniter\Shield\Entities\User($data);
         $userModel->save($user);
         CLI::write('User ' . $username . ' created', 'green');
     }
@@ -367,7 +367,7 @@ class User extends BaseCommand
     private function list(?string $username = null, ?string $email = null): void
     {
         $userModel = model('CodeIgniter\Shield\Models\UserModel');
-        $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
+        $users     = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
         if ($username) {
             $users = $users->like('username', $username);
         }
@@ -448,9 +448,9 @@ class User extends BaseCommand
             }
         }
 
-        $user  = new \CodeIgniter\Shield\Entities\User();
+        $user      = new \CodeIgniter\Shield\Entities\User();
         $userModel = model('CodeIgniter\Shield\Models\UserModel');
-        $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
+        $users     = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
 
         if ($username) {
             $user = $users->where('username', $username)->first();

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Commands;
 
 use CodeIgniter\CLI\BaseCommand;
-use CodeIgniter\CLI\CLI;
 use CodeIgniter\Shield\Commands\Utils\InputOutput;
+use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Exceptions\RuntimeException;
 use CodeIgniter\Shield\Models\UserModel;
 use Config\Services;
@@ -273,7 +273,7 @@ class User extends BaseCommand
 
         $userModel = model(UserModel::class);
 
-        $user = new \CodeIgniter\Shield\Entities\User($data);
+        $user = new UserEntity($data);
         $userModel->save($user);
 
         $this->write('User "' . $username . '" created', 'green');
@@ -578,7 +578,7 @@ class User extends BaseCommand
      * @param string|null $username User name to search for (optional)
      * @param string|null $email    User email to search for (optional)
      */
-    private function findUser($question = '', $username = null, $email = null): \CodeIgniter\Shield\Entities\User
+    private function findUser($question = '', $username = null, $email = null): UserEntity
     {
         if ($username === null && $email === null) {
             $choice = $this->prompt($question . ' by username or email ?', ['u', 'e']);
@@ -592,7 +592,7 @@ class User extends BaseCommand
 
         $userModel = model(UserModel::class);
 
-        $user = new \CodeIgniter\Shield\Entities\User();
+        $user = new UserEntity();
 
         $users = $userModel->join('auth_identities', 'auth_identities.user_id = users.id');
 

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -10,7 +10,10 @@ use Config\Services;
 
 class User extends BaseCommand
 {
-    private array $valid_actions = ['create', 'activate', 'deactivate', 'changename', 'changeemail', 'delete', 'password', 'list', 'addgroup', 'removegroup'];
+    private array $valid_actions = [
+        'create', 'activate', 'deactivate', 'changename', 'changeemail',
+        'delete', 'password', 'list', 'addgroup', 'removegroup',
+    ];
 
     /**
      * The group the command is lumped under
@@ -47,7 +50,7 @@ class User extends BaseCommand
      * @var array
      */
     protected $arguments = [
-        'action' => 'Valid actions : create, activate, deactivate, changename, changeemail, delete, password, list, addgroup, removegroup',
+        'action' => 'Valid actions: create, activate, deactivate, changename, changeemail, delete, password, list, addgroup, removegroup',
     ];
 
     /**
@@ -79,6 +82,7 @@ class User extends BaseCommand
     public function run(array $params): void
     {
         $action = CLI::getSegment(2);
+
         if ($action && in_array($action, $this->valid_actions, true)) {
             $userid       = (int) CLI::getOption('i');
             $username     = CLI::getOption('u');

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -603,7 +603,7 @@ class User extends BaseCommand
 
         $userModel = model(UserModel::class);
         $userModel
-            ->select('users.id as id, username, secret as email')
+            ->select('users.id as id, username, secret')
             ->join('auth_identities', 'users.id = auth_identities.user_id', 'LEFT')
             ->groupStart()
             ->where('auth_identities.type', Session::ID_TYPE_EMAIL_PASSWORD)
@@ -617,7 +617,7 @@ class User extends BaseCommand
         if ($username !== null) {
             $user = $userModel->where('username', $username)->first();
         } elseif ($email !== null) {
-            $user = $userModel->where('email', $email)->first();
+            $user = $userModel->where('secret', $email)->first();
         }
 
         if ($user === null) {

--- a/src/Commands/Utils/InputOutput.php
+++ b/src/Commands/Utils/InputOutput.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Commands\Utils;
+
+use CodeIgniter\CLI\CLI;
+
+class InputOutput
+{
+    /**
+     * Asks the user for input.
+     *
+     * @param string       $field      Output "field" question
+     * @param array|string $options    String to a default value, array to a list of options (the first option will be the default value)
+     * @param array|string $validation Validation rules
+     *
+     * @return string The user input
+     */
+    public function prompt(string $field, $options = null, $validation = null): string
+    {
+        return CLI::prompt($field, $options, $validation);
+    }
+
+    /**
+     * Outputs a string to the cli on its own line.
+     */
+    public function write(
+        string $text = '',
+        ?string $foreground = null,
+        ?string $background = null
+    ): void {
+        CLI::write($text, $foreground, $background);
+    }
+}

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -10,12 +10,11 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
-use CodeIgniter\Shield\Authentication\Passwords;
-use CodeIgniter\Shield\Config\Auth;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\ValidationException;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Traits\Viewable;
+use CodeIgniter\Shield\Validation\RegistrationValidationRules;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -30,11 +29,6 @@ class RegisterController extends BaseController
 
     protected $helpers = ['setting'];
 
-    /**
-     * Auth Table names
-     */
-    protected array $tables;
-
     public function initController(
         RequestInterface $request,
         ResponseInterface $response,
@@ -45,10 +39,6 @@ class RegisterController extends BaseController
             $response,
             $logger
         );
-
-        /** @var Auth $authConfig */
-        $authConfig   = config('Auth');
-        $this->tables = $authConfig->tables;
     }
 
     /**
@@ -175,37 +165,10 @@ class RegisterController extends BaseController
      * @return array<string, array<string, array<string>|string>>
      * @phpstan-return array<string, array<string, string|list<string>>>
      */
-    protected function getValidationRules(): array
+    public function getValidationRules(): array
     {
-        $registrationUsernameRules = array_merge(
-            config('AuthSession')->usernameValidationRules,
-            [sprintf('is_unique[%s.username]', $this->tables['users'])]
-        );
-        $registrationEmailRules = array_merge(
-            config('AuthSession')->emailValidationRules,
-            [sprintf('is_unique[%s.secret]', $this->tables['identities'])]
-        );
+        $rules = new RegistrationValidationRules();
 
-        return setting('Validation.registration') ?? [
-            'username' => [
-                'label' => 'Auth.username',
-                'rules' => $registrationUsernameRules,
-            ],
-            'email' => [
-                'label' => 'Auth.email',
-                'rules' => $registrationEmailRules,
-            ],
-            'password' => [
-                'label'  => 'Auth.password',
-                'rules'  => 'required|' . Passwords::getMaxLengthRule() . '|strong_password[]',
-                'errors' => [
-                    'max_byte' => 'Auth.errorPasswordTooLongBytes',
-                ],
-            ],
-            'password_confirm' => [
-                'label' => 'Auth.passwordConfirm',
-                'rules' => 'required|matches[password]',
-            ],
-        ];
+        return $rules->get();
     }
 }

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -165,7 +165,7 @@ class RegisterController extends BaseController
      * @return array<string, array<string, array<string>|string>>
      * @phpstan-return array<string, array<string, string|list<string>>>
      */
-    public function getValidationRules(): array
+    protected function getValidationRules(): array
     {
         $rules = new RegistrationValidationRules();
 

--- a/src/Exceptions/UserNotFoundException.php
+++ b/src/Exceptions/UserNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Exceptions;
+
+class UserNotFoundException extends RuntimeException
+{
+}

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -24,6 +24,11 @@ final class MockInputOutput extends InputOutput
         return array_pop($this->outputs);
     }
 
+    public function getFirstOutput(): string
+    {
+        return array_shift($this->outputs);
+    }
+
     /**
      * Returns all outputs.
      */

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -6,8 +6,8 @@ namespace CodeIgniter\Shield\Test;
 
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CodeIgniter;
-use CodeIgniter\Log\Exceptions\LogException;
 use CodeIgniter\Shield\Commands\Utils\InputOutput;
+use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
 use CodeIgniter\Test\PhpStreamWrapper;
 
@@ -67,7 +67,7 @@ final class MockInputOutput extends InputOutput
             CITestStreamFilter::removeErrorFilter();
 
             if ($input !== $userInput) {
-                throw new LogException($input . '!==' . $userInput);
+                throw new LogicException($input . '!==' . $userInput);
             }
         }
 

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -21,7 +21,7 @@ final class MockInputOutput extends InputOutput
 
     public function getLastOutput(): string
     {
-        return array_shift($this->outputs);
+        return array_pop($this->outputs);
     }
 
     /**

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Commands\Utils;
+namespace CodeIgniter\Shield\Test;
 
 use CodeIgniter\CLI\CLI;
 use CodeIgniter\CodeIgniter;

--- a/src/Validation/RegistrationValidationRules.php
+++ b/src/Validation/RegistrationValidationRules.php
@@ -32,6 +32,8 @@ class RegistrationValidationRules
             [sprintf('is_unique[%s.secret]', $this->tables['identities'])]
         );
 
+        helper('setting');
+
         return setting('Validation.registration') ?? [
             'username' => [
                 'label' => 'Auth.username',

--- a/src/Validation/RegistrationValidationRules.php
+++ b/src/Validation/RegistrationValidationRules.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Validation;
+
+use CodeIgniter\Shield\Authentication\Passwords;
+use CodeIgniter\Shield\Config\Auth;
+
+class RegistrationValidationRules
+{
+    /**
+     * Auth Table names
+     */
+    private array $tables;
+
+    public function __construct()
+    {
+        /** @var Auth $authConfig */
+        $authConfig   = config('Auth');
+        $this->tables = $authConfig->tables;
+    }
+
+    public function get(): array
+    {
+        $registrationUsernameRules = array_merge(
+            config('AuthSession')->usernameValidationRules,
+            [sprintf('is_unique[%s.username]', $this->tables['users'])]
+        );
+        $registrationEmailRules = array_merge(
+            config('AuthSession')->emailValidationRules,
+            [sprintf('is_unique[%s.secret]', $this->tables['identities'])]
+        );
+
+        return setting('Validation.registration') ?? [
+            'username' => [
+                'label' => 'Auth.username',
+                'rules' => $registrationUsernameRules,
+            ],
+            'email' => [
+                'label' => 'Auth.email',
+                'rules' => $registrationEmailRules,
+            ],
+            'password' => [
+                'label'  => 'Auth.password',
+                'rules'  => 'required|' . Passwords::getMaxLengthRule() . '|strong_password[]',
+                'errors' => [
+                    'max_byte' => 'Auth.errorPasswordTooLongBytes',
+                ],
+            ],
+            'password_confirm' => [
+                'label' => 'Auth.passwordConfirm',
+                'rules' => 'required|matches[password]',
+            ],
+        ];
+    }
+}

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -8,7 +8,7 @@ use CodeIgniter\Shield\Commands\User;
 use CodeIgniter\Shield\Commands\Utils\InputOutput;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Models\UserModel;
-use Tests\Commands\Utils\MockInputOutput;
+use CodeIgniter\Shield\Test\MockInputOutput;
 use Tests\Support\DatabaseTestCase;
 
 /**

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Commands;
 
 use CodeIgniter\Shield\Commands\User;
-use CodeIgniter\Shield\Commands\Utils\InputOutput;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Test\MockInputOutput;
@@ -16,7 +15,7 @@ use Tests\Support\DatabaseTestCase;
  */
 final class UserTest extends DatabaseTestCase
 {
-    private ?InputOutput $io = null;
+    private ?MockInputOutput $io = null;
 
     protected function tearDown(): void
     {

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -64,12 +64,22 @@ final class UserTest extends DatabaseTestCase
         ]);
     }
 
+    private function createUser(array $userData): UserEntity
+    {
+        /** @var UserEntity $user */
+        $user = fake(UserModel::class, ['username' => $userData['username']]);
+        $user->createEmailIdentity([
+            'email'    => $userData['email'],
+            'password' => $userData['password'],
+        ]);
+
+        return $user;
+    }
+
     public function testActivate(): void
     {
-        // Create a user.
-        /** @var UserEntity $user */
-        $user = fake(UserModel::class, ['username' => 'user2']);
-        $user->createEmailIdentity([
+        $user = $this->createUser([
+            'username' => 'user2',
             'email'    => 'user2@example.com',
             'password' => 'secret123',
         ]);
@@ -93,10 +103,8 @@ final class UserTest extends DatabaseTestCase
 
     public function testDeactivate(): void
     {
-        // Create a user.
-        /** @var UserEntity $user */
-        $user = fake(UserModel::class, ['username' => 'user3', 'active' => 1]);
-        $user->createEmailIdentity([
+        $user = $this->createUser([
+            'username' => 'user3',
             'email'    => 'user3@example.com',
             'password' => 'secret123',
         ]);

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -325,6 +325,28 @@ final class UserTest extends DatabaseTestCase
         $this->assertTrue($user->inGroup('admin'));
     }
 
+    public function testAddgroupCancel(): void
+    {
+        $this->createUser([
+            'username' => 'user10',
+            'email'    => 'user10@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $this->setMockIo(['n']);
+
+        command('shield:user addgroup -n user10 -g admin');
+
+        $this->assertStringContainsString(
+            'Addition of the user "user10" to the group "admin" cancelled',
+            $this->io->getLastOutput()
+        );
+
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user10@example.com']);
+        $this->assertFalse($user->inGroup('admin'));
+    }
+
     public function testRemovegroup(): void
     {
         $this->createUser([

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use CodeIgniter\CodeIgniter;
+use CodeIgniter\Shield\Entities\User;
+use CodeIgniter\Shield\Models\UserModel;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+use CodeIgniter\Test\PhpStreamWrapper;
+use Tests\Support\DatabaseTestCase;
+
+/**
+ * @internal
+ */
+final class UserTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
+            CITestStreamFilter::registration();
+            CITestStreamFilter::addOutputFilter();
+        } else {
+            $this->markTestSkipped('Cannot write tests with CI 4.2.x');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeErrorFilter();
+    }
+
+    private function setUserInput(string $input): void
+    {
+        // Register the PhpStreamWrapper.
+        PhpStreamWrapper::register();
+
+        PhpStreamWrapper::setContent($input);
+    }
+
+    private function resetUserInput(): void
+    {
+        // Restore php protocol wrapper.
+        PhpStreamWrapper::restore();
+    }
+
+    public function testCreate(): void
+    {
+        $input = 'Secret Passw0rd!';
+        $this->setUserInput($input);
+
+        command('shield:user create -n user1 -e user1@example.com');
+
+        $this->resetUserInput();
+
+        $this->assertStringContainsString(
+            'User user1 created',
+            CITestStreamFilter::$buffer
+        );
+
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user1@example.com']);
+        $this->seeInDatabase($this->tables['identities'], [
+            'user_id' => $user->id,
+            'secret'  => 'user1@example.com',
+        ]);
+        $this->seeInDatabase($this->tables['users'], [
+            'id'     => $user->id,
+            'active' => 0,
+        ]);
+    }
+
+    public function testActivate(): void
+    {
+        // Create a user.
+        /** @var User $user */
+        $user = fake(UserModel::class, ['username' => 'user2']);
+        $user->createEmailIdentity([
+            'email'    => 'user2@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $input = 'y';
+        $this->setUserInput($input);
+
+        command('shield:user activate -n user2');
+
+        $this->resetUserInput();
+
+        $this->assertStringContainsString(
+            'User user2 activated',
+            CITestStreamFilter::$buffer
+        );
+
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user2@example.com']);
+        $this->seeInDatabase($this->tables['users'], [
+            'id'     => $user->id,
+            'active' => 1,
+        ]);
+    }
+
+    public function testDeactivate(): void
+    {
+        // Create a user.
+        /** @var User $user */
+        $user = fake(UserModel::class, ['username' => 'user3', 'active' => 1]);
+        $user->createEmailIdentity([
+            'email'    => 'user3@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $input = 'y';
+        $this->setUserInput($input);
+
+        command('shield:user deactivate -n user3');
+
+        $this->resetUserInput();
+
+        $this->assertStringContainsString(
+            'User user3 deactivated',
+            CITestStreamFilter::$buffer
+        );
+
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user3@example.com']);
+        $this->seeInDatabase($this->tables['users'], [
+            'id'     => $user->id,
+            'active' => 0,
+        ]);
+    }
+}

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -254,6 +254,31 @@ final class UserTest extends DatabaseTestCase
         );
     }
 
+    public function testListByEmail(): void
+    {
+        $this->createUser([
+            'username' => 'user8',
+            'email'    => 'user8@example.com',
+            'password' => 'secret123',
+        ]);
+        $this->createUser([
+            'username' => 'user9',
+            'email'    => 'user9@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $this->setMockIo([]);
+
+        command('shield:user list -e user9@example.com');
+
+        $this->assertStringContainsString(
+            'Id	User
+2	user9 (user9@example.com)
+',
+            $this->io->getOutputs()
+        );
+    }
+
     public function testAddgroup(): void
     {
         $this->createUser([

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -228,6 +228,30 @@ final class UserTest extends DatabaseTestCase
         $this->assertNotSame($oldPasswordHash, $user->password_hash);
     }
 
+    public function testPasswordWithoutOptionsAndSpecifyEmail(): void
+    {
+        $this->createUser([
+            'username' => 'user7',
+            'email'    => 'user7@example.com',
+            'password' => 'secret123',
+        ]);
+        $users           = model(UserModel::class);
+        $user            = $users->findByCredentials(['email' => 'user7@example.com']);
+        $oldPasswordHash = $user->password_hash;
+
+        $this->setMockIo(['e', 'user7@example.com', 'y', 'newpassword', 'newpassword']);
+
+        command('shield:user password');
+
+        $this->assertStringContainsString(
+            'Password for "user7" set',
+            $this->io->getLastOutput()
+        );
+
+        $user = $users->findByCredentials(['email' => 'user7@example.com']);
+        $this->assertNotSame($oldPasswordHash, $user->password_hash);
+    }
+
     public function testList(): void
     {
         $this->createUser([

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -48,7 +48,7 @@ final class UserTest extends DatabaseTestCase
         command('shield:user create -n user1 -e user1@example.com');
 
         $this->assertStringContainsString(
-            'User user1 created',
+            'User "user1" created',
             $this->io->getLastOutput()
         );
 
@@ -96,7 +96,7 @@ final class UserTest extends DatabaseTestCase
         command('shield:user activate -n user2');
 
         $this->assertStringContainsString(
-            'User user2 activated',
+            'User "user2" activated',
             $this->io->getLastOutput()
         );
 
@@ -120,7 +120,7 @@ final class UserTest extends DatabaseTestCase
         command('shield:user deactivate -n user3');
 
         $this->assertStringContainsString(
-            'User user3 deactivated',
+            'User "user3" deactivated',
             $this->io->getLastOutput()
         );
 

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -60,7 +60,7 @@ final class UserTest extends DatabaseTestCase
 
         $this->assertStringContainsString(
             'User "user1" created',
-            $this->io->getLastOutput()
+            $this->io->getFirstOutput()
         );
 
         $users = model(UserModel::class);
@@ -92,11 +92,11 @@ final class UserTest extends DatabaseTestCase
 
         $this->assertStringContainsString(
             'The Username field must contain a unique value.',
-            $this->io->getOutputs()
+            $this->io->getFirstOutput()
         );
         $this->assertStringContainsString(
             'User creation aborted',
-            $this->io->getOutputs()
+            $this->io->getFirstOutput()
         );
 
         $users = model(UserModel::class);
@@ -211,11 +211,11 @@ final class UserTest extends DatabaseTestCase
 
         $this->assertStringContainsString(
             'The Username field must be at least 3 characters in length.',
-            $this->io->getOutputs()
+            $this->io->getFirstOutput()
         );
         $this->assertStringContainsString(
             'User name change aborted',
-            $this->io->getOutputs()
+            $this->io->getFirstOutput()
         );
 
         $users = model(UserModel::class);
@@ -265,11 +265,11 @@ final class UserTest extends DatabaseTestCase
 
         $this->assertStringContainsString(
             'The Email Address field must contain a valid email address.',
-            $this->io->getOutputs()
+            $this->io->getFirstOutput()
         );
         $this->assertStringContainsString(
             'User email change aborted',
-            $this->io->getOutputs()
+            $this->io->getFirstOutput()
         );
 
         $users = model(UserModel::class);

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -64,6 +64,9 @@ final class UserTest extends DatabaseTestCase
         ]);
     }
 
+    /**
+     * Create an active user.
+     */
     private function createUser(array $userData): UserEntity
     {
         /** @var UserEntity $user */
@@ -84,6 +87,10 @@ final class UserTest extends DatabaseTestCase
             'password' => 'secret123',
         ]);
 
+        $user->deactivate();
+        $users = model(UserModel::class);
+        $users->save($user);
+
         $this->setMockIo(['y']);
 
         command('shield:user activate -n user2');
@@ -93,8 +100,7 @@ final class UserTest extends DatabaseTestCase
             $this->io->getLastOutput()
         );
 
-        $users = model(UserModel::class);
-        $user  = $users->findByCredentials(['email' => 'user2@example.com']);
+        $user = $users->findByCredentials(['email' => 'user2@example.com']);
         $this->seeInDatabase($this->tables['users'], [
             'id'     => $user->id,
             'active' => 1,
@@ -103,7 +109,7 @@ final class UserTest extends DatabaseTestCase
 
     public function testDeactivate(): void
     {
-        $user = $this->createUser([
+        $this->createUser([
             'username' => 'user3',
             'email'    => 'user3@example.com',
             'password' => 'secret123',

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -356,7 +356,9 @@ final class UserTest extends DatabaseTestCase
         $user            = $users->findByCredentials(['email' => 'user7@example.com']);
         $oldPasswordHash = $user->password_hash;
 
-        $this->setMockIo(['e', 'user7@example.com', 'y', 'newpassword', 'newpassword']);
+        $this->setMockIo([
+            'e', 'user7@example.com', 'y', 'newpassword', 'newpassword',
+        ]);
 
         command('shield:user password');
 

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Commands;
 
 use CodeIgniter\Shield\Commands\User;
+use CodeIgniter\Shield\Commands\Utils\InputOutput;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Models\UserModel;
 use Tests\Commands\Utils\MockInputOutput;
@@ -15,6 +16,8 @@ use Tests\Support\DatabaseTestCase;
  */
 final class UserTest extends DatabaseTestCase
 {
+    private ?InputOutput $io = null;
+
     protected function tearDown(): void
     {
         parent::tearDown();
@@ -22,20 +25,31 @@ final class UserTest extends DatabaseTestCase
         User::resetInputOutput();
     }
 
+    /**
+     * Set MockInputOutput and user inputs.
+     *
+     * @param array<int, string> $inputs User inputs
+     * @phpstan-param list<string> $inputs
+     */
+    private function setMockIo(array $inputs): void
+    {
+        $this->io = new MockInputOutput();
+        $this->io->setInputs($inputs);
+        User::setInputOutput($this->io);
+    }
+
     public function testCreate(): void
     {
-        $io = new MockInputOutput();
-        $io->setInputs([
+        $this->setMockIo([
             'Secret Passw0rd!',
             'Secret Passw0rd!',
         ]);
-        User::setInputOutput($io);
 
         command('shield:user create -n user1 -e user1@example.com');
 
         $this->assertStringContainsString(
             'User user1 created',
-            $io->getLastOutput()
+            $this->io->getLastOutput()
         );
 
         $users = model(UserModel::class);
@@ -60,17 +74,13 @@ final class UserTest extends DatabaseTestCase
             'password' => 'secret123',
         ]);
 
-        $io = new MockInputOutput();
-        $io->setInputs([
-            'y',
-        ]);
-        User::setInputOutput($io);
+        $this->setMockIo(['y']);
 
         command('shield:user activate -n user2');
 
         $this->assertStringContainsString(
             'User user2 activated',
-            $io->getLastOutput()
+            $this->io->getLastOutput()
         );
 
         $users = model(UserModel::class);
@@ -91,17 +101,13 @@ final class UserTest extends DatabaseTestCase
             'password' => 'secret123',
         ]);
 
-        $io = new MockInputOutput();
-        $io->setInputs([
-            'y',
-        ]);
-        User::setInputOutput($io);
+        $this->setMockIo(['y']);
 
         command('shield:user deactivate -n user3');
 
         $this->assertStringContainsString(
             'User user3 deactivated',
-            $io->getLastOutput()
+            $this->io->getLastOutput()
         );
 
         $users = model(UserModel::class);

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -15,6 +15,13 @@ use Tests\Support\DatabaseTestCase;
  */
 final class UserTest extends DatabaseTestCase
 {
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        User::resetInputOutput();
+    }
+
     public function testCreate(): void
     {
         $io = new MockInputOutput();
@@ -25,8 +32,6 @@ final class UserTest extends DatabaseTestCase
         User::setInputOutput($io);
 
         command('shield:user create -n user1 -e user1@example.com');
-
-        User::resetInputOutput();
 
         $this->assertStringContainsString(
             'User user1 created',
@@ -63,8 +68,6 @@ final class UserTest extends DatabaseTestCase
 
         command('shield:user activate -n user2');
 
-        User::resetInputOutput();
-
         $this->assertStringContainsString(
             'User user2 activated',
             $io->getLastOutput()
@@ -95,8 +98,6 @@ final class UserTest extends DatabaseTestCase
         User::setInputOutput($io);
 
         command('shield:user deactivate -n user3');
-
-        User::resetInputOutput();
 
         $this->assertStringContainsString(
             'User user3 deactivated',

--- a/tests/Commands/Utils/MockInputOutput.php
+++ b/tests/Commands/Utils/MockInputOutput.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands\Utils;
+
+use CodeIgniter\CLI\CLI;
+use CodeIgniter\CodeIgniter;
+use CodeIgniter\Shield\Commands\Utils\InputOutput;
+use CodeIgniter\Test\Filters\CITestStreamFilter;
+
+final class MockInputOutput extends InputOutput
+{
+    private array $inputs  = [];
+    private array $outputs = [];
+
+    public function setInputs(array $inputs): void
+    {
+        $this->inputs = $inputs;
+    }
+
+    public function getLastOutput(): string
+    {
+        return array_shift($this->outputs);
+    }
+
+    public function prompt(string $field, $options = null, $validation = null): string
+    {
+        return array_shift($this->inputs);
+    }
+
+    public function write(
+        string $text = '',
+        ?string $foreground = null,
+        ?string $background = null
+    ): void {
+        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
+            CITestStreamFilter::registration();
+            CITestStreamFilter::addOutputFilter();
+        } else {
+            CITestStreamFilter::$buffer = '';
+
+            $streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
+        }
+
+        CLI::write($text, $foreground, $background);
+        $this->outputs[] = CITestStreamFilter::$buffer;
+
+        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
+            CITestStreamFilter::removeOutputFilter();
+            CITestStreamFilter::removeErrorFilter();
+        } else {
+            stream_filter_remove($streamFilter);
+        }
+    }
+}

--- a/tests/Commands/Utils/MockInputOutput.php
+++ b/tests/Commands/Utils/MockInputOutput.php
@@ -24,6 +24,14 @@ final class MockInputOutput extends InputOutput
         return array_shift($this->outputs);
     }
 
+    /**
+     * Returns all outputs.
+     */
+    public function getOutputs(): string
+    {
+        return implode('', $this->outputs);
+    }
+
     public function prompt(string $field, $options = null, $validation = null): string
     {
         return array_shift($this->inputs);


### PR DESCRIPTION
**Description**
Supersedes #579
Closes #566

Add command `shield:user` to manage users:
```
            shield:user create -n newusername -e newuser@example.com
```
```
            shield:user activate -n username
            shield:user activate -e user@example.com
```
```
            shield:user deactivate -n username
            shield:user deactivate -e user@example.com
```
```
            shield:user changename -n username --new-name newusername
            shield:user changename -e user@example.com --new-name newusername
```
```
            shield:user changeemail -n username --new-email newuseremail@example.com
            shield:user changeemail -e user@example.com --new-email newuseremail@example.com
```
```
            shield:user delete -i 123
            shield:user delete -n username
            shield:user delete -e user@example.com
```
```
            shield:user password -n username
            shield:user password -e user@example.com
```
```
            shield:user list
            shield:user list -n username -e user@example.com
```
```
            shield:user addgroup -n username -g mygroup
            shield:user addgroup -e user@example.com -g mygroup
```
```
            shield:user removegroup -n username -g mygroup
            shield:user removegroup -e user@example.com -g mygroup
```

TODO
- [x] remove `exit()`
- [x] fix if conditions
- [x] fix hard-coded table names
- [x] fix hard-coded validation rules

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
