### PR TITLE
fix: Change the visibility of validation properties for easier inheritance

### DIFF
--- a/src/Validation/ValidationRules.php
+++ b/src/Validation/ValidationRules.php
@@ -9,12 +9,12 @@ use CodeIgniter\Shield\Config\Auth;
 
 class ValidationRules
 {
-    private Auth $config;
+    protected Auth $config;
 
     /**
      * Auth Table names
      */
-    private array $tables;
+    protected array $tables;
 
     public function __construct()
     {


### PR DESCRIPTION
<!--

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Currently, the `Validation` class declares the properties `$config` and `$tables` as private which makes them impossible to use within child classes. This PR fixes that.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
