### PR TITLE
Remove supportOldDangerousPassword support

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -318,7 +318,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with \'CodeIgniter\\\\\\\\Shield\\\\\\\\Result\' and CodeIgniter\\\\Shield\\\\Result will always evaluate to true\\.$#',
-	'count' => 9,
+	'count' => 8,
 	'path' => __DIR__ . '/tests/Authentication/Authenticators/SessionAuthenticatorTest.php',
 ];
 $ignoreErrors[] = [

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -130,7 +130,7 @@ class Session implements AuthenticatorInterface
         $result = $this->check($credentials);
 
         // Credentials mismatch.
-        if (!$result->isOK()) {
+        if (! $result->isOK()) {
             // Always record a login attempt, whether success or not.
             $this->recordLoginAttempt($credentials, false, $ipAddress, $userAgent);
 
@@ -173,7 +173,7 @@ class Session implements AuthenticatorInterface
 
         $this->issueRememberMeToken();
 
-        if (!$this->hasAction()) {
+        if (! $this->hasAction()) {
             $this->completeLogin($user);
         }
 
@@ -284,10 +284,10 @@ class Session implements AuthenticatorInterface
 
         $field = array_pop($field);
 
-        if (!in_array($field, ['email', 'username'], true)) {
+        if (! in_array($field, ['email', 'username'], true)) {
             $idType = $field;
         } else {
-            $idType = (!isset($credentials['email']) && isset($credentials['username']))
+            $idType = (! isset($credentials['email']) && isset($credentials['username']))
                 ? self::ID_TYPE_USERNAME
                 : self::ID_TYPE_EMAIL_PASSWORD;
         }
@@ -337,7 +337,7 @@ class Session implements AuthenticatorInterface
         $passwords = service('passwords');
 
         // Now, try matching the passwords.
-        if (!$passwords->verify($givenPassword, $user->password_hash)) {
+        if (! $passwords->verify($givenPassword, $user->password_hash)) {
             return new Result([
                 'success' => false,
                 'reason'  => lang('Auth.invalidPassword'),
@@ -885,7 +885,7 @@ class Session implements AuthenticatorInterface
      */
     public function recordActiveDate(): void
     {
-        if (!$this->user instanceof User) {
+        if (! $this->user instanceof User) {
             throw new InvalidArgumentException(
                 __METHOD__ . '() requires logged in user before calling.'
             );

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -336,30 +336,20 @@ class Session implements AuthenticatorInterface
         /** @var Passwords $passwords */
         $passwords = service('passwords');
 
-        // This is only for supportOldDangerousPassword.
-        $needsRehash = false;
-
         // Now, try matching the passwords.
         if (! $passwords->verify($givenPassword, $user->password_hash)) {
-            if (
-                ! setting('Auth.supportOldDangerousPassword')
-                || ! $passwords->verifyDanger($givenPassword, $user->password_hash) // @phpstan-ignore-line
-            ) {
                 return new Result([
                     'success' => false,
                     'reason'  => lang('Auth.invalidPassword'),
                 ]);
-            }
-
-            // Passed with old dangerous password.
-            $needsRehash = true;
+            
         }
 
         // Check to see if the password needs to be rehashed.
         // This would be due to the hash algorithm or hash
         // cost changing since the last time that a user
         // logged in.
-        if ($passwords->needsRehash($user->password_hash) || $needsRehash) {
+        if ($passwords->needsRehash($user->password_hash)) {
             $user->password_hash = $passwords->hash($givenPassword);
             $this->provider->save($user);
         }

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -95,8 +95,8 @@ class Session implements AuthenticatorInterface
         if ($securityConfig->csrfProtection === 'cookie') {
             throw new SecurityException(
                 'Config\Security::$csrfProtection is set to \'cookie\'.'
-                . ' Same-site attackers may bypass the CSRF protection.'
-                . ' Please set it to \'session\'.'
+                    . ' Same-site attackers may bypass the CSRF protection.'
+                    . ' Please set it to \'session\'.'
             );
         }
     }
@@ -130,7 +130,7 @@ class Session implements AuthenticatorInterface
         $result = $this->check($credentials);
 
         // Credentials mismatch.
-        if (! $result->isOK()) {
+        if (!$result->isOK()) {
             // Always record a login attempt, whether success or not.
             $this->recordLoginAttempt($credentials, false, $ipAddress, $userAgent);
 
@@ -173,7 +173,7 @@ class Session implements AuthenticatorInterface
 
         $this->issueRememberMeToken();
 
-        if (! $this->hasAction()) {
+        if (!$this->hasAction()) {
             $this->completeLogin($user);
         }
 
@@ -284,10 +284,10 @@ class Session implements AuthenticatorInterface
 
         $field = array_pop($field);
 
-        if (! in_array($field, ['email', 'username'], true)) {
+        if (!in_array($field, ['email', 'username'], true)) {
             $idType = $field;
         } else {
-            $idType = (! isset($credentials['email']) && isset($credentials['username']))
+            $idType = (!isset($credentials['email']) && isset($credentials['username']))
                 ? self::ID_TYPE_USERNAME
                 : self::ID_TYPE_EMAIL_PASSWORD;
         }
@@ -337,12 +337,11 @@ class Session implements AuthenticatorInterface
         $passwords = service('passwords');
 
         // Now, try matching the passwords.
-        if (! $passwords->verify($givenPassword, $user->password_hash)) {
-                return new Result([
-                    'success' => false,
-                    'reason'  => lang('Auth.invalidPassword'),
-                ]);
-            
+        if (!$passwords->verify($givenPassword, $user->password_hash)) {
+            return new Result([
+                'success' => false,
+                'reason'  => lang('Auth.invalidPassword'),
+            ]);
         }
 
         // Check to see if the password needs to be rehashed.
@@ -644,10 +643,10 @@ class Session implements AuthenticatorInterface
         if ($userId !== null) {
             throw new LogicException(
                 'The user has User Info in Session, so already logged in or in pending login state.'
-                . ' If a logged in user logs in again with other account, the session data of the previous'
-                . ' user will be used as the new user.'
-                . ' Fix your code to prevent users from logging in without logging out or delete the session data.'
-                . ' user_id: ' . $userId
+                    . ' If a logged in user logs in again with other account, the session data of the previous'
+                    . ' user will be used as the new user.'
+                    . ' Fix your code to prevent users from logging in without logging out or delete the session data.'
+                    . ' user_id: ' . $userId
             );
         }
 
@@ -732,18 +731,18 @@ class Session implements AuthenticatorInterface
         if ($this->getIdentitiesForAction($user) !== []) {
             throw new LogicException(
                 'The user has identities for action, so cannot complete login.'
-                . ' If you want to start to login with auth action, use startLogin() instead.'
-                . ' Or delete identities for action in database.'
-                . ' user_id: ' . $user->id
+                    . ' If you want to start to login with auth action, use startLogin() instead.'
+                    . ' Or delete identities for action in database.'
+                    . ' user_id: ' . $user->id
             );
         }
         // Check auth_action in Session
         if ($this->getSessionKey('auth_action')) {
             throw new LogicException(
                 'The user has auth action in session, so cannot complete login.'
-                . ' If you want to start to login with auth action, use startLogin() instead.'
-                . ' Or delete `auth_action` and `auth_action_message` in session data.'
-                . ' user_id: ' . $user->id
+                    . ' If you want to start to login with auth action, use startLogin() instead.'
+                    . ' Or delete `auth_action` and `auth_action_message` in session data.'
+                    . ' user_id: ' . $user->id
             );
         }
 
@@ -886,7 +885,7 @@ class Session implements AuthenticatorInterface
      */
     public function recordActiveDate(): void
     {
-        if (! $this->user instanceof User) {
+        if (!$this->user instanceof User) {
             throw new InvalidArgumentException(
                 __METHOD__ . '() requires logged in user before calling.'
             );

--- a/src/Authentication/Passwords.php
+++ b/src/Authentication/Passwords.php
@@ -82,21 +82,6 @@ class Passwords
     }
 
     /**
-     * Verifies a password against a previously hashed password.
-     *
-     * @param string $password The password we're checking
-     * @param string $hash     The previously hashed password
-     *
-     * @deprecated This is only for backward compatibility.
-     */
-    public function verifyDanger(string $password, string $hash): bool
-    {
-        return password_verify(base64_encode(
-            hash('sha384', $password, true)
-        ), $hash);
-    }
-
-    /**
      * Checks to see if a password should be rehashed.
      */
     public function needsRehash(string $hashedPassword): bool

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -364,16 +364,6 @@ class Auth extends BaseConfig
     public int $hashCost = 10;
 
     /**
-     * If you need to support passwords saved in versions prior to Shield v1.0.0-beta.4.
-     * set this to true.
-     *
-     * See https://github.com/codeigniter4/shield/security/advisories/GHSA-c5vj-f36q-p9vg
-     *
-     * @deprecated This is only for backward compatibility.
-     */
-    public bool $supportOldDangerousPassword = false;
-
-    /**
      * ////////////////////////////////////////////////////////////////////
      * OTHER SETTINGS
      * ////////////////////////////////////////////////////////////////////

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -304,34 +304,6 @@ final class SessionAuthenticatorTest extends DatabaseTestCase
         $this->assertSame($this->user->id, $foundUser->id);
     }
 
-    public function testCheckSuccessOldDangerousPassword(): void
-    {
-        /** @var Auth $config */
-        $config                              = config('Auth');
-        $config->supportOldDangerousPassword = true; // @phpstan-ignore-line
-
-        fake(
-            UserIdentityModel::class,
-            [
-                'user_id' => $this->user->id,
-                'type'    => Session::ID_TYPE_EMAIL_PASSWORD,
-                'secret'  => 'foo@example.com',
-                'secret2' => '$2y$10$WswjNNcR24cJvsXvBc5TveVVVQ9/EYC0eq.Ad9e/2cVnmeSEYBOEm',
-            ]
-        );
-
-        $result = $this->auth->check([
-            'email'    => 'foo@example.com',
-            'password' => 'passw0rd!',
-        ]);
-
-        $this->assertInstanceOf(Result::class, $result);
-        $this->assertTrue($result->isOK());
-
-        $foundUser = $result->extraInfo();
-        $this->assertSame($this->user->id, $foundUser->id);
-    }
-
     public function testAttemptCannotFindUser(): void
     {
         $result = $this->auth->attempt([

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -12,7 +12,6 @@ use CodeIgniter\Shield\Config\Auth;
 use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Shield\Models\RememberModel;
-use CodeIgniter\Shield\Models\UserIdentityModel;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Result;
 use CodeIgniter\Test\Mock\MockEvents;


### PR DESCRIPTION
Fixes #771 

Ref: https://github.com/codeigniter4/shield/commit/ea9688dd01d100193d834117dbfc2cfabcf9ea0b

**Description**
I removed supportOldDangerousPassword. And also there is no usage of verifyDanger() anymore I also deleted it. I didn't update the docs because docs already have the information about deprecation for version 1.0.0 release.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide


