### PR TITLE
chore: update phpstan-codeigniter to v1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "codeigniter4/settings": "^2.1"
     },
     "require-dev": {
-        "codeigniter/phpstan-codeigniter": "^1.1",
+        "codeigniter/phpstan-codeigniter": "^1.3",
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": "^4.2.7",
         "firebase/php-jwt": "^6.4",

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
@@ -264,8 +262,28 @@ The type \'basic\', \'md5\', and \'sha1\' are deprecated\\. They are not cryptog
 	'path' => __DIR__ . '/src/Models/UserIdentityModel.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot unset offset \'email\' on array\\{username\\: string, status\\: string, status_message\\: string, active\\: bool, last_active\\: string, deleted_at\\: string\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Models/UserModel.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Cannot unset offset \'password_hash\' on array\\{username\\: string, status\\: string, status_message\\: string, active\\: bool, last_active\\: string, deleted_at\\: string\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Models/UserModel.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 2,
+	'path' => __DIR__ . '/src/Models/UserModel.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Offset \'email\' does not exist on array\\{username\\: string, status\\: string, status_message\\: string, active\\: bool, last_active\\: string, deleted_at\\: string\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Models/UserModel.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Offset \'password_hash\' does not exist on array\\{username\\: string, status\\: string, status_message\\: string, active\\: bool, last_active\\: string, deleted_at\\: string\\}\\.$#',
+	'count' => 1,
 	'path' => __DIR__ . '/src/Models/UserModel.php',
 ];
 $ignoreErrors[] = [
@@ -340,16 +358,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with \'CodeIgniter\\\\\\\\Shield\\\\\\\\Entities\\\\\\\\UserIdentity\' and CodeIgniter\\\\Shield\\\\Entities\\\\UserIdentity will always evaluate to true\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/tests/Unit/UserTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot access property \\$active on array\\|object\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/tests/Unit/UserTest.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot access property \\$password_hash on array\\|object\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/tests/Unit/UserTest.php',
 ];


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
v1.3.0.70400 offers shiny new features
```
* Provides precise return types for `CodeIgniter\Model`'s `find()`, `findAll()`, and `first()` methods.
* Allows dynamic return type transformation of `CodeIgniter\Model` when `asArray()` or `asObject()` is called.
```

The new errors added is the result of phpstan not able to infer when names of selected fields are renamed, e.g. `select('secret1 as email')`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
