### PR TITLE
fix: LoginModel cannot use uuid for id column

### DIFF
--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Authentication\Authenticators;
 
 use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\AuthenticationException;
 use CodeIgniter\Shield\Authentication\AuthenticatorInterface;
@@ -209,9 +210,29 @@ class JWT implements AuthenticatorInterface
         /** @var AuthJWT $config */
         $config = config('AuthJWT');
 
+        $token = $this->getTokenFromHeader($request);
+
         return $this->attempt([
-            'token' => $request->getHeaderLine($config->authenticatorHeader),
+            'token' => $token,
         ])->isOK();
+    }
+
+    private function getTokenFromHeader(RequestInterface $request): string
+    {
+        assert($request instanceof IncomingRequest);
+
+        /** @var AuthJWT $config */
+        $config = config('AuthJWT');
+
+        $tokenHeader = $request->getHeaderLine(
+            $config->authenticatorHeader ?? 'Authorization'
+        );
+
+        if (strpos($tokenHeader, 'Bearer') === 0) {
+            return trim(substr($tokenHeader, 6));
+        }
+
+        return $tokenHeader;
     }
 
     /**

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -39,7 +39,7 @@ class LoginModel extends BaseModel
         'id_type'    => 'required',
         'identifier' => 'permit_empty|string',
         'user_agent' => 'permit_empty|string',
-        'user_id'    => 'permit_empty|integer',
+        'user_id'    => 'permit_empty',
         'date'       => 'required|valid_date',
     ];
     protected $validationMessages = [];


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
i want use uuid for user id, so let set the validation customable or change the behavior.

my opinion is for improve jwt token security auth at sub payload not integer id, but uuid

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
