### PR TITLE
translate lang [id]

### DIFF
--- a/src/Language/id/Auth.php
+++ b/src/Language/id/Auth.php
@@ -30,7 +30,7 @@ return [
     'password'        => 'Kata Sandi',
     'passwordConfirm' => 'Kata Sandi (lagi)',
     'haveAccount'     => 'Sudah punya akun?',
-    'token'           => '(To be translated) Token',
+    'token'           => 'Token',
 
     // Buttons
     'confirm' => 'Konfirmasi',
@@ -52,7 +52,7 @@ return [
     'magicLinkExpired'   => 'Maaf, tautan sudah tidak berlaku.',
     'checkYourEmail'     => 'Periksa email Anda!',
     'magicLinkDetails'   => 'Kami baru saja mengirimi Anda email dengan tautan Masuk di dalamnya. Ini hanya berlaku selama {0} menit.',
-    'magicLinkDisabled'  => '(To be translated) Use of MagicLink is currently not allowed.',
+    'magicLinkDisabled'  => 'Penggunaan MagicLink saat ini tidak diperbolehkan.',
     'successLogout'      => 'Anda telah berhasil keluar.',
     'backToLogin'        => 'Kembali ke masuk',
 
@@ -71,7 +71,7 @@ return [
     'errorPasswordTooLongBytes' => 'Panjang kata sandi tidak boleh lebih dari {param} byte.',
     'passwordChangeSuccess'     => 'Kata sandi berhasil diubah',
     'userDoesNotExist'          => 'Kata sandi tidak diubah. User tidak ditemukan',
-    'resetTokenExpired'         => 'Maaf, token setel ulang Anda sudah habis waktu.',
+    'resetTokenExpired'         => 'Maaf, token setel ulang Anda sudah kedaluwarsa.',
 
     // Email Globals
     'emailInfo'      => 'Beberapa informasi tentang seseorang:',
@@ -81,7 +81,7 @@ return [
 
     // 2FA
     'email2FATitle'       => 'Otentikasi Dua Faktor',
-    'confirmEmailAddress' => 'Alamat email konfirmasi Anda.',
+    'confirmEmailAddress' => 'Konfirmasi alamat email Anda.',
     'emailEnterCode'      => 'Konfirmasi email Anda',
     'emailConfirmCode'    => 'Masukkan kode 6 digit yang baru saja kami kirimkan ke alamat email Anda.',
     'email2FASubject'     => 'Kode otentikasi Anda',


### PR DESCRIPTION

**Description**
I have changed `src\Language\id\Auth.php`. Because there are sentences that have not been translated

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
