### PR TITLE
docs: change dotenv to text

### DIFF
--- a/docs/addons/jwt.md
+++ b/docs/addons/jwt.md
@@ -107,7 +107,7 @@ The default claims will be included in all tokens issued by Shield.
 Set your secret key in the `$keys` property, or set it in your `.env` file.
 
 E.g.:
-```dotenv
+```text
 authjwt.keys.default.0.secret = 8XBFsF6HThIa7OV/bSynahEch+WbKrGcuiJVYPiwqPE=
 ```
 


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/shield/pull/860#discussion_r1340639476
highlight.js does not support dotenv.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
