### PR TITLE
fix: show 404 page when see `/logout` if not login

### DIFF
--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Controllers;
 
 use App\Controllers\BaseController;
+use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Traits\Viewable;
@@ -87,9 +88,15 @@ class LoginController extends BaseController
 
     /**
      * Logs the current user out.
+     *
+     * @throws PageNotFoundException if user not login
      */
     public function logoutAction(): RedirectResponse
     {
+        if (! auth()->loggedIn()) {
+            throw PageNotFoundException::forPageNotFound();
+        }
+
         // Capture logout redirect URL before auth logout,
         // otherwise you cannot check the user in `logoutRedirect()`.
         $url = config('Auth')->logoutRedirect();


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
See https://github.com/codeigniter4/shield/pull/921#issuecomment-1771506477

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
