### PR TITLE
Prep for 1.0.3 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "codeigniter/phpstan-codeigniter": "^1.3",
         "codeigniter4/devkit": "^1.0",
-        "codeigniter4/framework": "^4.3.5",
+        "codeigniter4/framework": ">=4.3.5 <4.5.0 || ^4.5.1",
         "firebase/php-jwt": "^6.4",
         "mikey179/vfsstream": "^1.6.7",
         "mockery/mockery": "^1.0",

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -41,7 +41,7 @@ class Auth
     /**
      * The current version of CodeIgniter Shield
      */
-    public const SHIELD_VERSION = '1.0.2';
+    public const SHIELD_VERSION = '1.0.3';
 
     protected AuthConfig $config;
     protected ?Authentication $authenticate = null;


### PR DESCRIPTION
**Description**
Updates version references for 1.0.3.
Prev #1068

- update `"codeigniter4/framework"` version. See https://jubianchi.github.io/semver-check/#/%3E%3D4.3.5%20%3C4.5.0%20||%20^4.5.1/4.5.0

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
