### PR TITLE
docs: remove `Config\Security::$csrfProtection` config method by `.env`

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -136,7 +136,7 @@ your project.
     service('auth')->routes($routes);
     ```
 
-4. **Security Setup** Set `Config\Security::$csrfProtection` to `'session'` (or set `security.csrfProtection = session` in your **.env** file) for security reasons, if you use Session Authenticator.
+4. **Security Setup** Set `Config\Security::$csrfProtection` to `'session'` for security reasons, if you use Session Authenticator.
 
 5. **Migration** Run the migrations.
 


### PR DESCRIPTION
**Description**
It is not recommended. Because it should be set to `session` in all environments.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [] Conforms to style guide
