### PR TITLE
fix: AccessTokens authenticator records all accesses to database

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,16 @@
 # Upgrade Guide
 
+## Version 1.0.0-beta.6 to 1.0.0-beta.7
+
+### Install New Config AuthToken.php
+
+A new Config file **AuthToken.php** has been introduced. Run `php spark shield:setup`
+again to install it into **app/Config/**, or install it manually.
+
+Then change the default settings as necessary. When using Token authentication,
+the default value has been changed from all accesses to be recorded in the
+``token_logins`` table to only accesses that fail authentication to be recorded.
+
 ## Version 1.0.0-beta.3 to 1.0.0-beta.4
 
 ### Important Password Changes

--- a/src/Config/AuthToken.php
+++ b/src/Config/AuthToken.php
@@ -7,13 +7,13 @@ namespace CodeIgniter\Shield\Config;
 use CodeIgniter\Config\BaseConfig;
 
 /**
- * Authenticator Configuration for Token Auth and HMAC Auth
+ * Configuration for Token Auth and HMAC Auth
  */
 class AuthToken extends BaseConfig
 {
     /**
      * --------------------------------------------------------------------
-     * Record Login Attempts for Token and HMAC Authorization
+     * Record Login Attempts for Token Auth and HMAC Auth
      * --------------------------------------------------------------------
      * Specify which login attempts are recorded in the database.
      *

--- a/src/Filters/TokenAuth.php
+++ b/src/Filters/TokenAuth.php
@@ -21,7 +21,7 @@ class TokenAuth implements FilterInterface
 {
     /**
      * Do whatever processing this filter needs to do.
-     * By default it should not return anything during
+     * By default, it should not return anything during
      * normal execution. However, when an abnormal state
      * is found, it should return an instance of
      * CodeIgniter\HTTP\Response. If it does, script

--- a/tests/Authentication/Authenticators/AccessTokenAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/AccessTokenAuthenticatorTest.php
@@ -174,7 +174,7 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
         $this->assertFalse($result->isOK());
         $this->assertSame(lang('Auth.badToken'), $result->reason());
 
-        // A login attempt should have always been recorded
+        // A failed login attempt should have been recorded by default.
         $this->seeInDatabase($this->tables['token_logins'], [
             'id_type'    => AccessTokens::ID_TYPE_ACCESS_TOKEN,
             'identifier' => 'abc123',
@@ -202,8 +202,8 @@ final class AccessTokenAuthenticatorTest extends DatabaseTestCase
         $this->assertInstanceOf(AccessToken::class, $foundUser->currentAccessToken());
         $this->assertSame($token->token, $foundUser->currentAccessToken()->token);
 
-        // A login attempt should have been recorded
-        $this->seeInDatabase($this->tables['token_logins'], [
+        // A successful login attempt is not recorded by default.
+        $this->dontSeeInDatabase($this->tables['token_logins'], [
             'id_type'    => AccessTokens::ID_TYPE_ACCESS_TOKEN,
             'identifier' => $token->raw_token,
             'success'    => 1,


### PR DESCRIPTION
**Description**
Fixes  #815

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
