### PR TITLE
test: fix Registrar for DB Config

### DIFF
--- a/tests/Authentication/HasHmacTokensTest.php
+++ b/tests/Authentication/HasHmacTokensTest.php
@@ -57,12 +57,12 @@ final class HasHmacTokensTest extends DatabaseTestCase
         // Give the user a couple of access tokens
         $token1 = fake(
             UserIdentityModel::class,
-            ['user_id' => $this->user->id, 'type' => 'hmac_sha256', 'secret' => 'key1', 'secret2' => 'd862cd9ddc23e960ca6d45a3e0b64c7509f0c0ef0e5f7b64be8910a6a714c89b83fab95251bbf17f6c84b42c26cf460a28ea969591dc64b1f5c4b323f47615d2e8cbe4c62118001d3274e0f25850b0ac2617bc43119af22c99a1a83072002267177da01f9f37225435e1914be004f4d35a49869b737ed10ab232c1ed1048bb96ef6fb70979dc9c981e17134f4356a938']
+            ['user_id' => $this->user->id, 'type' => 'hmac_sha256', 'secret' => 'key1', 'secret2' => 'd862cd9ddc23e960ca6d45a3e0b64c7509f0c0ef0e5f7b64be8910a6a714c89b83fab95251bbf17f6c84b42c26cf460a28ea969591dc64b1f5c4b323f47615d2e8cbe4c62118001d3274e0f25850b0ac2617bc43119af22c99a1a83072002267177da01f9f37225435e1914be004f4d35a49869b737ed10ab232c1ed1048bb9']
         );
 
         $token2 = fake(
             UserIdentityModel::class,
-            ['user_id' => $this->user->id, 'type' => 'hmac_sha256', 'secret' => 'key2', 'secret2' => 'd862cd9ddc23e960ca6d45a3e0b64c7509f0c0ef0e5f7b64be8910a6a714c89b83fab95251bbf17f6c84b42c26cf460a28ea969591dc64b1f5c4b323f47615d2e8cbe4c62118001d3274e0f25850b0ac2617bc43119af22c99a1a83072002267177da01f9f37225435e1914be004f4d35a49869b737ed10ab232c1ed1048bb96ef6fb70979dc9c981e17134f4356a938']
+            ['user_id' => $this->user->id, 'type' => 'hmac_sha256', 'secret' => 'key2', 'secret2' => 'd862cd9ddc23e960ca6d45a3e0b64c7509f0c0ef0e5f7b64be8910a6a714c89b83fab95251bbf17f6c84b42c26cf460a28ea969591dc64b1f5c4b323f47615d2e8cbe4c62118001d3274e0f25850b0ac2617bc43119af22c99a1a83072002267177da01f9f37225435e1914be004f4d35a49869b737ed10ab232c1ed1048bb9']
         );
 
         $tokens = $this->user->hmacTokens();

--- a/tests/_support/Config/Registrar.php
+++ b/tests/_support/Config/Registrar.php
@@ -136,7 +136,7 @@ class Registrar
 
         // Under GitHub Actions, we can set an ENV var named 'DB'
         // so that we can test against multiple databases.
-        if (($group = getenv('DB')) && ! isset(self::$dbConfig[$group])) {
+        if (($group = getenv('DB')) && isset(self::$dbConfig[$group])) {
             $config['tests'] = self::$dbConfig[$group];
         }
 


### PR DESCRIPTION
**Description**
Fixes a serious bug in DB testing configuration.

```
phpunit / PHP 8.1 - MySQLi
...
1) Tests\Authentication\Authenticators\HmacAuthenticatorTest::testAttemptCannotFindUser
TypeError: CodeIgniter\Database\SQLite3\Connection::_escapeString(): Argument #1 ($str) must be of type string, CodeIgniter\I18n\Time given, called in /home/runner/work/shield/shield/vendor/codeigniter4/framework/system/Database/BaseConnection.php on line 1346
...
```
https://github.com/codeigniter4/shield/actions/runs/8600000130/job/23564066896

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
