### PR TITLE
fix: add missing args to `lang('Auth.invalidEmail')`

### DIFF
--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -73,7 +73,7 @@ class Email2FA implements ActionInterface
         }
 
         if (empty($email) || $email !== $user->email) {
-            return redirect()->route('auth-action-show')->with('error', lang('Auth.invalidEmail'));
+            return redirect()->route('auth-action-show')->with('error', lang('Auth.invalidEmail', [$email]));
         }
 
         $identity = $this->getIdentity($user);

--- a/tests/Controllers/ActionsTest.php
+++ b/tests/Controllers/ActionsTest.php
@@ -103,7 +103,7 @@ final class ActionsTest extends DatabaseTestCase
 
         $result->assertRedirect();
         $this->assertSame(site_url('/auth/a/show'), $result->getRedirectUrl());
-        $result->assertSessionHas('error', lang('Auth.invalidEmail'));
+        $result->assertSessionHas('error', lang('Auth.invalidEmail', ['foo@example.com']));
     }
 
     private function insertIdentityEmal2FA(): void


### PR DESCRIPTION
**Description**
Follow-up #1145

The argument has been added in #1145:
```diff
-    'invalidEmail'          => 'Unable to verify the email address matches the email on record.',
+    'invalidEmail'          => 'Unable to verify the email address matches the email "{0}".',
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
