### PR TITLE
fix: replace `url_is()`

### DIFF
--- a/src/Filters/AbstractAuthFilter.php
+++ b/src/Filters/AbstractAuthFilter.php
@@ -31,7 +31,7 @@ abstract class AbstractAuthFilter implements FilterInterface
 
         if (! auth()->loggedIn()) {
             // Set the entrance url to redirect a user after successful login
-            if (! url_is('login')) {
+            if (uri_string() !== route_to('login')) {
                 $session = session();
                 $session->setTempdata('beforeLoginUrl', current_url(), 300);
             }

--- a/src/Filters/SessionAuth.php
+++ b/src/Filters/SessionAuth.php
@@ -75,7 +75,7 @@ class SessionAuth implements FilterInterface
                 ->with('error', $authenticator->getPendingMessage());
         }
 
-        if (! url_is('login')) {
+        if (uri_string() !== route_to('login')) {
             $session = session();
             $session->setTempdata('beforeLoginUrl', current_url(), 300);
         }


### PR DESCRIPTION
**Description**
`url_is()` checks the URI path. If the path is changed by devs, it will not work.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
