### PR TITLE
fix: Call to a member function getErrors() on null in CheckQueryReturnTrait

### DIFF
--- a/src/Models/CheckQueryReturnTrait.php
+++ b/src/Models/CheckQueryReturnTrait.php
@@ -41,6 +41,8 @@ trait CheckQueryReturnTrait
 
     protected function checkValidationError(): void
     {
+        $this->validation ??= service('validation');
+
         $validationErrors = $this->validation->getErrors();
 
         if ($validationErrors !== []) {

--- a/src/Models/CheckQueryReturnTrait.php
+++ b/src/Models/CheckQueryReturnTrait.php
@@ -41,7 +41,9 @@ trait CheckQueryReturnTrait
 
     protected function checkValidationError(): void
     {
-        $this->validation ??= service('validation');
+        if ($this->validation === null) {
+            return;
+        }
 
         $validationErrors = $this->validation->getErrors();
 


### PR DESCRIPTION
**Description**
Fixes #1087

Since CI 4.5.0, `$this->validation` may be null.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
