### PR TITLE
refactor: fix method names with incorrect case

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -136,22 +136,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Authentication/Authenticators/Session.php',
 ];
 $ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method CodeIgniter\\\\Shield\\\\Result\\:\\:isOK\\(\\) with incorrect case\\: isOk$#',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Authentication/Passwords.php',
-];
-$ignoreErrors[] = [
 	// identifier: empty.notAllowed
 	'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
 	'count' => 4,
 	'path' => __DIR__ . '/src/Authentication/Passwords/NothingPersonalValidator.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method CodeIgniter\\\\Shield\\\\Result\\:\\:isOK\\(\\) with incorrect case\\: isOk$#',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Authentication/Passwords/ValidationRules.php',
 ];
 $ignoreErrors[] = [
 	// identifier: booleanAnd.rightNotBoolean
@@ -315,12 +303,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method CodeIgniter\\\\Shield\\\\Filters\\\\AuthRates\\:\\:before\\(\\) should return CodeIgniter\\\\HTTP\\\\RedirectResponse\\|void but returns CodeIgniter\\\\HTTP\\\\ResponseInterface\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Filters/AuthRates.php',
-];
-$ignoreErrors[] = [
-	// identifier: method.nameCase
-	'message' => '#^Call to method CodeIgniter\\\\HTTP\\\\ResponseInterface\\:\\:setJSON\\(\\) with incorrect case\\: setJson$#',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Filters/TokenAuth.php',
 ];
 $ignoreErrors[] = [
 	// identifier: empty.notAllowed

--- a/src/Authentication/Passwords.php
+++ b/src/Authentication/Passwords.php
@@ -124,7 +124,7 @@ class Passwords
             $class = new $className($this->config);
 
             $result = $class->check($password, $user);
-            if (! $result->isOk()) {
+            if (! $result->isOK()) {
                 return $result;
             }
         }

--- a/src/Authentication/Passwords/ValidationRules.php
+++ b/src/Authentication/Passwords/ValidationRules.php
@@ -54,7 +54,7 @@ class ValidationRules
 
         $result = $checker->check($value, $user);
 
-        if (! $result->isOk()) {
+        if (! $result->isOK()) {
             if ($data === []) {
                 $error1 = $result->reason();
             } else {
@@ -62,7 +62,7 @@ class ValidationRules
             }
         }
 
-        return $result->isOk();
+        return $result->isOK();
     }
 
     /**

--- a/src/Filters/TokenAuth.php
+++ b/src/Filters/TokenAuth.php
@@ -58,7 +58,7 @@ class TokenAuth implements FilterInterface
         if (! $result->isOK() || (! empty($arguments) && $result->extraInfo()->tokenCant($arguments[0]))) {
             return service('response')
                 ->setStatusCode(Response::HTTP_UNAUTHORIZED)
-                ->setJson(['message' => lang('Auth.badToken')]);
+                ->setJSON(['message' => lang('Auth.badToken')]);
         }
 
         if (setting('Auth.recordActiveDate')) {
@@ -72,7 +72,7 @@ class TokenAuth implements FilterInterface
 
             return service('response')
                 ->setStatusCode(Response::HTTP_FORBIDDEN)
-                ->setJson(['message' => lang('Auth.activationBlocked')]);
+                ->setJSON(['message' => lang('Auth.activationBlocked')]);
         }
     }
 


### PR DESCRIPTION
**Description**
- fix method names

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [x] Conforms to style guide
