### PR TITLE
feat: using a more precise return

### DIFF
--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -118,9 +118,7 @@ class EmailActivator implements ActionInterface
 
         // No match - let them try again.
         if (! $authenticator->checkAction($identity, $postedToken)) {
-            session()->setFlashdata('error', lang('Auth.invalidActivateToken'));
-
-            return $this->view(setting('Auth.views')['action_email_activate_show']);
+            return redirect()->back()->with('error', lang('Auth.invalidActivateToken'));
         }
 
         $user = $authenticator->getUser();

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -358,6 +358,7 @@ final class RegisterTest extends DatabaseTestCase
         $result->assertStatus(302);
         $result->assertRedirect();
         $result->assertRedirectTo('/auth/a/show');
+        $result->assertSee(lang('Auth.invalidActivateToken'));
     }
 
     protected function setupConfig(): void

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -337,7 +337,7 @@ final class RegisterTest extends DatabaseTestCase
         $config                      = config('Auth');
         $config->actions['register'] = EmailActivator::class;
         Factories::injectMock('config', 'Auth', $config);
-        
+
         // Already registered but not yet activated and logged in.
         $result = $this->post('/register', [
             'email'            => 'foo@example.com',
@@ -353,11 +353,10 @@ final class RegisterTest extends DatabaseTestCase
         $result = $this->withSession()->post('/auth/a/verify', [
             'token' => 'invalid-token',
         ]);
-        
+
         // Should have been redirected to the previous page.
         $result->assertStatus(302);
         $result->assertRedirect();
-        $result->assertRedirectTo('/auth/a/show');
         $result->assertSee(lang('Auth.invalidActivateToken'));
     }
 

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -331,6 +331,35 @@ final class RegisterTest extends DatabaseTestCase
         );
     }
 
+    public function testRegisterActionRedirectsIfTokenNotMatch(): void
+    {
+        // Ensure our action is defined
+        $config                      = config('Auth');
+        $config->actions['register'] = EmailActivator::class;
+        Factories::injectMock('config', 'Auth', $config);
+        
+        // Already registered but not yet activated and logged in.
+        $result = $this->post('/register', [
+            'email'            => 'foo@example.com',
+            'username'         => 'foo',
+            'password'         => 'abkdhflkjsdflkjasd;lkjf',
+            'password_confirm' => 'abkdhflkjsdflkjasd;lkjf',
+        ]);
+
+        // Should have been redirected to the action's page.
+        $result->assertRedirectTo('/auth/a/show');
+
+        // Attempted to send an invalid token.
+        $result = $this->withSession()->post('/auth/a/verify', [
+            'token' => 'invalid-token',
+        ]);
+        
+        // Should have been redirected to the previous page.
+        $result->assertStatus(302);
+        $result->assertRedirect();
+        $result->assertRedirectTo('/auth/a/show');
+    }
+
     protected function setupConfig(): void
     {
         $config             = config('Validation');


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**

The previous behavior may look like there is no problem, but when the user submits the verification code it will automatically change the state of the URL to `http://localhost:8080/auth/a/verify`. 

When the codes don't match and they accidentally refresh the page it will cause a 404 error because the route `auth/a/verify` with the `GET` method does not exist.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
