### PR TITLE
chore: fix `codeigniter/coding-standard` version to `1.7.*`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "codeigniter4/settings": "^2.1"
     },
     "require-dev": {
+        "codeigniter/coding-standard": "1.7.*",
         "codeigniter/phpstan-codeigniter": "^1.3",
         "codeigniter4/devkit": "^1.0",
         "codeigniter4/framework": ">=4.3.5 <4.5.0 || ^4.5.1",


### PR DESCRIPTION
**Description**
coding-standard 1.8.0 enables rules for PHP 8.1.
So we cannot use it unless we drop PHP 7.4 support.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
