### PR TITLE
fix: remove `strong_password` from shield:user validation rules

### DIFF
--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -232,6 +232,9 @@ class User extends BaseCommand
         if (($key = array_search('strong_password[]', $passwordRules, true)) !== false) {
             unset($passwordRules[$key]);
         }
+        if (($key = array_search('strong_password', $passwordRules, true)) !== false) {
+            unset($passwordRules[$key]);
+        }
 
         /** @var Auth $config */
         $config = config('Auth');


### PR DESCRIPTION
**Description**
Follow-up #833

In previous versions, we used `strong_password` not `strong_password[]`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
