### PR TITLE
fix: LoginModel cannot use uuid for id column

### DIFF
--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -39,7 +39,7 @@ class LoginModel extends BaseModel
         'id_type'    => 'required',
         'identifier' => 'permit_empty|string',
         'user_agent' => 'permit_empty|string',
-        'user_id'    => 'permit_empty|integer',
+        'user_id'    => 'permit_empty',
         'date'       => 'required|valid_date',
     ];
     protected $validationMessages = [];

--- a/src/Models/LoginModel.php
+++ b/src/Models/LoginModel.php
@@ -40,7 +40,7 @@ class LoginModel extends BaseModel
         'identifier' => 'permit_empty|string',
         'user_agent' => 'permit_empty|string',
         'user_id'    => 'permit_empty',
-        'date'       => 'required|valid_date',
+        'date'       => 'required',
     ];
     protected $validationMessages = [];
     protected $skipValidation     = false;


### PR DESCRIPTION
**Description**
Supersedes #1044

i want use uuid for user id, so let set the validation customable or change the behavior.

my opinion is for improve jwt token security auth at sub payload not integer id, but uuid

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
