### PR TITLE
docs: run rector for fix rector errors

### DIFF
--- a/src/Filters/AuthRates.php
+++ b/src/Filters/AuthRates.php
@@ -59,7 +59,6 @@ class AuthRates implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param Response|ResponseInterface $response
      * @param array|null                 $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void

--- a/src/Filters/ChainAuth.php
+++ b/src/Filters/ChainAuth.php
@@ -67,7 +67,6 @@ class ChainAuth implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param Response|ResponseInterface $response
      * @param array|null                 $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void

--- a/src/Filters/ForcePasswordResetFilter.php
+++ b/src/Filters/ForcePasswordResetFilter.php
@@ -52,7 +52,6 @@ class ForcePasswordResetFilter implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param Response|ResponseInterface $response
      * @param array|null                 $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void

--- a/src/Filters/JWTAuth.php
+++ b/src/Filters/JWTAuth.php
@@ -64,7 +64,6 @@ class JWTAuth implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param Response|ResponseInterface $response
      * @param array|null                 $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void

--- a/src/Filters/SessionAuth.php
+++ b/src/Filters/SessionAuth.php
@@ -95,7 +95,6 @@ class SessionAuth implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param Response|ResponseInterface $response
      * @param array|null                 $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void

--- a/src/Filters/TokenAuth.php
+++ b/src/Filters/TokenAuth.php
@@ -79,7 +79,6 @@ class TokenAuth implements FilterInterface
     /**
      * We don't have anything to do here.
      *
-     * @param Response|ResponseInterface $response
      * @param array|null                 $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/shield/actions/runs/8571440801/job/23491670281?pr=1084

```diff
1) src/Filters/AuthRates.php:58

    ---------- begin diff ----------
@@ @@
     /**
      * We don't have anything to do here.
      *
-     * @param Response|ResponseInterface $response
      * @param array|null                 $arguments
      */
     public function after(RequestInterface $request, ResponseInterface $response, $arguments = null): void
    ----------- end diff -----------

Applied rules:
 * RemoveUselessParamTagRector
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
