### PR TITLE
fix: `JWT::loggedIn()` does not remove `Bearer` prefix

### DIFF
--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Authentication\Authenticators;
 
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\AuthenticationException;
 use CodeIgniter\Shield\Authentication\AuthenticatorInterface;
@@ -209,9 +210,29 @@ class JWT implements AuthenticatorInterface
         /** @var AuthJWT $config */
         $config = config('AuthJWT');
 
+        $token = $this->getTokenFromHeader($request);
+
         return $this->attempt([
-            'token' => $request->getHeaderLine($config->authenticatorHeader),
+            'token' => $token,
         ])->isOK();
+    }
+
+    private function getTokenFromHeader(RequestInterface $request): string
+    {
+        assert($request instanceof IncomingRequest);
+
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
+
+        $tokenHeader = $request->getHeaderLine(
+            $config->authenticatorHeader ?? 'Authorization'
+        );
+
+        if (strpos($tokenHeader, 'Bearer') === 0) {
+            return trim(substr($tokenHeader, 6));
+        }
+
+        return $tokenHeader;
     }
 
     /**

--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -207,9 +207,6 @@ class JWT implements AuthenticatorInterface
         /** @var IncomingRequest $request */
         $request = service('request');
 
-        /** @var AuthJWT $config */
-        $config = config('AuthJWT');
-
         $token = $this->getTokenFromHeader($request);
 
         return $this->attempt([
@@ -217,7 +214,7 @@ class JWT implements AuthenticatorInterface
         ])->isOK();
     }
 
-    private function getTokenFromHeader(RequestInterface $request): string
+    public function getTokenFromHeader(RequestInterface $request): string
     {
         assert($request instanceof IncomingRequest);
 

--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -207,14 +207,17 @@ class JWT implements AuthenticatorInterface
         /** @var IncomingRequest $request */
         $request = service('request');
 
-        $token = $this->getTokenFromHeader($request);
+        $token = $this->getTokenFromRequest($request);
 
         return $this->attempt([
             'token' => $token,
         ])->isOK();
     }
 
-    public function getTokenFromHeader(RequestInterface $request): string
+    /**
+     * Gets token from Request.
+     */
+    public function getTokenFromRequest(RequestInterface $request): string
     {
         assert($request instanceof IncomingRequest);
 

--- a/src/Filters/JWTAuth.php
+++ b/src/Filters/JWTAuth.php
@@ -44,7 +44,7 @@ class JWTAuth implements FilterInterface
         /** @var JWT $authenticator */
         $authenticator = auth('jwt')->getAuthenticator();
 
-        $token = $authenticator->getTokenFromHeader($request);
+        $token = $authenticator->getTokenFromRequest($request);
 
         $result = $authenticator->attempt(['token' => $token]);
 

--- a/src/Filters/JWTAuth.php
+++ b/src/Filters/JWTAuth.php
@@ -19,7 +19,6 @@ use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Shield\Authentication\Authenticators\JWT;
-use CodeIgniter\Shield\Config\AuthJWT;
 use Config\Services;
 
 /**
@@ -45,7 +44,7 @@ class JWTAuth implements FilterInterface
         /** @var JWT $authenticator */
         $authenticator = auth('jwt')->getAuthenticator();
 
-        $token = $this->getTokenFromHeader($request);
+        $token = $authenticator->getTokenFromHeader($request);
 
         $result = $authenticator->attempt(['token' => $token]);
 
@@ -60,24 +59,6 @@ class JWTAuth implements FilterInterface
         if (setting('Auth.recordActiveDate')) {
             $authenticator->recordActiveDate();
         }
-    }
-
-    private function getTokenFromHeader(RequestInterface $request): string
-    {
-        assert($request instanceof IncomingRequest);
-
-        /** @var AuthJWT $config */
-        $config = config('AuthJWT');
-
-        $tokenHeader = $request->getHeaderLine(
-            $config->authenticatorHeader ?? 'Authorization'
-        );
-
-        if (strpos($tokenHeader, 'Bearer') === 0) {
-            return trim(substr($tokenHeader, 6));
-        }
-
-        return $tokenHeader;
     }
 
     /**

--- a/tests/Authentication/Authenticators/JWTAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/JWTAuthenticatorTest.php
@@ -282,4 +282,16 @@ final class JWTAuthenticatorTest extends DatabaseTestCase
 
         return $generator->generateToken($this->user);
     }
+
+    public function testGetTokenFromRequest(): void
+    {
+        $request = Services::incomingrequest(null, false);
+
+        $jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+        $request->setHeader('Authorization', 'Bearer ' . $jwt);
+
+        $token = $this->auth->getTokenFromRequest($request);
+
+        $this->assertSame($jwt, $token);
+    }
 }


### PR DESCRIPTION
**Description**
Supersedes #1039 , Close #1039
Fixes #1038 

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
