### PR TITLE
fix: `shield:user create` with default group

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "mockery/mockery": "^1.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "rector/rector": "0.18.13"
+        "rector/rector": "0.19.0"
     },
     "provide": {
         "codeigniter4/authentication-implementation": "1.0"

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -158,16 +158,7 @@ $ignoreErrors[] = [
 	'count' => 1,
 	'path' => __DIR__ . '/src/Collectors/Auth.php',
 ];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Shield\\\\Commands\\\\Generators\\\\UserModelGenerator\\:\\:\\$arguments is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$arguments\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Commands/Generators/UserModelGenerator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^PHPDoc type array\\<string, string\\> of property CodeIgniter\\\\Shield\\\\Commands\\\\Generators\\\\UserModelGenerator\\:\\:\\$options is not the same as PHPDoc type array of overridden property CodeIgniter\\\\CLI\\\\BaseCommand\\:\\:\\$options\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Commands/Generators/UserModelGenerator.php',
-];
+
 $ignoreErrors[] = [
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 1,
@@ -317,23 +308,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Models/UserModel.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$data \\(array\\|CodeIgniter\\\\Shield\\\\Entities\\\\User\\) of method CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:insert\\(\\) should be contravariant with parameter \\$data \\(array\\|object\\|null\\) of method CodeIgniter\\\\Model\\:\\:insert\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Models/UserModel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$data \\(array\\|CodeIgniter\\\\Shield\\\\Entities\\\\User\\) of method CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:save\\(\\) should be contravariant with parameter \\$data \\(array\\|object\\) of method CodeIgniter\\\\BaseModel\\:\\:save\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Models/UserModel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$data \\(array\\|CodeIgniter\\\\Shield\\\\Entities\\\\User\\) of method CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:update\\(\\) should be contravariant with parameter \\$data \\(array\\|object\\|null\\) of method CodeIgniter\\\\Model\\:\\:update\\(\\)$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Models/UserModel.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Return type \\(int\\|string\\|true\\) of method CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:insert\\(\\) should be covariant with return type \\(int\\|object\\|string\\|false\\) of method CodeIgniter\\\\Model\\:\\:insert\\(\\)$#',
-	'count' => 1,
+	'message' => '#^Return type \\(int|string|true\\) of method CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:insert\\(\\) should be covariant with return type \\(\\(\\$returnID is true \\? int|string|false \\: bool\\) of method CodeIgniter\\\\Model\\:\\:insert\\(\\)\\$#',
+	'count' => 4,
 	'path' => __DIR__ . '/src/Models/UserModel.php',
 ];
 $ignoreErrors[] = [

--- a/rector.php
+++ b/rector.php
@@ -33,7 +33,6 @@ use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\If_\UnwrapFutureCompatibleIfPhpVersionRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
-use Rector\DeadCode\Rector\StmtsAwareInterface\RemoveJustPropertyFetchForAssignRector;
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
@@ -98,11 +97,6 @@ return static function (RectorConfig $rectorConfig): void {
 
         // May load view files directly when detecting classes
         StringClassNameToClassConstantRector::class,
-
-        // See https://github.com/codeigniter4/shield/issues/228
-        RemoveJustPropertyFetchForAssignRector::class => [
-            __DIR__ . '/src/Models/UserModel.php',
-        ],
 
         // Ignore tests that use CodeIgniter::CI_VERSION
         UnwrapFutureCompatibleIfPhpVersionRector::class => [

--- a/src/Commands/Hmac.php
+++ b/src/Commands/Hmac.php
@@ -54,7 +54,7 @@ class Hmac extends BaseCommand
     /**
      * the Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'action' => <<<'EOL'
@@ -72,7 +72,7 @@ class Hmac extends BaseCommand
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [];
 

--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -47,14 +47,14 @@ class Setup extends BaseCommand
     /**
      * the Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [];
 
     /**
      * the Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '-f' => 'Force overwrite ALL existing files in destination.',

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -86,7 +86,7 @@ class User extends BaseCommand
     /**
      * Command's Arguments
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $arguments = [
         'action' => <<<'EOL'
@@ -107,7 +107,7 @@ class User extends BaseCommand
     /**
      * Command's Options
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $options = [
         '-i'          => 'User id',
@@ -300,6 +300,10 @@ class User extends BaseCommand
 
         $user = new UserEntity($data);
         $userModel->save($user);
+
+        // Add to default group
+        $user = $userModel->findById($userModel->getInsertID());
+        $userModel->addToDefaultGroup($user);
 
         $this->write('User "' . $username . '" created', 'green');
     }

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -542,15 +542,15 @@ class UserIdentityModel extends BaseModel
      * Throws an Exception when it fails.
      *
      * @param array|int|string|null $id
-     * @param array|object|null     $data
+     * @param array|object|null     $row
      *
      * @return true if the update is successful
      *
      * @throws ValidationException
      */
-    public function update($id = null, $data = null): bool
+    public function update($id = null, $row = null): bool
     {
-        $result = parent::update($id, $data);
+        $result = parent::update($id, $row);
 
         $this->checkQueryReturn($result);
 

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -251,18 +251,18 @@ class UserModel extends BaseModel
      * Override the BaseModel's `insert()` method.
      * If you pass User object, also inserts Email Identity.
      *
-     * @param array|User $data
+     * @param array|User $row
      *
      * @return int|string|true Insert ID if $returnID is true
      *
      * @throws ValidationException
      */
-    public function insert($data = null, bool $returnID = true)
+    public function insert($row = null, bool $returnID = true)
     {
         // Clone User object for not changing the passed object.
-        $this->tempUser = $data instanceof User ? clone $data : null;
+        $this->tempUser = $row instanceof User ? clone $row : null;
 
-        $result = parent::insert($data, $returnID);
+        $result = parent::insert($row, $returnID);
 
         $this->checkQueryReturn($result);
 
@@ -274,20 +274,20 @@ class UserModel extends BaseModel
      * If you pass User object, also updates Email Identity.
      *
      * @param array|int|string|null $id
-     * @param array|User            $data
+     * @param array|User            $row
      *
      * @return true if the update is successful
      *
      * @throws ValidationException
      */
-    public function update($id = null, $data = null): bool
+    public function update($id = null, $row = null): bool
     {
         // Clone User object for not changing the passed object.
-        $this->tempUser = $data instanceof User ? clone $data : null;
+        $this->tempUser = $row instanceof User ? clone $row : null;
 
         try {
             /** @throws DataException */
-            $result = parent::update($id, $data);
+            $result = parent::update($id, $row);
         } catch (DataException $e) {
             // When $data is an array.
             if ($this->tempUser === null) {
@@ -316,15 +316,15 @@ class UserModel extends BaseModel
      * Override the BaseModel's `save()` method.
      * If you pass User object, also updates Email Identity.
      *
-     * @param array|User $data
+     * @param array|User $row
      *
      * @return true if the save is successful
      *
      * @throws ValidationException
      */
-    public function save($data): bool
+    public function save($row): bool
     {
-        $result = parent::save($data);
+        $result = parent::save($row);
 
         $this->checkQueryReturn($result);
 

--- a/tests/Authentication/MagicLinkTest.php
+++ b/tests/Authentication/MagicLinkTest.php
@@ -114,7 +114,7 @@ final class MagicLinkTest extends DatabaseTestCase
             'user_id' => $user->id,
             'type'    => Session::ID_TYPE_MAGIC_LINK,
             'secret'  => 'abasdasdf',
-            'expires' => Time::now()->subDays(5),
+            'expires' => Time::now()->subDays(5)->format('Y-m-d H:i:s'),
         ]);
 
         $result = $this->get(route_to('verify-magic-link') . '?token=abasdasdf');
@@ -136,7 +136,7 @@ final class MagicLinkTest extends DatabaseTestCase
             'user_id' => $user->id,
             'type'    => Session::ID_TYPE_MAGIC_LINK,
             'secret'  => 'abasdasdf',
-            'expires' => Time::now()->addMinutes(60),
+            'expires' => Time::now()->addMinutes(60)->format('Y-m-d H:i:s'),
         ]);
 
         $result = $this->get(route_to('verify-magic-link') . '?token=abasdasdf');

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Commands;
 
 use CodeIgniter\Shield\Commands\User;
+use CodeIgniter\Shield\Config\AuthGroups;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Test\MockInputOutput;
@@ -92,6 +93,10 @@ final class UserTest extends DatabaseTestCase
         $this->seeInDatabase($this->tables['users'], [
             'id'     => $user->id,
             'active' => 0,
+        ]);
+        $this->seeInDatabase($this->tables['groups_users'], [
+            'user_id' => $user->id,
+            'group'   => config(AuthGroups::class)->defaultGroup,
         ]);
     }
 

--- a/tests/Controllers/MagicLinkTest.php
+++ b/tests/Controllers/MagicLinkTest.php
@@ -103,7 +103,7 @@ final class MagicLinkTest extends TestCase
             'user_id' => $user->id,
             'type'    => Session::ID_TYPE_MAGIC_LINK,
             'secret'  => 'abasdasdf',
-            'expires' => Time::now()->addMinutes(60),
+            'expires' => Time::now()->addMinutes(60)->format('Y-m-d H:i:s'),
         ]);
 
         $result = $this->get(route_to('verify-magic-link') . '?token=abasdasdf');


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
fix: #998 

The user registration form sets the default group value for the user when a new user is registered. Although I don't consider this a bug, I prefer that this process be done for command `shield:user create` as well.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
