### PR TITLE
fix: `chain` filter does not update `last_active`

### DIFF
--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -160,7 +160,7 @@ class Auth extends BaseConfig
      * --------------------------------------------------------------------
      * If true, will always update the `last_active` datetime for the
      * logged-in user on every page request.
-     * This feature only works when session/tokens filter is active.
+     * This feature only works when session/tokens/hmac/chain/jwt filter is active.
      *
      * @see https://codeigniter4.github.io/shield/quick_start_guide/using_session_auth/#protecting-pages for set filters.
      */

--- a/src/Filters/ChainAuth.php
+++ b/src/Filters/ChainAuth.php
@@ -53,9 +53,17 @@ class ChainAuth implements FilterInterface
         $chain = config('Auth')->authenticationChain;
 
         foreach ($chain as $alias) {
-            if (auth($alias)->loggedIn()) {
+            $auth = auth($alias);
+
+            if ($auth->loggedIn()) {
                 // Make sure Auth uses this Authenticator
                 auth()->setAuthenticator($alias);
+
+                $authenticator = $auth->getAuthenticator();
+
+                if (setting('Auth.recordActiveDate')) {
+                    $authenticator->recordActiveDate();
+                }
 
                 return;
             }

--- a/src/Filters/ChainAuth.php
+++ b/src/Filters/ChainAuth.php
@@ -17,7 +17,6 @@ use CodeIgniter\Filters\FilterInterface;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
-use CodeIgniter\HTTP\Response;
 use CodeIgniter\HTTP\ResponseInterface;
 
 /**
@@ -29,14 +28,8 @@ use CodeIgniter\HTTP\ResponseInterface;
 class ChainAuth implements FilterInterface
 {
     /**
-     * Do whatever processing this filter needs to do.
-     * By default it should not return anything during
-     * normal execution. However, when an abnormal state
-     * is found, it should return an instance of
-     * CodeIgniter\HTTP\Response. If it does, script
-     * execution will end and that Response will be
-     * sent back to the client, allowing for error pages,
-     * redirects, etc.
+     * Checks authenticators in sequence to see if the user is logged in through
+     * either of authenticators.
      *
      * @param array|null $arguments
      *


### PR DESCRIPTION
**Description**
Fixes #1154

The `chain` filter also should update `last_active`.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
