### PR TITLE
feat: add magic link force login config

### DIFF
--- a/docs/references/magic_link_login.md
+++ b/docs/references/magic_link_login.md
@@ -23,6 +23,15 @@ in the **app/Config/Auth.php** file.
 public int $magicLinkLifetime = HOUR;
 ```
 
+### Magic Link Force Login
+
+By default, Magic Link will throw Logic exception if current user session is exist. If you want replace existing user session with new user session change it to `true`
+in the **app/Config/Auth.php** file.
+
+```php
+public bool $allowMagicLinkForceLogin = false;
+```
+
 ## Responding to Magic Link Logins
 
 !!! note

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -646,8 +646,8 @@ class Session implements AuthenticatorInterface
         /** @var int|string|null $userId */
         $userId = $this->getSessionUserKey('id');
 
-        // Check if already logged in.
-        if ($userId !== null) {
+        // Check if already logged in and magic link force login config.
+        if ($userId !== null && config('Auth')->allowMagicLinkForceLogin === false) {
             throw new LogicException(
                 'The user has User Info in Session, so already logged in or in pending login state.'
                     . ' If a logged in user logs in again with other account, the session data of the previous'

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -180,6 +180,15 @@ class Auth extends BaseConfig
 
     /**
      * --------------------------------------------------------------------
+     * Force Magic Link Logins
+     * --------------------------------------------------------------------
+     * If true, will allows the use of "magic links" sent via the email
+     * to replace the current session user data with a new user session.
+     */
+    public bool $allowMagicLinkForceLogin = false;
+
+    /**
+     * --------------------------------------------------------------------
      * Magic Link Lifetime
      * --------------------------------------------------------------------
      * Specifies the amount of time, in seconds, that a magic link is valid.


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**

This feature provides config for developers so that the behavior when checking user sessions in the `startLogin` function can be easily controlled. So the user does not need to log out to assign a new user session. 

We also set the default value in that configuration to `false` to preserve the previous behavior


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
