### PR TITLE
fix: `shield:user create` does not assign a default group

### DIFF
--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -310,6 +310,12 @@ class User extends BaseCommand
             $userModel->save($user);
             $this->write('User "' . $username . '" created', 'green');
         }
+
+        // Add to default group
+        $user = $userModel->findById($userModel->getInsertID());
+        $userModel->addToDefaultGroup($user);
+
+        $this->write('The user is added to the default group.', 'green');
     }
 
     /**

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Commands;
 
 use CodeIgniter\Shield\Commands\User;
+use CodeIgniter\Shield\Config\AuthGroups;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Test\MockInputOutput;
@@ -92,6 +93,10 @@ final class UserTest extends DatabaseTestCase
         $this->seeInDatabase($this->tables['users'], [
             'id'     => $user->id,
             'active' => 0,
+        ]);
+        $this->seeInDatabase($this->tables['groups_users'], [
+            'user_id' => $user->id,
+            'group'   => config(AuthGroups::class)->defaultGroup,
         ]);
     }
 


### PR DESCRIPTION
**Description**
Supersedes #999
Fixes #998

The user registration form sets the default group value for the user when a new user is registered.
But the command `shield:user create` does not set the default group. 
I think we should fix the inconsistency as a bug.

> What do you think about reading the available roles from the config file and presenting that as a required choice to the user? https://github.com/codeigniter4/shield/pull/999#issuecomment-1890845904

It would be nice, but nobody has implemented it. It can be implemented as enhancement later.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
