### PR TITLE
fix: [HMAC Auth] wrong header key

### DIFF
--- a/src/Authentication/Authenticators/HmacSha256.php
+++ b/src/Authentication/Authenticators/HmacSha256.php
@@ -200,7 +200,7 @@ class HmacSha256 implements AuthenticatorInterface
         $request = service('request');
 
         return $this->attempt([
-            'token' => $request->getHeaderLine(config('Auth')->authenticatorHeader['tokens']),
+            'token' => $request->getHeaderLine(config('Auth')->authenticatorHeader['hmac']),
         ])->isOK();
     }
 


### PR DESCRIPTION
**Description**
Follow-up #795

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
