### PR TITLE
docs: update docs color scheme

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+shield.codeigniter.com

--- a/docs/assets/css/codeigniter.css
+++ b/docs/assets/css/codeigniter.css
@@ -1,0 +1,18 @@
+[data-md-color-scheme="codeigniter"] {
+    --md-primary-fg-color:        #dd4814;
+    --md-primary-fg-color--light: #ECB7B7;
+    --md-primary-fg-color--dark:  #90030C;
+
+    --md-default-bg-color: #fcfcfc;
+
+    --md-typeset-a-color: #e74c3c;
+    --md-accent-fg-color: #97310e;
+
+    --md-accent-fg-color--transparent: #ECB7B7;
+
+    --md-code-bg-color: #ffffff;
+
+    .md-typeset code {
+        border: 1px solid #e1e4e5;
+    }
+}

--- a/docs/assets/css/codeigniter_dark_mode.css
+++ b/docs/assets/css/codeigniter_dark_mode.css
@@ -1,7 +1,16 @@
 [data-md-color-scheme="slate"] {
-    --md-primary-fg-color: #6a290d;
+    --md-primary-fg-color: #b13a10;
     --md-primary-fg-color--light: #8d7474;
     --md-primary-fg-color--dark: #6d554d;
+
+    --md-default-bg-color: #1e2129;
+
+    --md-typeset-a-color: #ed6436;
+    --md-accent-fg-color: #f18a67;
+
+    --md-accent-fg-color--transparent: #625151;
+
+    --md-code-bg-color: #282b2d;
 
     .hljs-title,
     .hljs-title.class_,
@@ -43,31 +52,30 @@
         color: #ddba52
     }
 
-    .md-typeset .note > .admonition-title,
-    .md-typeset .note > summary {
-        background-color: #0000001a;
+    .md-typeset code {
+        border: 1px solid #3f4547;
     }
 
     .md-typeset .admonition.note,
     .md-typeset details.note {
-        border-color: #675647;
+        border-color: #2c5293;
     }
 
     .md-typeset .note > .admonition-title:before,
     .md-typeset .note > summary:before {
-        background-color: #65686d;
+        background-color: #2c5293;
         -webkit-mask-image: var(--md-admonition-icon--note);
         mask-image: var(--md-admonition-icon--note);
     }
 
     .md-typeset .admonition.warning,
     .md-typeset details.warning {
-        border-color: #776144;
+        border-color: #97631e;
     }
 
     .md-typeset .warning > .admonition-title:before,
     .md-typeset .warning > summary:before {
-        background-color: #d9913bc2;
+        background-color: #97631e;
         -webkit-mask-image: var(--md-admonition-icon--warning);
         mask-image: var(--md-admonition-icon--warning);
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,17 +12,17 @@ theme:
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: deep orange
-      accent: orange
+      scheme: codeigniter
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: deep orange
-      accent: orange
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -68,8 +68,9 @@ markdown_extensions:
   - pymdownx.details
 
 extra_css:
-  - https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/styles/default.min.css
-  - assets/css/dark_mode.css
+  - https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/styles/github.min.css
+  - assets/css/codeigniter.css
+  - assets/css/codeigniter_dark_mode.css
 
 extra_javascript:
   - https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/highlight.min.js


### PR DESCRIPTION
**Description**
This PR updates the docs color scheme to match one from Tasks and Queue projects.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
