### PR TITLE
feat: add -g option to `shield:user create`

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -161,6 +161,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: codeigniter.factoriesClassConstFetch
+	'message' => '#^Call to function model with CodeIgniter\\\\Shield\\\\Models\\\\GroupModel\\:\\:class is discouraged\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Commands/User.php',
+];
+$ignoreErrors[] = [
+	// identifier: codeigniter.factoriesClassConstFetch
 	'message' => '#^Call to function model with CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:class is discouraged\\.$#',
 	'count' => 9,
 	'path' => __DIR__ . '/src/Commands/User.php',
@@ -259,7 +265,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: codeigniter.factoriesClassConstFetch
 	'message' => '#^Call to function model with CodeIgniter\\\\Shield\\\\Models\\\\GroupModel\\:\\:class is discouraged\\.$#',
-	'count' => 2,
+	'count' => 4,
 	'path' => __DIR__ . '/src/Entities/User.php',
 ];
 $ignoreErrors[] = [
@@ -329,6 +335,12 @@ $ignoreErrors[] = [
 The type \'basic\', \'md5\', and \'sha1\' are deprecated\\. They are not cryptographically secure\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Models/UserIdentityModel.php',
+];
+$ignoreErrors[] = [
+	// identifier: codeigniter.factoriesClassConstFetch
+	'message' => '#^Call to function model with CodeIgniter\\\\Shield\\\\Models\\\\GroupModel\\:\\:class is discouraged\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Models/UserModel.php',
 ];
 $ignoreErrors[] = [
 	// identifier: codeigniter.factoriesClassConstFetch

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -43,8 +43,11 @@ trait Authorizable
                 continue;
             }
 
+            /** @var GroupModel $groupModel */
+            $groupModel = model(GroupModel::class);
+
             // make sure it's a valid group
-            if (! $this->isValidGroup($group)) {
+            if (! $groupModel->isValidGroup($group)) {
                 throw AuthorizationException::forUnknownGroup($group);
             }
 
@@ -57,18 +60,6 @@ trait Authorizable
         }
 
         return $this;
-    }
-
-    /**
-     * @TODO duplicate of UserModel::isValidGroup()
-     *
-     * @param non-empty-string $group
-     */
-    private function isValidGroup(string $group): bool
-    {
-        $allowedGroups = array_keys(setting('AuthGroups.groups'));
-
-        return (bool) (in_array($group, $allowedGroups, true));
     }
 
     /**
@@ -106,8 +97,11 @@ trait Authorizable
     {
         $this->populateGroups();
 
+        /** @var GroupModel $groupModel */
+        $groupModel = model(GroupModel::class);
+
         foreach ($groups as $group) {
-            if (! $this->isValidGroup($group)) {
+            if (! $groupModel->isValidGroup($group)) {
                 throw AuthorizationException::forUnknownGroup($group);
             }
         }

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -33,8 +33,6 @@ trait Authorizable
     {
         $this->populateGroups();
 
-        $configGroups = $this->getConfigGroups();
-
         $groupCount = count($this->groupCache);
 
         foreach ($groups as $group) {
@@ -46,7 +44,7 @@ trait Authorizable
             }
 
             // make sure it's a valid group
-            if (! in_array($group, $configGroups, true)) {
+            if (! $this->isValidGroup($group)) {
                 throw AuthorizationException::forUnknownGroup($group);
             }
 
@@ -59,6 +57,18 @@ trait Authorizable
         }
 
         return $this;
+    }
+
+    /**
+     * @TODO duplicate of UserModel::isValidGroup()
+     *
+     * @param non-empty-string $group
+     */
+    private function isValidGroup(string $group): bool
+    {
+        $allowedGroups = array_keys(setting('AuthGroups.groups'));
+
+        return (bool) (in_array($group, $allowedGroups, true));
     }
 
     /**
@@ -96,10 +106,8 @@ trait Authorizable
     {
         $this->populateGroups();
 
-        $configGroups = $this->getConfigGroups();
-
         foreach ($groups as $group) {
-            if (! in_array($group, $configGroups, true)) {
+            if (! $this->isValidGroup($group)) {
                 throw AuthorizationException::forUnknownGroup($group);
             }
         }
@@ -396,14 +404,6 @@ trait Authorizable
 
             $model->insertBatch($inserts);
         }
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function getConfigGroups(): array
-    {
-        return array_keys(setting('AuthGroups.groups'));
     }
 
     /**

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -19,6 +19,7 @@ use CodeIgniter\Shield\Commands\Exceptions\CancelException;
 use CodeIgniter\Shield\Config\Auth;
 use CodeIgniter\Shield\Entities\User as UserEntity;
 use CodeIgniter\Shield\Exceptions\UserNotFoundException;
+use CodeIgniter\Shield\Models\GroupModel;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Validation\ValidationRules;
 use Config\Services;
@@ -305,6 +306,11 @@ class User extends BaseCommand
 
         $user = new UserEntity($data);
 
+        // Validate the group
+        if ($group !== null && ! $this->validateGroup($group)) {
+            throw new CancelException('Invalid group: "' . $group . '"');
+        }
+
         if ($username === null) {
             $userModel->allowEmptyInserts()->save($user);
             $this->write('New User created', 'green');
@@ -325,6 +331,14 @@ class User extends BaseCommand
 
             $this->write('The user is added to group "' . $group . '".', 'green');
         }
+    }
+
+    private function validateGroup(string $group): bool
+    {
+        /** @var GroupModel $groupModel */
+        $groupModel = model(GroupModel::class);
+
+        return $groupModel->isValidGroup($group);
     }
 
     /**

--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -53,6 +53,7 @@ class User extends BaseCommand
         shield:user <action> options
 
             shield:user create -n newusername -e newuser@example.com
+            shield:user create -n newusername -e newuser@example.com -g mygroup
 
             shield:user activate -n username
             shield:user activate -e user@example.com
@@ -159,7 +160,7 @@ class User extends BaseCommand
         try {
             switch ($action) {
                 case 'create':
-                    $this->create($username, $email);
+                    $this->create($username, $email, $group);
                     break;
 
                 case 'activate':
@@ -252,8 +253,9 @@ class User extends BaseCommand
      *
      * @param string|null $username User name to create (optional)
      * @param string|null $email    User email to create (optional)
+     * @param string|null $group    Group to add user to (optional)
      */
-    private function create(?string $username = null, ?string $email = null): void
+    private function create(?string $username = null, ?string $email = null, ?string $group = null): void
     {
         $data = [];
 
@@ -311,11 +313,18 @@ class User extends BaseCommand
             $this->write('User "' . $username . '" created', 'green');
         }
 
-        // Add to default group
         $user = $userModel->findById($userModel->getInsertID());
-        $userModel->addToDefaultGroup($user);
 
-        $this->write('The user is added to the default group.', 'green');
+        if ($group === null) {
+            // Add to default group
+            $userModel->addToDefaultGroup($user);
+
+            $this->write('The user is added to the default group.', 'green');
+        } else {
+            $user->addGroup($group);
+
+            $this->write('The user is added to group "' . $group . '".', 'green');
+        }
     }
 
     /**

--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -81,6 +81,6 @@ class GroupModel extends BaseModel
     {
         $allowedGroups = array_keys(setting('AuthGroups.groups'));
 
-        return (bool) (in_array($group, $allowedGroups, true));
+        return in_array($group, $allowedGroups, true);
     }
 }

--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -73,4 +73,14 @@ class GroupModel extends BaseModel
 
         $this->checkQueryReturn($return);
     }
+
+    /**
+     * @param non-empty-string $group Group name
+     */
+    public function isValidGroup(string $group): bool
+    {
+        $allowedGroups = array_keys(setting('AuthGroups.groups'));
+
+        return (bool) (in_array($group, $allowedGroups, true));
+    }
 }

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -153,14 +153,25 @@ class UserModel extends BaseModel
      */
     public function addToDefaultGroup(User $user): void
     {
-        $defaultGroup  = setting('AuthGroups.defaultGroup');
-        $allowedGroups = array_keys(setting('AuthGroups.groups'));
+        $defaultGroup = setting('AuthGroups.defaultGroup');
 
-        if (empty($defaultGroup) || ! in_array($defaultGroup, $allowedGroups, true)) {
+        if (empty($defaultGroup) || ! $this->isValidGroup($defaultGroup)) {
             throw new InvalidArgumentException(lang('Auth.unknownGroup', [$defaultGroup ?? '--not found--']));
         }
 
         $user->addGroup($defaultGroup);
+    }
+
+    /**
+     * @TODO duplicate of Authorizable::isValidGroup()
+     *
+     * @param non-empty-string $group
+     */
+    private function isValidGroup(string $group): bool
+    {
+        $allowedGroups = array_keys(setting('AuthGroups.groups'));
+
+        return (bool) (in_array($group, $allowedGroups, true));
     }
 
     public function fake(Generator &$faker): User

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -155,23 +155,14 @@ class UserModel extends BaseModel
     {
         $defaultGroup = setting('AuthGroups.defaultGroup');
 
-        if (empty($defaultGroup) || ! $this->isValidGroup($defaultGroup)) {
+        /** @var GroupModel $groupModel */
+        $groupModel = model(GroupModel::class);
+
+        if (empty($defaultGroup) || ! $groupModel->isValidGroup($defaultGroup)) {
             throw new InvalidArgumentException(lang('Auth.unknownGroup', [$defaultGroup ?? '--not found--']));
         }
 
         $user->addGroup($defaultGroup);
-    }
-
-    /**
-     * @TODO duplicate of Authorizable::isValidGroup()
-     *
-     * @param non-empty-string $group
-     */
-    private function isValidGroup(string $group): bool
-    {
-        $allowedGroups = array_keys(setting('AuthGroups.groups'));
-
-        return (bool) (in_array($group, $allowedGroups, true));
     }
 
     public function fake(Generator &$faker): User

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -100,6 +100,40 @@ final class UserTest extends DatabaseTestCase
         ]);
     }
 
+    public function testCreateWithGroupBeta(): void
+    {
+        $this->setMockIo([
+            'Secret Passw0rd!',
+            'Secret Passw0rd!',
+        ]);
+
+        command('shield:user create -n user1 -e user1@example.com -g beta');
+
+        $this->assertStringContainsString(
+            'User "user1" created',
+            $this->io->getFirstOutput()
+        );
+        $this->assertStringContainsString(
+            'The user is added to group "beta"',
+            $this->io->getFirstOutput()
+        );
+
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user1@example.com']);
+        $this->seeInDatabase($this->tables['identities'], [
+            'user_id' => $user->id,
+            'secret'  => 'user1@example.com',
+        ]);
+        $this->seeInDatabase($this->tables['users'], [
+            'id'     => $user->id,
+            'active' => 0,
+        ]);
+        $this->seeInDatabase($this->tables['groups_users'], [
+            'user_id' => $user->id,
+            'group'   => 'beta',
+        ]);
+    }
+
     public function testCreateNotUniqueName(): void
     {
         $user = $this->createUser([

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -134,6 +134,25 @@ final class UserTest extends DatabaseTestCase
         ]);
     }
 
+    public function testCreateWithInvalidGroup(): void
+    {
+        $this->setMockIo([
+            'Secret Passw0rd!',
+            'Secret Passw0rd!',
+        ]);
+
+        command('shield:user create -n user1 -e user1@example.com -g invalid');
+
+        $this->assertStringContainsString(
+            'Invalid group: "invalid"',
+            $this->io->getFirstOutput()
+        );
+
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user1@example.com']);
+        $this->assertNull($user);
+    }
+
     public function testCreateNotUniqueName(): void
     {
         $user = $this->createUser([


### PR DESCRIPTION
~~Needs #1162~~

**Description**
- add -g option to `shield:user create`
- add `GroupModel::isValidGroup()`

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
