### PR TITLE
refactor: update minimum CI4 version to 4.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See the [An Official Auth Library](https://codeigniter.com/news/shield) for more
 
 Usage of Shield requires the following:
 
-- A [CodeIgniter 4.2.7+](https://github.com/codeigniter4/CodeIgniter4/) based project
+- A [CodeIgniter 4.3.5+](https://github.com/codeigniter4/CodeIgniter4/) based project
 - [Composer](https://getcomposer.org/) for package management
 - PHP 7.4.3+
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,12 @@
 
 ## Version 1.0.0-beta.6 to 1.0.0-beta.7
 
+### The minimum CodeIgniter version
+
+Shield requires CodeIgniter 4.3.5 or later.
+Versions prior to 4.3.5 have known vulnerabilities.
+See https://github.com/codeigniter4/CodeIgniter4/security/advisories
+
 ### Mandatory Config Changes
 
 #### New Config\AuthToken

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "codeigniter/phpstan-codeigniter": "^1.3",
         "codeigniter4/devkit": "^1.0",
-        "codeigniter4/framework": "^4.2.7",
+        "codeigniter4/framework": "^4.3.5",
         "firebase/php-jwt": "^6.4",
         "mikey179/vfsstream": "^1.6.7",
         "mockery/mockery": "^1.0",

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -5,7 +5,7 @@ These instructions assume that you have already [installed the CodeIgniter 4 app
 ## Requirements
 
 - [Composer](https://getcomposer.org)
-- Codeigniter **v4.2.7** or later
+- Codeigniter **v4.3.5** or later
 - A created database that you can access via the Spark CLI script
   - InnoDB (not MyISAM) is required if MySQL is used.
 

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Test;
 
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\CodeIgniter;
 use CodeIgniter\Shield\Commands\Utils\InputOutput;
 use CodeIgniter\Shield\Exceptions\LogicException;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
@@ -52,23 +51,21 @@ final class MockInputOutput extends InputOutput
     {
         $input = array_shift($this->inputs);
 
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            CITestStreamFilter::registration();
-            CITestStreamFilter::addOutputFilter();
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
 
-            PhpStreamWrapper::register();
-            PhpStreamWrapper::setContent($input);
+        PhpStreamWrapper::register();
+        PhpStreamWrapper::setContent($input);
 
-            $userInput = CLI::prompt($field, $options, $validation);
+        $userInput = CLI::prompt($field, $options, $validation);
 
-            PhpStreamWrapper::restore();
+        PhpStreamWrapper::restore();
 
-            CITestStreamFilter::removeOutputFilter();
-            CITestStreamFilter::removeErrorFilter();
+        CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeErrorFilter();
 
-            if ($input !== $userInput) {
-                throw new LogicException($input . '!==' . $userInput);
-            }
+        if ($input !== $userInput) {
+            throw new LogicException($input . '!==' . $userInput);
         }
 
         return $input;
@@ -79,23 +76,13 @@ final class MockInputOutput extends InputOutput
         ?string $foreground = null,
         ?string $background = null
     ): void {
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            CITestStreamFilter::registration();
-            CITestStreamFilter::addOutputFilter();
-        } else {
-            CITestStreamFilter::$buffer = '';
-
-            $streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        }
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
 
         CLI::write($text, $foreground, $background);
         $this->outputs[] = CITestStreamFilter::$buffer;
 
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            CITestStreamFilter::removeOutputFilter();
-            CITestStreamFilter::removeErrorFilter();
-        } else {
-            stream_filter_remove($streamFilter);
-        }
+        CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeErrorFilter();
     }
 }

--- a/tests/Commands/SetupTest.php
+++ b/tests/Commands/SetupTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Commands;
 
-use CodeIgniter\CodeIgniter;
 use CodeIgniter\Shield\Commands\Setup;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
 use Config\Services;
@@ -16,31 +15,20 @@ use Tests\Support\TestCase;
  */
 final class SetupTest extends TestCase
 {
-    private $streamFilter;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            CITestStreamFilter::registration();
-            CITestStreamFilter::addOutputFilter();
-        } else {
-            CITestStreamFilter::$buffer = '';
-            $this->streamFilter         = stream_filter_append(STDOUT, 'CITestStreamFilter');
-        }
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            CITestStreamFilter::removeOutputFilter();
-            CITestStreamFilter::removeErrorFilter();
-        } else {
-            stream_filter_remove($this->streamFilter);
-        }
+        CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeErrorFilter();
     }
 
     public function testRun(): void

--- a/tests/Commands/UserModelGeneratorTest.php
+++ b/tests/Commands/UserModelGeneratorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Commands;
 
-use CodeIgniter\CodeIgniter;
 use CodeIgniter\Test\CIUnitTestCase;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
 
@@ -13,22 +12,13 @@ use CodeIgniter\Test\Filters\CITestStreamFilter;
  */
 final class UserModelGeneratorTest extends CIUnitTestCase
 {
-    private $streamFilter;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            CITestStreamFilter::registration();
-            CITestStreamFilter::addOutputFilter();
-            CITestStreamFilter::addErrorFilter();
-        } else {
-            CITestStreamFilter::$buffer = '';
-
-            $this->streamFilter = stream_filter_append(STDOUT, 'CITestStreamFilter');
-            $this->streamFilter = stream_filter_append(STDERR, 'CITestStreamFilter');
-        }
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addOutputFilter();
+        CITestStreamFilter::addErrorFilter();
 
         if (is_file(HOMEPATH . 'src/Models/UserModel.php')) {
             copy(HOMEPATH . 'src/Models/UserModel.php', HOMEPATH . 'src/Models/UserModel.php.bak');
@@ -41,12 +31,8 @@ final class UserModelGeneratorTest extends CIUnitTestCase
     {
         parent::tearDown();
 
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            CITestStreamFilter::removeOutputFilter();
-            CITestStreamFilter::removeErrorFilter();
-        } else {
-            stream_filter_remove($this->streamFilter);
-        }
+        CITestStreamFilter::removeOutputFilter();
+        CITestStreamFilter::removeErrorFilter();
 
         $this->deleteTestFiles();
 

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Controllers;
 
-use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Actions\Email2FA;
@@ -110,11 +109,7 @@ final class LoginTest extends DatabaseTestCase
 
     public function testLoginActionEmailSuccess(): void
     {
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            Time::setTestNow('March 10, 2017', 'UTC');
-        } else {
-            Time::setTestNow('March 10, 2017', 'America/Chicago');
-        }
+        Time::setTestNow('March 10, 2017', 'UTC');
 
         $this->user->createEmailIdentity([
             'email'    => 'foo@example.com',
@@ -166,11 +161,7 @@ final class LoginTest extends DatabaseTestCase
 
     public function testLoginActionUsernameSuccess(): void
     {
-        if (version_compare(CodeIgniter::CI_VERSION, '4.3.0', '>=')) {
-            Time::setTestNow('March 10, 2017', 'UTC');
-        } else {
-            Time::setTestNow('March 10, 2017', 'America/Chicago');
-        }
+        Time::setTestNow('March 10, 2017', 'UTC');
 
         // Add 'username' to $validFields
         $authConfig                = config('Auth');


### PR DESCRIPTION
**Description**
CI 4.4 is already released, and there are vulnerabilities in prior to 4.3.5. 

- update minimum CI4 version to 4.3.5
- remove code for CI 4.2.x or before

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
