### PR TITLE
mkdocs: configure page redirects

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,4 +15,5 @@ jobs:
           python-version: 3.x
       - run: pip3 install mkdocs-material
       - run: pip3 install mkdocs-git-revision-date-localized-plugin
+      - run: pip3 install mkdocs-redirects
       - run: mkdocs gh-deploy --force

--- a/admin/how_to_build_docs.md
+++ b/admin/how_to_build_docs.md
@@ -14,6 +14,7 @@ See https://squidfunk.github.io/mkdocs-material/getting-started/.
 pip3 install mkdocs
 pip3 install mkdocs-material
 pip3 install mkdocs-git-revision-date-localized-plugin
+pip3 install mkdocs-redirects
 ```
 
 ## Build the Docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,20 @@ plugins:
   - search
   - git-revision-date-localized:
       enable_creation_date: true
+  - redirects:
+      redirect_maps:
+        'auth_actions.md': 'references/authentication/auth_actions.md'
+        'authentication.md': 'references/authentication/authentication.md'
+        'authorization.md': 'references/authorization.md'
+        'banning_users.md': 'user_management/banning_users.md'
+        'concepts.md': 'getting_started/concepts.md'
+        'customization.md': 'customization/table_names.md'
+        'events.md': 'references/events.md'
+        'forcing_password_reset.md': 'user_management/forcing_password_reset.md'
+        'install.md': 'getting_started/install.md'
+        'quickstart.md': 'quick_start_guide/using_session_auth.md'
+        'session_auth_event_and_logging.md': 'references/authentication/session.md'
+        'testing.md': 'references/testing.md'
 nav:
   - Home: index.md
   - Getting Started:


### PR DESCRIPTION
**Description**
Follow-up #839

- add [mkdocs-redirects](https://github.com/mkdocs/mkdocs-redirects) plugin
- configure page redirects
 
**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
