### PR TITLE
docs: add `logout` to session except list

### DIFF
--- a/docs/customization/route_config.md
+++ b/docs/customization/route_config.md
@@ -57,7 +57,7 @@ update the paths for `except`:
 public $globals = [
     'before' => [
         // ...
-        'session' => ['except' => ['*/login*', '*/register', '*/auth/a/*', 'logout']],
+        'session' => ['except' => ['*/login*', '*/register', '*/auth/a/*', '*/logout']],
     ],
     // ...
 ];

--- a/docs/customization/route_config.md
+++ b/docs/customization/route_config.md
@@ -57,7 +57,7 @@ update the paths for `except`:
 public $globals = [
     'before' => [
         // ...
-        'session' => ['except' => ['*/login*', '*/register', '*/auth/a/*']],
+        'session' => ['except' => ['*/login*', '*/register', '*/auth/a/*', 'logout']],
     ],
     // ...
 ];

--- a/docs/quick_start_guide/using_session_auth.md
+++ b/docs/quick_start_guide/using_session_auth.md
@@ -100,7 +100,7 @@ If you want to limit all routes (e.g. `localhost:8080/admin`, `localhost:8080/pa
 public $globals = [
     'before' => [
         // ...
-        'session' => ['except' => ['login*', 'register', 'auth/a/*']],
+        'session' => ['except' => ['login*', 'register', 'auth/a/*', 'logout']],
     ],
     // ...
 ];

--- a/docs/references/controller_filters.md
+++ b/docs/references/controller_filters.md
@@ -47,7 +47,7 @@ If you want to limit all routes (e.g. `localhost:8080/admin`, `localhost:8080/pa
 public $globals = [
     'before' => [
         // ...
-        'session' => ['except' => ['login*', 'register', 'auth/a/*']],
+        'session' => ['except' => ['login*', 'register', 'auth/a/*', 'logout']],
     ],
     // ...
 ];
@@ -102,7 +102,7 @@ Then the global `before` filter for `session` should look like so:
 public $globals = [
     'before' => [
         // ...
-        'session' => ['except' => ['accounts/login*', 'accounts/register', 'accounts/auth/a/*']]
+        'session' => ['except' => ['accounts/login*', 'accounts/register', 'accounts/auth/a/*', 'accounts/logout']]
     ]
 ]
 ```


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
The duty of **session** is to protect URLs. I think devs should know that there is no reason to protect **logout**. That's why I think we don't need to change the code.
I have already added this topic #642 .

fix #920 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
