### PR TITLE
Allow specifying namespace when generating routes.

### DIFF
--- a/docs/customization/route_config.md
+++ b/docs/customization/route_config.md
@@ -19,6 +19,16 @@ $routes->get('register', '\App\Controllers\Auth\RegisterController::registerView
 
 After customization, check your routes with the [spark routes](https://codeigniter.com/user_guide/incoming/routing.html#spark-routes) command.
 
+## Change Namespace
+
+If you are overriding all of the auth controllers, you can specify the namespace as an option to the `routes()` helper:
+
+```php
+service('auth')->routes($routes, ['namespace' => '\App\Controllers\Auth']);
+```
+
+This will generate the routes with the specified namespace instead of the default Shield namespace. This can be combined with any other options, like `except`.
+
 ## Use Locale Routes
 
 You can use the `{locale}` placeholder in your routes

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -138,7 +138,9 @@ class Auth
     {
         $authRoutes = config('AuthRoutes')->routes;
 
-        $routes->group('/', ['namespace' => 'CodeIgniter\Shield\Controllers'], static function (RouteCollection $routes) use ($authRoutes, $config): void {
+        $namespace = $config['namespace'] ?? 'CodeIgniter\Shield\Controllers';
+
+        $routes->group('/', ['namespace' => $namespace], static function (RouteCollection $routes) use ($authRoutes, $config): void {
             foreach ($authRoutes as $name => $row) {
                 if (! isset($config['except']) || ! in_array($name, $config['except'], true)) {
                     foreach ($row as $params) {

--- a/tests/Unit/AuthRoutesTest.php
+++ b/tests/Unit/AuthRoutesTest.php
@@ -51,4 +51,16 @@ final class AuthRoutesTest extends TestCase
         $this->assertArrayHasKey('logout', $routes);
         $this->assertArrayHasKey('auth/a/show', $routes);
     }
+
+    public function testRoutesCustomNamespace(): void
+    {
+        $collection = single_service('routes');
+        $auth       = service('auth');
+
+        $auth->routes($collection, ['namespace' => 'Auth']);
+
+        $routes = $collection->getRoutes('get');
+
+        $this->assertSame('\Auth\RegisterController::registerView', $routes['register']);
+    }
 }


### PR DESCRIPTION
**Description**
If you need to override all of the auth controllers it is a pain to have to specify all of the routes manually when all you need is to change the namespace. This change allows you to pass a `namespace` option along into the `auth()->routes()` call.

```php
auth()->routes($routes, ['namespace' => 'App\Controllers\Auth']);
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
