### PR TITLE
fix: passing Time to Query Builder in UserModel

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -376,7 +376,7 @@ class UserModel extends BaseModel
         assert($user->last_active instanceof Time);
 
         // Safe date string for database
-        $last_active = $user->last_active;
+        $last_active = $this->timeToDate($user->last_active);
 
         $this->builder()
             ->set('last_active', $last_active)


### PR DESCRIPTION
**Description**
See #1086, #1092

Query Builder does not accept Time instances.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
