### PR TITLE
fix: redirect inactive account to auth action page

### DIFF
--- a/src/Filters/SessionAuth.php
+++ b/src/Filters/SessionAuth.php
@@ -61,10 +61,12 @@ class SessionAuth implements FilterInterface
             }
 
             if ($user !== null && ! $user->isActivated()) {
-                $authenticator->logout();
-
-                return redirect()->route('login')
-                    ->with('error', lang('Auth.activationBlocked'));
+                // If an action has been defined for register, start it up.
+                $hasAction = $authenticator->startUpAction('register', $user);
+                if ($hasAction) {
+                    return redirect()->route('auth-action-show')
+                        ->with('error', lang('Auth.activationBlocked'));
+                }
             }
 
             return;

--- a/tests/Authentication/Filters/AbstractFilterTestCase.php
+++ b/tests/Authentication/Filters/AbstractFilterTestCase.php
@@ -69,6 +69,7 @@ abstract class AbstractFilterTestCase extends TestCase
             echo 'Open';
         });
         $routes->get('login', 'AuthController::login', ['as' => 'login']);
+        $routes->get('auth/a/show', 'AuthActionController::show', ['as' => 'auth-action-show']);
         $routes->get('protected-user-route', static function (): void {
             echo 'Protected';
         }, ['filter' => $this->alias . ':users-read']);

--- a/tests/Authentication/Filters/SessionFilterTest.php
+++ b/tests/Authentication/Filters/SessionFilterTest.php
@@ -58,7 +58,7 @@ final class SessionFilterTest extends AbstractFilterTestCase
         $this->assertGreaterThan(auth('session')->user()->updated_at, auth('session')->user()->last_active);
     }
 
-    public function testBlocksInactiveUsers(): void
+    public function testBlocksInactiveUsersAndRedirectsToAuthAction(): void
     {
         $user = fake(UserModel::class, ['active' => false]);
 
@@ -77,7 +77,7 @@ final class SessionFilterTest extends AbstractFilterTestCase
         $result = $this->actingAs($user)
             ->get('protected-route');
 
-        $result->assertRedirectTo('/login');
+        $result->assertRedirectTo('/auth/a/show');
         // User should be logged out
         $this->assertNull(auth('session')->id());
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
The `isActivated()` check works for when a register action has been set in the auth config. Currently, if an inactive account tries to log in, the system redirects the user to the login page with the error message: 
```console
You must activate your account before logging in.
```
This begs the question: _"How do I activate my account?"_

This PR fixes this issue by redirecting the user to the auth action page, where a new token is generated and sent to the user's email.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
