### PR TITLE
refactor: update default value `$hashCost` to 12

### DIFF
--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -354,14 +354,14 @@ class Auth extends BaseConfig
      * --------------------------------------------------------------------
      * The BCRYPT method of hashing allows you to define the "cost"
      * or number of iterations made, whenever a password hash is created.
-     * This defaults to a value of 10 which is an acceptable number.
+     * This defaults to a value of 12 which is an acceptable number.
      * However, depending on the security needs of your application
      * and the power of your hardware, you might want to increase the
      * cost. This makes the hashing process takes longer.
      *
      * Valid range is between 4 - 31.
      */
-    public int $hashCost = 10;
+    public int $hashCost = 12;
 
     /**
      * If you need to support passwords saved in versions prior to Shield v1.0.0-beta.4.

--- a/tests/Unit/PasswordsTest.php
+++ b/tests/Unit/PasswordsTest.php
@@ -52,7 +52,7 @@ final class PasswordsTest extends CIUnitTestCase
     public function testNeedsRehashTakesCareOptions(string $hashedPassword): void
     {
         $config           = new AuthConfig();
-        $config->hashCost = 12;
+        $config->hashCost = 13;
         $passwords        = new Passwords($config);
 
         $result = $passwords->needsRehash($hashedPassword);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
[PHP is increasing the default bcrypt cost](https://wiki.php.net/rfc/bcrypt_cost_2023) to either 11 or 12 to keep up with increases in computing, so we should do the same within Shield. The current **default of 10 was set in PHP 11 years ago**, which is no longer a suitable default.

12 appears to be the sweet spot between performance and security, as confirmed by a member of the Hashcat team. **Symfony uses a cost of 13**, however that may be too high for some servers. Laravel uses a cost of 12.

Due to the way hashing works, there are **no BC** issues - older passwords with lower rounds will still be handled properly, and code that automatically rehashes passwords will upgrade them over time. [The RFC contains hash calculation timings](https://wiki.php.net/rfc/bcrypt_cost_2023) if you'd like more information on the impacts.

Now, due to the increase in hardware speed, using 12 is more suitable for the Shield.

More info [see](https://github.com/laravel/laravel/pull/6245).


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
