### PR TITLE
docs: remove unneeded `/` from routes

### DIFF
--- a/docs/guides/api_hmac_keys.md
+++ b/docs/guides/api_hmac_keys.md
@@ -24,7 +24,7 @@ The `generateHmacToken()` method requires a name for the token. These are free s
 the user/device the token was generated from/for, like 'Johns MacBook Air'.
 
 ```php
-$routes->get('/hmac/token', static function () {
+$routes->get('hmac/token', static function () {
     $token = auth()->user()->generateHmacToken(service('request')->getVar('token_name'));
 
     return json_encode(['key' => $token->secret, 'secretKey' => $token->secret2]);

--- a/docs/guides/api_tokens.md
+++ b/docs/guides/api_tokens.md
@@ -11,7 +11,7 @@ Tokens are issued with the `generateAccessToken()` method on the user. This retu
 The `generateAccessToken()` method requires a name for the token. These are free strings and are often used to identify the user/device the token was generated from, like 'Johns MacBook Air'.
 
 ```php
-$routes->get('/access/token', static function() {
+$routes->get('access/token', static function() {
     $token = auth()->user()->generateAccessToken(service('request')->getVar('token_name'));
 
     return json_encode(['token' => $token->raw_token]);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Remove unnecessary `/` from routes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
