### PR TITLE
fix: Shield may not send correct HTML mail

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -88,7 +88,8 @@ class Email2FA implements ActionInterface
 
         // Send the user an email with the code
         helper('email');
-        $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
+        $email = emailer(['mailType' => 'html'])
+            ->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($user->email);
         $email->setSubject(lang('Auth.email2FASubject'));
         $email->setMessage($this->view(setting('Auth.views')['action_email_2fa_email'], ['code' => $identity->secret, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -92,7 +92,11 @@ class Email2FA implements ActionInterface
             ->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($user->email);
         $email->setSubject(lang('Auth.email2FASubject'));
-        $email->setMessage($this->view(setting('Auth.views')['action_email_2fa_email'], ['code' => $identity->secret, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));
+        $email->setMessage($this->view(
+            setting('Auth.views')['action_email_2fa_email'],
+            ['code'  => $identity->secret, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date],
+            ['debug' => false]
+        ));
 
         if ($email->send(false) === false) {
             throw new RuntimeException('Cannot send email for user: ' . $user->email . "\n" . $email->printDebugger(['headers']));

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -65,7 +65,8 @@ class EmailActivator implements ActionInterface
 
         // Send the email
         helper('email');
-        $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
+        $email = emailer(['mailType' => 'html'])
+            ->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($userEmail);
         $email->setSubject(lang('Auth.emailActivateSubject'));
         $email->setMessage($this->view(setting('Auth.views')['action_email_activate_email'], ['code' => $code, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -69,7 +69,11 @@ class EmailActivator implements ActionInterface
             ->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($userEmail);
         $email->setSubject(lang('Auth.emailActivateSubject'));
-        $email->setMessage($this->view(setting('Auth.views')['action_email_activate_email'], ['code' => $code, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));
+        $email->setMessage($this->view(
+            setting('Auth.views')['action_email_activate_email'],
+            ['code'  => $code, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date],
+            ['debug' => false]
+        ));
 
         if ($email->send(false) === false) {
             throw new RuntimeException('Cannot send email for user: ' . $user->email . "\n" . $email->printDebugger(['headers']));

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -125,7 +125,11 @@ class MagicLinkController extends BaseController
             ->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($user->email);
         $email->setSubject(lang('Auth.magicLinkSubject'));
-        $email->setMessage($this->view(setting('Auth.views')['magic-link-email'], ['token' => $token, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));
+        $email->setMessage($this->view(
+            setting('Auth.views')['magic-link-email'],
+            ['token' => $token, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date],
+            ['debug' => false]
+        ));
 
         if ($email->send(false) === false) {
             log_message('error', $email->printDebugger(['headers']));

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -121,7 +121,8 @@ class MagicLinkController extends BaseController
 
         // Send the user an email with the code
         helper('email');
-        $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
+        $email = emailer(['mailType' => 'html'])
+            ->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
         $email->setTo($user->email);
         $email->setSubject(lang('Auth.magicLinkSubject'));
         $email->setMessage($this->view(setting('Auth.views')['magic-link-email'], ['token' => $token, 'ipAddress' => $ipAddress, 'userAgent' => $userAgent, 'date' => $date]));

--- a/src/Helpers/email_helper.php
+++ b/src/Helpers/email_helper.php
@@ -17,6 +17,8 @@ if (! defined('emailer')) {
     /**
      * Provides convenient access to the CodeIgniter Email class.
      *
+     * @param array<string, mixed> $overrides Email preferences to override.
+     *
      * @internal
      */
     function emailer(array $overrides = []): Email
@@ -46,7 +48,7 @@ if (! defined('emailer')) {
         ];
 
         if ($overrides !== []) {
-            $config = array_merge($overrides, $config);
+            $config = array_merge($config, $overrides);
         }
 
         /** @var Email $email */


### PR DESCRIPTION
**Description**
Closes #1018, Resolves #1019

- fix `emailer()`
- fix code that sends email

Before:
![Screenshot 2024-02-08 13 15 06](https://github.com/codeigniter4/shield/assets/87955/84a4608b-2ebc-425e-af32-8594ad2b267b)

After:
![Screenshot 2024-02-08 13 14 58](https://github.com/codeigniter4/shield/assets/87955/e1c9a8d0-fd97-48bf-aa4c-5e10ece9c2cc)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
