### PR TITLE
feat: added `revokeAccessTokenBySecret()`

### DIFF
--- a/docs/guides/api_tokens.md
+++ b/docs/guides/api_tokens.md
@@ -47,10 +47,11 @@ if ($user->tokenCan('users-read')) {
 
 ### Revoking Tokens
 
-Tokens can be revoked by deleting them from the database with the `revokeAccessToken($rawToken)` or `revokeAllAccessTokens()` methods.
+Tokens can be revoked by deleting them from the database with the `revokeAccessToken($rawToken)`, `revokeAccessTokenBySecret($secret)` or `revokeAllAccessTokens()` methods.
 
 ```php
 $user->revokeAccessToken($rawToken);
+$user->revokeAccessTokenBySecret($secret);
 $user->revokeAllAccessTokens();
 ```
 

--- a/docs/references/authentication/tokens.md
+++ b/docs/references/authentication/tokens.md
@@ -56,6 +56,12 @@ Typically, the plain text token is retrieved from the request's headers as part 
 process. If you need to revoke the token for another user as an admin, and don't have access to the
 token, you would need to get the user's access tokens and delete them manually.
 
+If you don't have the raw token usable to remove the token there is the possibility to remove it using the tokens secret thats stored in the database. It's possible to get a list of all tokens with there secret using the `accessTokens()` function.
+
+```php
+$user->revokeAccessTokenBySecret($secret);
+```
+
 You can revoke all access tokens with the `revokeAllAccessTokens()` method.
 
 ```php

--- a/src/Authentication/Traits/HasAccessTokens.php
+++ b/src/Authentication/Traits/HasAccessTokens.php
@@ -48,6 +48,17 @@ trait HasAccessTokens
     }
 
     /**
+     * Delete any access tokens for the given secret token.
+     */
+    public function revokeAccessTokenBySecret(string $secretToken): void
+    {
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+
+        $identityModel->revokeAccessTokenBySecret($this, $secretToken);
+    }
+
+    /**
      * Revokes all access tokens for this user.
      */
     public function revokeAllAccessTokens(): void

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -457,6 +457,21 @@ class UserIdentityModel extends BaseModel
     }
 
     /**
+     * Delete any access tokens for the given secret token.
+     */
+    public function revokeAccessTokenBySecret(User $user, string $secretToken): void
+    {
+        $this->checkUserId($user);
+
+        $return = $this->where('user_id', $user->id)
+            ->where('type', AccessTokens::ID_TYPE_ACCESS_TOKEN)
+            ->where('secret', $secretToken)
+            ->delete();
+
+        $this->checkQueryReturn($return);
+    }
+
+    /**
      * Revokes all access tokens for this user.
      */
     public function revokeAllAccessTokens(User $user): void

--- a/tests/Authentication/HasAccessTokensTest.php
+++ b/tests/Authentication/HasAccessTokensTest.php
@@ -101,6 +101,17 @@ final class HasAccessTokensTest extends DatabaseTestCase
         $this->assertCount(0, $this->user->accessTokens());
     }
 
+    public function testRevokeAccessTokenBySecret(): void
+    {
+        $token = $this->user->generateAccessToken('foo');
+
+        $this->assertCount(1, $this->user->accessTokens());
+
+        $this->user->revokeAccessTokenBySecret($token->secret);
+
+        $this->assertCount(0, $this->user->accessTokens());
+    }
+
     public function testRevokeAllAccessTokens(): void
     {
         $this->user->generateAccessToken('foo');


### PR DESCRIPTION
**Description**
After losing some tokens while i developed my app and i didnt want to remove all of the tokens i changed the `revokeAccessToken` to support removeing them by the secret that you can get with the `AccessTokens()` function.

superseded: #838 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
