### PR TITLE
test: update assertion in JWTManagerTest

### DIFF
--- a/tests/Unit/Authentication/JWT/JWTManagerTest.php
+++ b/tests/Unit/Authentication/JWT/JWTManagerTest.php
@@ -182,9 +182,9 @@ final class JWTManagerTest extends TestCase
         $this->assertIsString($token);
 
         $headers = $this->decodeJWT($token, 'header');
-        $this->assertSame([
-            'extra_key' => 'extra_value',
+        $this->assertEqualsCanonicalizing([
             'typ'       => 'JWT',
+            'extra_key' => 'extra_value',
             'alg'       => 'HS256',
         ], $headers);
     }


### PR DESCRIPTION
**Description**
It seems the order of array items changed by the library upgrade.

```diff
1) Tests\Unit\Authentication\JWT\JWTManagerTest::testIssueAddHeader
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
+    'typ' => 'JWT'
     'extra_key' => 'extra_value'
-    'typ' => 'JWT'
     'alg' => 'HS256'
 )

/home/runner/work/shield/shield/tests/Unit/Authentication/JWT/JWTManagerTest.php:186
phpvfscomposer:///home/runner/work/shield/shield/vendor/phpunit/phpunit/phpunit:106
```
https://github.com/codeigniter4/shield/actions/runs/7073301556/job/19253043215?pr=963

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
