### PR TITLE
test: fix incorrect condition in AbstractTranslationTestCase

### DIFF
--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -9,6 +9,7 @@ on:
       - '!src/Language/en/**.php'
       - 'phpunit*'
       - '.github/workflows/phpunit-lang.yml'
+      - 'tests/Language/AbstractTranslationTestCase.php'
   push:
     branches:
       - develop
@@ -17,6 +18,7 @@ on:
       - '!src/Language/en/**.php'
       - 'phpunit*'
       - '.github/workflows/phpunit-lang.yml'
+      - 'tests/Language/AbstractTranslationTestCase.php'
 
 jobs:
   main:

--- a/tests/Language/AbstractTranslationTestCase.php
+++ b/tests/Language/AbstractTranslationTestCase.php
@@ -324,7 +324,7 @@ abstract class AbstractTranslationTestCase extends TestCase
                 preg_match_all('/(\{[^\}]+\})/', $translation, $matches);
                 array_shift($matches);
 
-                if ($matches === []) {
+                if ($matches === [[]]) {
                     unset($matches);
 
                     continue;


### PR DESCRIPTION
**Description**
Fix the following error.
```
 ------ -----------------------------------------------------------------------
  Line   tests/Language/AbstractTranslationTestCase.php
 ------ -----------------------------------------------------------------------
  327    Strict comparison using === between array{list<non-empty-string>} and
         array{} will always evaluate to false.
         💡 Because the type is coming from a PHPDoc, you can turn off this
            check by setting treatPhpDocTypesAsCertain: false in your
            phpstan.neon.dist.
 ------ -----------------------------------------------------------------------
```
https://github.com/codeigniter4/shield/actions/runs/10269040515/job/28413552557?pr=1152

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
