### PR TITLE
feat: `shield:setup` does Email setup

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -124,16 +124,8 @@ your project.
 
     class Email extends BaseConfig
     {
-        /**
-         * @var string
-         */
-        public $fromEmail = 'your_mail@example.com';
-
-        /**
-         * @var string
-         */
-        public $fromName = 'your name';
-
+        public string $fromEmail  = 'your_mail@example.com';
+        public string $fromName   = 'your name';
         // ...
     }
     ```

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -54,9 +54,12 @@ Require it with an explicit version constraint allowing its desired stability.
 
 ## Initial Setup
 
+There are a few setup items to do before you can start using Shield in
+your project.
+
 ### Command Setup
 
-1. Run the following command. This command handles steps 1-5 of *Manual Setup* and runs the migrations.
+1. Run the following command. This command handles steps 1-6 of *Manual Setup*.
 
     ```console
     php spark shield:setup
@@ -67,35 +70,7 @@ Require it with an explicit version constraint allowing its desired stability.
         If you want to customize table names, you must change the table names before running database migrations.
         See [Customizing Table Names](../customization/table_names.md).
 
-2. Configure **app/Config/Email.php** to allow Shield to send emails with the [Email Class](https://codeigniter.com/user_guide/libraries/email.html).
-
-    ```php
-    <?php
-
-    namespace Config;
-
-    use CodeIgniter\Config\BaseConfig;
-
-    class Email extends BaseConfig
-    {
-        /**
-         * @var string
-         */
-        public $fromEmail = 'your_mail@example.com';
-
-        /**
-         * @var string
-         */
-        public $fromName = 'your name';
-
-        // ...
-    }
-    ```
-
 ### Manual Setup
-
-There are a few setup items to do before you can start using Shield in
-your project.
 
 1. Copy the **Auth.php**, **AuthGroups.php**, and **AuthToken.php** from **vendor/codeigniter4/shield/src/Config/** into your project's config folder and update the namespace to `Config`. You will also need to have these classes extend the original classes. See the example below. These files contain all the settings, group, and permission information for your application and will need to be modified to meet the needs of your site.
 
@@ -138,25 +113,7 @@ your project.
 
 4. **Security Setup** Set `Config\Security::$csrfProtection` to `'session'` for security reasons, if you use Session Authenticator.
 
-5. **Migration** Run the migrations.
-
-    !!! note
-
-        If you want to customize table names, you must change the table names before running database migrations.
-        See [Customizing Table Names](../customization/table_names.md).
-
-    ```console
-    php spark migrate --all
-    ```
-
-    #### Note: migration error
-
-    When you run `spark migrate --all`, if you get `Class "SQLite3" not found` error:
-
-    1. Remove sample migration files in **tests/_support/Database/Migrations/**
-    2. Or install `sqlite3` php extension
-
-6. Configure **app/Config/Email.php** to allow Shield to send emails.
+5. Configure **app/Config/Email.php** to allow Shield to send emails with the [Email Class](https://codeigniter.com/user_guide/libraries/email.html).
 
     ```php
     <?php
@@ -180,3 +137,21 @@ your project.
         // ...
     }
     ```
+
+6. **Migration** Run the migrations.
+
+    !!! note
+
+        If you want to customize table names, you must change the table names before running database migrations.
+        See [Customizing Table Names](../customization/table_names.md).
+
+    ```console
+    php spark migrate --all
+    ```
+
+    #### Note: migration error
+
+    When you run `spark migrate --all`, if you get `Class "SQLite3" not found` error:
+
+    1. Remove sample migration files in **tests/_support/Database/Migrations/**
+    2. Or install `sqlite3` php extension

--- a/rector.php
+++ b/rector.php
@@ -20,6 +20,7 @@ use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsPar
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
@@ -108,6 +109,11 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/tests/Commands/SetupTest.php',
             __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
             __DIR__ . '/tests/Controllers/LoginTest.php',
+        ],
+
+        RecastingRemovalRector::class => [
+            // To check old Email Config file
+            __DIR__ . '/src/Commands/Setup.php',
         ],
     ]);
 

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Commands;
 
 use CodeIgniter\CLI\BaseCommand as FrameworkBaseCommand;
+use CodeIgniter\CLI\Commands;
 use CodeIgniter\Shield\Commands\Utils\InputOutput;
+use Psr\Log\LoggerInterface;
 
 abstract class BaseCommand extends FrameworkBaseCommand
 {
@@ -18,6 +20,13 @@ abstract class BaseCommand extends FrameworkBaseCommand
      * @var string
      */
     protected $group = 'Shield';
+
+    public function __construct(LoggerInterface $logger, Commands $commands)
+    {
+        parent::__construct($logger, $commands);
+
+        $this->ensureInputOutput();
+    }
 
     /**
      * Asks the user for input.

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeIgniter\Shield\Commands;
+
+use CodeIgniter\CLI\BaseCommand as FrameworkBaseCommand;
+use CodeIgniter\Shield\Commands\Utils\InputOutput;
+
+abstract class BaseCommand extends FrameworkBaseCommand
+{
+    protected static ?InputOutput $io = null;
+
+    /**
+     * The group the command is lumped under
+     * when listing commands.
+     *
+     * @var string
+     */
+    protected $group = 'Shield';
+
+    /**
+     * Asks the user for input.
+     *
+     * @param string       $field      Output "field" question
+     * @param array|string $options    String to a default value, array to a list of options (the first option will be the default value)
+     * @param array|string $validation Validation rules
+     *
+     * @return string The user input
+     */
+    protected function prompt(string $field, $options = null, $validation = null): string
+    {
+        return self::$io->prompt($field, $options, $validation);
+    }
+
+    /**
+     * Outputs a string to the cli on its own line.
+     */
+    protected function write(
+        string $text = '',
+        ?string $foreground = null,
+        ?string $background = null
+    ): void {
+        self::$io->write($text, $foreground, $background);
+    }
+
+    /**
+     * Outputs an error to the CLI using STDERR instead of STDOUT
+     */
+    protected function error(
+        string $text,
+        string $foreground = 'light_red',
+        ?string $background = null
+    ): void {
+        self::$io->error($text, $foreground, $background);
+    }
+
+    protected function ensureInputOutput(): void
+    {
+        if (self::$io === null) {
+            self::$io = new InputOutput();
+        }
+    }
+
+    /**
+     * @internal Testing purpose only
+     */
+    public static function setInputOutput(InputOutput $io): void
+    {
+        self::$io = $io;
+    }
+
+    /**
+     * @internal Testing purpose only
+     */
+    public static function resetInputOutput(): void
+    {
+        self::$io = null;
+    }
+}

--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -317,8 +317,8 @@ class Setup extends BaseCommand
         }
 
         $config    = new EmailConfig();
-        $fromEmail = $config->fromEmail;
-        $fromName  = $config->fromName;
+        $fromEmail = (string) $config->fromEmail; // Old Config may return null.
+        $fromName  = (string) $config->fromName;
 
         if ($fromEmail !== '' && $fromName !== '') {
             $this->write(CLI::color('  Email Setup: ', 'green') . 'Everything is fine.');

--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -316,7 +316,7 @@ class Setup extends BaseCommand
             return;
         }
 
-        $config    = new EmailConfig();
+        $config    = config(EmailConfig::class);
         $fromEmail = (string) $config->fromEmail; // Old Config may return null.
         $fromName  = (string) $config->fromName;
 

--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -175,7 +175,7 @@ class Setup extends BaseCommand
                 ! $overwrite
                 && $this->prompt("  File '{$cleanPath}' already exists in destination. Overwrite?", ['n', 'y']) === 'n'
             ) {
-                CLI::error("  Skipped {$cleanPath}. If you wish to overwrite, please use the '-f' option or reply 'y' to the prompt.");
+                $this->error("  Skipped {$cleanPath}. If you wish to overwrite, please use the '-f' option or reply 'y' to the prompt.");
 
                 return;
             }
@@ -184,7 +184,7 @@ class Setup extends BaseCommand
         if (write_file($path, $content)) {
             $this->write(CLI::color('  Created: ', 'green') . $cleanPath);
         } else {
-            CLI::error("  Error creating {$cleanPath}.");
+            $this->error("  Error creating {$cleanPath}.");
         }
     }
 
@@ -202,12 +202,12 @@ class Setup extends BaseCommand
         $output = $this->replacer->add($content, $code, $pattern, $replace);
 
         if ($output === true) {
-            CLI::error("  Skipped {$cleanPath}. It has already been updated.");
+            $this->error("  Skipped {$cleanPath}. It has already been updated.");
 
             return;
         }
         if ($output === false) {
-            CLI::error("  Error checking {$cleanPath}.");
+            $this->error("  Error checking {$cleanPath}.");
 
             return;
         }
@@ -215,7 +215,7 @@ class Setup extends BaseCommand
         if (write_file($path, $output)) {
             $this->write(CLI::color('  Updated: ', 'green') . $cleanPath);
         } else {
-            CLI::error("  Error updating {$cleanPath}.");
+            $this->error("  Error updating {$cleanPath}.");
         }
     }
 
@@ -244,7 +244,7 @@ class Setup extends BaseCommand
             return true;
         }
 
-        CLI::error("  Error updating {$cleanPath}.");
+        $this->error("  Error updating {$cleanPath}.");
 
         return false;
     }
@@ -294,7 +294,7 @@ class Setup extends BaseCommand
         $cleanPath = clean_path($path);
 
         if (! is_file($path)) {
-            CLI::error("  Not found file '{$cleanPath}'.");
+            $this->error("  Not found file '{$cleanPath}'.");
 
             return;
         }
@@ -312,7 +312,7 @@ class Setup extends BaseCommand
         if (write_file($path, $output)) {
             $this->write(CLI::color('  Updated: ', 'green') . "We have updated file '{$cleanPath}' for security reasons.");
         } else {
-            CLI::error("  Error updating file '{$cleanPath}'.");
+            $this->error("  Error updating file '{$cleanPath}'.");
         }
     }
 
@@ -324,7 +324,7 @@ class Setup extends BaseCommand
         $cleanPath = clean_path($path);
 
         if (! is_file($path)) {
-            CLI::error("  Not found file '{$cleanPath}'.");
+            $this->error("  Not found file '{$cleanPath}'.");
 
             return;
         }
@@ -370,7 +370,7 @@ class Setup extends BaseCommand
         if (write_file($path, $output)) {
             $this->write(CLI::color('  Updated: ', 'green') . $cleanPath);
         } else {
-            CLI::error("  Error updating file '{$cleanPath}'.");
+            $this->error("  Error updating file '{$cleanPath}'.");
         }
     }
 
@@ -414,6 +414,14 @@ class Setup extends BaseCommand
         ?string $background = null
     ): void {
         self::$io->write($text, $foreground, $background);
+    }
+
+    private function error(
+        string $text,
+        string $foreground = 'light_red',
+        ?string $background = null
+    ): void {
+        self::$io->error($text, $foreground, $background);
     }
 
     private function ensureInputOutput(): void

--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -4,28 +4,15 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Shield\Commands;
 
-use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\CLI\CLI;
-use CodeIgniter\CodeIgniter;
 use CodeIgniter\Commands\Database\Migrate;
 use CodeIgniter\Shield\Commands\Setup\ContentReplacer;
-use CodeIgniter\Shield\Commands\Utils\InputOutput;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
 use Config\Email as EmailConfig;
 use Config\Services;
 
 class Setup extends BaseCommand
 {
-    private static ?InputOutput $io = null;
-
-    /**
-     * The group the command is lumped under
-     * when listing commands.
-     *
-     * @var string
-     */
-    protected $group = 'Shield';
-
     /**
      * The Command's name
      *
@@ -401,49 +388,5 @@ class Setup extends BaseCommand
         $this->write($output);
 
         CITestStreamFilter::$buffer = '';
-    }
-
-    private function prompt(string $field, $options = null, $validation = null): string
-    {
-        return self::$io->prompt($field, $options, $validation);
-    }
-
-    private function write(
-        string $text = '',
-        ?string $foreground = null,
-        ?string $background = null
-    ): void {
-        self::$io->write($text, $foreground, $background);
-    }
-
-    private function error(
-        string $text,
-        string $foreground = 'light_red',
-        ?string $background = null
-    ): void {
-        self::$io->error($text, $foreground, $background);
-    }
-
-    private function ensureInputOutput(): void
-    {
-        if (self::$io === null) {
-            self::$io = new InputOutput();
-        }
-    }
-
-    /**
-     * @internal Testing purpose only
-     */
-    public static function setInputOutput(InputOutput $io): void
-    {
-        self::$io = $io;
-    }
-
-    /**
-     * @internal Testing purpose only
-     */
-    public static function resetInputOutput(): void
-    {
-        self::$io = null;
     }
 }

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Shield\Commands;
 
-use CodeIgniter\CLI\BaseCommand;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Commands\Exceptions\BadInputException;
 use CodeIgniter\Shield\Commands\Exceptions\CancelException;
-use CodeIgniter\Shield\Commands\Utils\InputOutput;
 use CodeIgniter\Shield\Config\Auth;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Exceptions\UserNotFoundException;
@@ -18,19 +16,10 @@ use Config\Services;
 
 class User extends BaseCommand
 {
-    private static ?InputOutput $io = null;
-    private array $validActions     = [
+    private array $validActions = [
         'create', 'activate', 'deactivate', 'changename', 'changeemail',
         'delete', 'password', 'list', 'addgroup', 'removegroup',
     ];
-
-    /**
-     * The group the command is lumped under
-     * when listing commands.
-     *
-     * @var string
-     */
-    protected $group = 'Shield';
 
     /**
      * Command's name
@@ -249,31 +238,6 @@ class User extends BaseCommand
             'email'    => $rules['email'],
             'password' => $rules['password'],
         ];
-    }
-
-    /**
-     * Asks the user for input.
-     *
-     * @param string       $field      Output "field" question
-     * @param array|string $options    String to a default value, array to a list of options (the first option will be the default value)
-     * @param array|string $validation Validation rules
-     *
-     * @return string The user input
-     */
-    private function prompt(string $field, $options = null, $validation = null): string
-    {
-        return self::$io->prompt($field, $options, $validation);
-    }
-
-    /**
-     * Outputs a string to the cli on its own line.
-     */
-    private function write(
-        string $text = '',
-        ?string $foreground = null,
-        ?string $background = null
-    ): void {
-        self::$io->write($text, $foreground, $background);
     }
 
     /**
@@ -691,28 +655,5 @@ class User extends BaseCommand
         $this->checkUserExists($user);
 
         return $userModel->findById($user['id']);
-    }
-
-    private function ensureInputOutput(): void
-    {
-        if (self::$io === null) {
-            self::$io = new InputOutput();
-        }
-    }
-
-    /**
-     * @internal Testing purpose only
-     */
-    public static function setInputOutput(InputOutput $io): void
-    {
-        self::$io = $io;
-    }
-
-    /**
-     * @internal Testing purpose only
-     */
-    public static function resetInputOutput(): void
-    {
-        self::$io = null;
     }
 }

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -126,7 +126,6 @@ class User extends BaseCommand
      */
     public function run(array $params): int
     {
-        $this->ensureInputOutput();
         $this->setTables();
         $this->setValidationRules();
 

--- a/src/Commands/Utils/InputOutput.php
+++ b/src/Commands/Utils/InputOutput.php
@@ -32,4 +32,12 @@ class InputOutput
     ): void {
         CLI::write($text, $foreground, $background);
     }
+
+    /**
+     * Outputs an error to the CLI using STDERR instead of STDOUT
+     */
+    public function error(string $text, string $foreground = 'light_red', ?string $background = null): void
+    {
+        CLI::error($text, $foreground, $background);
+    }
 }

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -53,6 +53,7 @@ final class MockInputOutput extends InputOutput
 
         CITestStreamFilter::registration();
         CITestStreamFilter::addOutputFilter();
+        CITestStreamFilter::addErrorFilter();
 
         PhpStreamWrapper::register();
         PhpStreamWrapper::setContent($input);

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -85,4 +85,15 @@ final class MockInputOutput extends InputOutput
         CITestStreamFilter::removeOutputFilter();
         CITestStreamFilter::removeErrorFilter();
     }
+
+    public function error(string $text, string $foreground = 'light_red', ?string $background = null): void
+    {
+        CITestStreamFilter::registration();
+        CITestStreamFilter::addErrorFilter();
+
+        CLI::error($text, $foreground, $background);
+        $this->outputs[] = CITestStreamFilter::$buffer;
+
+        CITestStreamFilter::removeErrorFilter();
+    }
 }

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -83,7 +83,6 @@ final class MockInputOutput extends InputOutput
         $this->outputs[] = CITestStreamFilter::$buffer;
 
         CITestStreamFilter::removeOutputFilter();
-        CITestStreamFilter::removeErrorFilter();
     }
 
     public function error(string $text, string $foreground = 'light_red', ?string $background = null): void

--- a/tests/Commands/SetupTest.php
+++ b/tests/Commands/SetupTest.php
@@ -49,12 +49,7 @@ final class SetupTest extends TestCase
             'y',
         ]);
 
-        $root = vfsStream::setup('root');
-        vfsStream::copyFromFileSystem(
-            APPPATH,
-            $root
-        );
-        $appFolder = $root->url() . '/';
+        $appFolder = $this->createFilesystem();
 
         $command = new Setup(Services::logger(), Services::commands());
 
@@ -76,7 +71,7 @@ final class SetupTest extends TestCase
         $security = file_get_contents($appFolder . 'Config/Security.php');
         $this->assertStringContainsString('$csrfProtection = \'session\';', $security);
 
-        $result = str_replace(["\033[0;32m", "\033[0m"], '', $this->io->getOutputs());
+        $result = $this->getOutputWithoutColorCode();
 
         $this->assertStringContainsString(
             '  Created: vfs://root/Config/Auth.php
@@ -103,12 +98,7 @@ final class SetupTest extends TestCase
         $config->fromEmail = 'admin@example.com';
         $config->fromName  = 'Site Admin';
 
-        $root = vfsStream::setup('root');
-        vfsStream::copyFromFileSystem(
-            APPPATH,
-            $root
-        );
-        $appFolder = $root->url() . '/';
+        $appFolder = $this->createFilesystem();
 
         $command = new Setup(Services::logger(), Services::commands());
 
@@ -116,7 +106,7 @@ final class SetupTest extends TestCase
 
         $command->run([]);
 
-        $result = str_replace(["\033[0;32m", "\033[0m"], '', $this->io->getOutputs());
+        $result = $this->getOutputWithoutColorCode();
 
         $this->assertStringContainsString(
             '  Created: vfs://root/Config/Auth.php
@@ -127,5 +117,24 @@ final class SetupTest extends TestCase
   Updated: We have updated file \'vfs://root/Config/Security.php\' for security reasons.',
             $result
         );
+    }
+
+    /**
+     * @return string app folder path
+     */
+    private function createFilesystem(): string
+    {
+        $root = vfsStream::setup('root');
+        vfsStream::copyFromFileSystem(
+            APPPATH,
+            $root
+        );
+
+        return $root->url() . '/';
+    }
+
+    private function getOutputWithoutColorCode(): string
+    {
+        return str_replace(["\033[0;32m", "\033[0m"], '', $this->io->getOutputs());
     }
 }

--- a/tests/Commands/SetupTest.php
+++ b/tests/Commands/SetupTest.php
@@ -16,7 +16,6 @@ use Tests\Support\TestCase;
 final class SetupTest extends TestCase
 {
     private ?MockInputOutput $io = null;
-    private $streamFilter;
 
     protected function tearDown(): void
     {

--- a/tests/Commands/SetupTest.php
+++ b/tests/Commands/SetupTest.php
@@ -135,6 +135,12 @@ final class SetupTest extends TestCase
 
     private function getOutputWithoutColorCode(): string
     {
-        return str_replace(["\033[0;32m", "\033[0m"], '', $this->io->getOutputs());
+        $output = str_replace(["\033[0;32m", "\033[0m"], '', $this->io->getOutputs());
+
+        if (is_windows()) {
+            $output = str_replace("\r\n", "\n", $output);
+        }
+
+        return $output;
     }
 }


### PR DESCRIPTION
~~Needs #871~~

**Description**
- `shield:setup` does Email setup
- refactor

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
