### PR TITLE
refactor: remove Composer autoloading of email helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
             "CodeIgniter\\Shield\\": "src"
         },
         "files": [
-            "src/Helpers/auth_helper.php",
-            "src/Helpers/email_helper.php"
+            "src/Helpers/auth_helper.php"
         ],
         "exclude-from-classmap": [
             "**/Database/Migrations/**"

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -78,6 +78,7 @@ class Email2FA implements ActionInterface
         $date      = Time::now()->toDateTimeString();
 
         // Send the user an email with the code
+        helper('email');
         $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($user->email);
         $email->setSubject(lang('Auth.email2FASubject'));

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -55,6 +55,7 @@ class EmailActivator implements ActionInterface
         $date      = Time::now()->toDateTimeString();
 
         // Send the email
+        helper('email');
         $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($userEmail);
         $email->setSubject(lang('Auth.emailActivateSubject'));

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -113,6 +113,7 @@ class MagicLinkController extends BaseController
         $date      = Time::now()->toDateTimeString();
 
         // Send the user an email with the code
+        helper('email');
         $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($user->email);
         $email->setSubject(lang('Auth.magicLinkSubject'));


### PR DESCRIPTION


**Description**
See https://forum.codeigniter.com/showthread.php?tid=88545

The Email helper is used in a limited number of places, and it would be inefficient to load it on every page.

Also, if a library autoloads helpers by Composer, there is no way to stop that loading. 
So I have changed my mind, it is better not using helper autoloading by Composer in libraries.
If autoloading is necessary, developers can set it up in `Config\Autoload`.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
