### PR TITLE
fix: setup command cannot update `Config\Autoload::$helpers` with multiple lines

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -256,10 +256,8 @@ class Setup extends BaseCommand
         $helpers    = $config->helpers;
         $newHelpers = array_unique(array_merge($helpers, ['auth', 'setting']));
 
-        $pattern = '/^    public \$helpers = \[.*\];/mu';
-        $replace = '    public $helpers = [\'' . implode("', '", $newHelpers) . '\'];';
         $content = file_get_contents($path);
-        $output  = preg_replace($pattern, $replace, $content);
+        $output  = $this->updateAutoloadHelpers($content, $newHelpers);
 
         // check if the content is updated
         if ($output === $content) {
@@ -275,6 +273,18 @@ class Setup extends BaseCommand
         } else {
             $this->error("  Error updating file '{$cleanPath}'.");
         }
+    }
+
+    /**
+     * @param string       $content    The content of Config\Autoload.
+     * @param list<string> $newHelpers The list of helpers.
+     */
+    private function updateAutoloadHelpers(string $content, array $newHelpers): string
+    {
+        $pattern = '/^    public \$helpers = \[.*?\];/msu';
+        $replace = '    public $helpers = [\'' . implode("', '", $newHelpers) . '\'];';
+
+        return preg_replace($pattern, $replace, $content);
     }
 
     private function removeHelperLoadingInBaseController(): void

--- a/tests/Commands/SetupTest.php
+++ b/tests/Commands/SetupTest.php
@@ -131,6 +131,41 @@ final class SetupTest extends TestCase
         );
     }
 
+    public function testUpdateAutoloadHelpers(): void
+    {
+        $command = new Setup(Services::logger(), Services::commands());
+
+        $updateAutoloadHelpers = $this->getPrivateMethodInvoker($command, 'updateAutoloadHelpers');
+
+        $content = <<<'EOL'
+            class Autoload extends AutoloadConfig
+            {
+                /**
+                 * -------------------------------------------------------------------
+                 * Helpers
+                 * -------------------------------------------------------------------
+                 * Prototype:
+                 *   $helpers = [
+                 *       'form',
+                 *   ];
+                 *
+                 * @var list<string>
+                 */
+                public $helpers = [
+                    'text',
+                    'form',
+                ];
+            }
+            EOL;
+        $helpers = ['text', 'form', 'auth', 'setting'];
+        $output  = $updateAutoloadHelpers($content, $helpers);
+
+        $this->assertStringContainsString(
+            "public \$helpers = ['text', 'form', 'auth', 'setting'];",
+            $output
+        );
+    }
+
     /**
      * @return string app folder path
      */


### PR DESCRIPTION
**Description**
See https://forum.codeigniter.com/showthread.php?tid=90747&pid=418193#pid418193

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
