### PR TITLE
fix date localized-plugin and refactor action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip3 install mkdocs-material
-      - run: pip3 install mkdocs-git-revision-date-localized-plugin
-      - run: pip3 install mkdocs-redirects
-      - run: mkdocs gh-deploy --force
+      - name: Install Dependencies
+        run: |
+          pip3 install mkdocs-material
+          pip3 install mkdocs-git-revision-date-localized-plugin
+          pip3 install mkdocs-redirects
+      - name: Publish Shiled Documentation
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
The production date by **mkdocs-git-revision-date-localized-plugin** on local is correct, this is due to local access to **.git**.
Now in the online mode, these dates are displayed incorrectly. This PR is trying to address this issue.
I already tested [here](https://github.com/datamweb/shield-oauth/pull/76).

- fix Last update&Created
- refactor action steps

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
