### PR TITLE
Prep for 1.0.1 release

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,7 +1,7 @@
 {
     "title": [
         {
-            "pattern": "^(\\[\\d+\\.\\d+\\]\\s{1})?(feat|fix|chore|docs|perf|refactor|style|test|lang)(\\([\\-.@:`a-zA-Z0-9]+\\))?!?:\\s{1}\\S.+\\S$",
+            "pattern": "^(\\[\\d+\\.\\d+\\]\\s{1})?(feat|fix|chore|docs|perf|refactor|style|test|lang)(\\([\\-.@:`a-zA-Z0-9]+\\))?!?:\\s{1}\\S.+\\S|Prep for \\d\\.\\d\\.\\d release$",
             "message": "PR title must include the type (feat, fix, chore, docs, perf, refactor, style, test, lang) of the commit per Conventional Commits specification. See https://www.conventionalcommits.org/en/v1.0.0/ for the discussion."
         }
     ]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 on:
   push:
     branches:
-      - master
+      - develop
 permissions:
   contents: write
 jobs:

--- a/admin/RELEASE.md
+++ b/admin/RELEASE.md
@@ -2,6 +2,9 @@
 
 > Documentation guide based on the releases of `1.0.0-beta.5` on March 17, 2023.
 >
+> Updated for `1.0.1` on February 15, 2024.
+> Starting with this version, we have stopped using the `master` branch.
+>
 > -kenjis
 
 ## Changelog
@@ -25,8 +28,8 @@ To auto-generate, navigate to the
 [Releases](https://github.com/codeigniter4/shield/releases) page,
 click the "Draft a new release" button.
 
-* Tag: "v1.0.0-beta.5" (Create new tag)
-* Target: develop
+* Tag: `v1.x.x` (Create new tag)
+* Target: `develop`
 
 Click the "Generate release notes" button.
 
@@ -50,42 +53,29 @@ the changelog.
 > been included with their PR, so this process assumes you will not be
 > generating much new content.
 
-* [ ] Create a new branch `release-1.x.x`
-* [ ] Update **src/Auth.php** with the new version number:
-  `const SHIELD_VERSION = '1.x.x';`
-* [ ] Commit the changes with "Prep for 1.x.x release" and push to origin
+* [ ] Run `php admin/prepare-release.php 1.x.x` and push to origin
+    * The above command does the following:
+      * Create a new branch `release-1.x.x`
+      * Update **src/Auth.php** with the new version number:
+        `const SHIELD_VERSION = '1.x.x';`
+      * Commit the changes with "Prep for 1.x.x release" and push to origin
 * [ ] Create a new PR from `release-1.x.x` to `develop`:
-    * Title: "Prep for 1.x.x release"
-    * Description: "Updates version references for `1.x.x`." (plus checklist)
+    * Title: `Prep for 1.x.x release`
+    * Description: `Updates version references for 1.x.x.` (plus checklist)
 * [ ] Let all tests run, then review and merge the PR
-* [ ] Create a new PR from `develop` to `master`:
-    * Title: "1.x.x Ready code"
-    * Description: blank
 * [ ] Merge the PR
 * [ ] Create a new Release:
-    * Version: "v1.x.x"
-    * Target: master
-    * Title: "v1.x.x"
+    * Version: `v1.x.x`
+    * Target: `develop`
+    * Title: `v1.x.x`
     * Click the "Generate release notes" button
-    * Remove "### Others (Only for checking. Remove this category)" section
-    * Add important notes if necessary
-    * Add link to Upgrade Guide if necessary
-    * Check "Create a discussion for this release"
+    * [ ] Remove "### Others (Only for checking. Remove this category)" section
+    * [ ] Add important notes if necessary
+    * [ ] Add link to Upgrade Guide if necessary
+    * [ ] Check "Create a discussion for this release"
     * Click the "Publish release" button
 * [ ] Watch for the "docs" action and verify that the user guide updated:
     * [docs](https://github.com/codeigniter4/shield/actions/workflows/docs.yml)
-* [ ] Fast-forward `develop` branch to catch the merge commit from `master`
-  (note: pushing to `develop` is restricted to administrators):
-    ```console
-    git fetch origin
-    git checkout develop
-    git merge origin/develop
-    git merge origin/master
-    git push origin HEAD # Only administrators can push to the protected branch.
-    ```
-  **At this point, `master` must be merged into `develop`.** Otherwise, the
-  GitHub-generated release note from `develop` for the next release will not be
-  generated correctly.
 * [ ] Publish any Security Advisories that were resolved from private forks
   (note: publishing is restricted to administrators)
 * [ ] Announce the release on the forums and Slack channel

--- a/admin/prepare-release.php
+++ b/admin/prepare-release.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+function replace_file_content(string $path, string $pattern, string $replace): void
+{
+    $file   = file_get_contents($path);
+    $output = preg_replace($pattern, $replace, $file);
+    file_put_contents($path, $output);
+}
+
+// Main.
+chdir(__DIR__ . '/..');
+
+if ($argc !== 2) {
+    echo "Usage: php {$argv[0]} <version>" . PHP_EOL;
+    echo "E.g.,: php {$argv[0]} 1.0.1" . PHP_EOL;
+
+    exit(1);
+}
+
+// Gets version number from argument.
+$version      = $argv[1]; // e.g., '4.4.3'
+$versionParts = explode('.', $version);
+$minor        = $versionParts[0] . '.' . $versionParts[1];
+
+// Creates a branch for release.
+system('git switch develop');
+system('git switch -c release-' . $version);
+
+// Updates version number in "src/Auth.php".
+replace_file_content(
+    './src/Auth.php',
+    '/const SHIELD_VERSION = \'.*?\';/u',
+    "const SHIELD_VERSION = '{$version}';"
+);
+
+// Commits
+system('git add -u');
+system('git commit -m "Prep for ' . $version . ' release"');

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -41,7 +41,7 @@ class Auth
     /**
      * The current version of CodeIgniter Shield
      */
-    public const SHIELD_VERSION = '1.0.0';
+    public const SHIELD_VERSION = '1.0.1';
 
     protected AuthConfig $config;
     protected ?Authentication $authenticate = null;


### PR DESCRIPTION
**Description**
Updates version references for 1.0.1.
Prev #990

- update RELEASE.md. See also #1025
- add script for release
- use `develop` in `workflows/docs.yml`
- update `prlint.json`

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
