### PR TITLE
refactor: replace `/>` with `>` for input tags

### DIFF
--- a/src/Views/email_2fa_show.php
+++ b/src/Views/email_2fa_show.php
@@ -23,7 +23,7 @@
                     <input type="email" class="form-control" name="email"
                         inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>"
                         <?php /** @var \CodeIgniter\Shield\Entities\User $user */ ?>
-                        value="<?= old('email', $user->email) ?>" required />
+                        value="<?= old('email', $user->email) ?>" required>
                 </div>
 
                 <div class="d-grid col-8 mx-auto m-3">

--- a/src/Views/email_2fa_verify.php
+++ b/src/Views/email_2fa_verify.php
@@ -21,7 +21,7 @@
                 <!-- Code -->
                 <div class="mb-2">
                     <input type="number" class="form-control" name="token" placeholder="000000"
-                        inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" required />
+                        inputmode="numeric" pattern="[0-9]*" autocomplete="one-time-code" required>
                 </div>
 
                 <div class="d-grid col-8 mx-auto m-3">

--- a/src/Views/email_activate_show.php
+++ b/src/Views/email_activate_show.php
@@ -21,7 +21,7 @@
                 <!-- Code -->
                 <div class="form-floating mb-2">
                     <input type="text" class="form-control" id="floatingTokenInput" name="token" placeholder="000000" inputmode="numeric"
-                        pattern="[0-9]*" autocomplete="one-time-code" value="<?= old('token') ?>" required />
+                        pattern="[0-9]*" autocomplete="one-time-code" value="<?= old('token') ?>" required>
                     <label for="floatingTokenInput"><?= lang('Auth.token') ?></label>
                 </div>
 

--- a/src/Views/login.php
+++ b/src/Views/login.php
@@ -33,13 +33,13 @@
 
                     <!-- Email -->
                     <div class="form-floating mb-3">
-                        <input type="email" class="form-control" id="floatingEmailInput" name="email" inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>" value="<?= old('email') ?>" required />
+                        <input type="email" class="form-control" id="floatingEmailInput" name="email" inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>" value="<?= old('email') ?>" required>
                         <label for="floatingEmailInput"><?= lang('Auth.email') ?></label>
                     </div>
 
                     <!-- Password -->
                     <div class="form-floating mb-3">
-                        <input type="password" class="form-control" id="floatingPasswordInput" name="password" inputmode="text" autocomplete="current-password" placeholder="<?= lang('Auth.password') ?>" required />
+                        <input type="password" class="form-control" id="floatingPasswordInput" name="password" inputmode="text" autocomplete="current-password" placeholder="<?= lang('Auth.password') ?>" required>
                         <label for="floatingPasswordInput"><?= lang('Auth.password') ?></label>
                     </div>
 

--- a/src/Views/magic_link_form.php
+++ b/src/Views/magic_link_form.php
@@ -30,7 +30,7 @@
                 <!-- Email -->
                 <div class="form-floating mb-2">
                     <input type="email" class="form-control" id="floatingEmailInput" name="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>"
-                           value="<?= old('email', auth()->user()->email ?? null) ?>" required />
+                           value="<?= old('email', auth()->user()->email ?? null) ?>" required>
                     <label for="floatingEmailInput"><?= lang('Auth.email') ?></label>
                 </div>
 

--- a/src/Views/register.php
+++ b/src/Views/register.php
@@ -29,25 +29,25 @@
 
                     <!-- Email -->
                     <div class="form-floating mb-2">
-                        <input type="email" class="form-control" id="floatingEmailInput" name="email" inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>" value="<?= old('email') ?>" required />
+                        <input type="email" class="form-control" id="floatingEmailInput" name="email" inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>" value="<?= old('email') ?>" required>
                         <label for="floatingEmailInput"><?= lang('Auth.email') ?></label>
                     </div>
 
                     <!-- Username -->
                     <div class="form-floating mb-4">
-                        <input type="text" class="form-control" id="floatingUsernameInput" name="username" inputmode="text" autocomplete="username" placeholder="<?= lang('Auth.username') ?>" value="<?= old('username') ?>" required />
+                        <input type="text" class="form-control" id="floatingUsernameInput" name="username" inputmode="text" autocomplete="username" placeholder="<?= lang('Auth.username') ?>" value="<?= old('username') ?>" required>
                         <label for="floatingUsernameInput"><?= lang('Auth.username') ?></label>
                     </div>
 
                     <!-- Password -->
                     <div class="form-floating mb-2">
-                        <input type="password" class="form-control" id="floatingPasswordInput" name="password" inputmode="text" autocomplete="new-password" placeholder="<?= lang('Auth.password') ?>" required />
+                        <input type="password" class="form-control" id="floatingPasswordInput" name="password" inputmode="text" autocomplete="new-password" placeholder="<?= lang('Auth.password') ?>" required>
                         <label for="floatingPasswordInput"><?= lang('Auth.password') ?></label>
                     </div>
 
                     <!-- Password (Again) -->
                     <div class="form-floating mb-5">
-                        <input type="password" class="form-control" id="floatingPasswordConfirmInput" name="password_confirm" inputmode="text" autocomplete="new-password" placeholder="<?= lang('Auth.passwordConfirm') ?>" required />
+                        <input type="password" class="form-control" id="floatingPasswordConfirmInput" name="password_confirm" inputmode="text" autocomplete="new-password" placeholder="<?= lang('Auth.passwordConfirm') ?>" required>
                         <label for="floatingPasswordConfirmInput"><?= lang('Auth.passwordConfirm') ?></label>
                     </div>
 


### PR DESCRIPTION
**Description**
`/` is not needed for HTML5.

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
