### PR TITLE
chore: fix PHPUnit version to ^9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "mockery/mockery": "^1.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",
+        "phpunit/phpunit": "^9.6",
         "rector/rector": "1.0.5"
     },
     "provide": {


### PR DESCRIPTION
**Description**
- fix PHPUnit version

```
Run vendor/bin/phpunit --verbose --coverage-text --testsuite main
PHPUnit 10.5.20 by Sebastian Bergmann and contributors.

Unknown option "--verbose"
Error: Process completed with exit code 2.
```
https://github.com/codeigniter4/shield/actions/runs/9068936228/job/24922066021

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
