### PR TITLE
fix: Shield ignores `AuthToken::$authenticatorHeader` config

### DIFF
--- a/src/Filters/HmacAuth.php
+++ b/src/Filters/HmacAuth.php
@@ -33,7 +33,7 @@ class HmacAuth implements FilterInterface
         $authenticator = auth('hmac')->getAuthenticator();
 
         $requestParams = [
-            'token' => $request->getHeaderLine(setting('Auth.authenticatorHeader')['hmac'] ?? 'Authorization'),
+            'token' => $request->getHeaderLine(setting('AuthToken.authenticatorHeader')['hmac'] ?? 'Authorization'),
             'body'  => $request->getBody() ?? '',
         ];
 

--- a/src/Filters/TokenAuth.php
+++ b/src/Filters/TokenAuth.php
@@ -52,7 +52,7 @@ class TokenAuth implements FilterInterface
         $authenticator = auth('tokens')->getAuthenticator();
 
         $result = $authenticator->attempt([
-            'token' => $request->getHeaderLine(setting('Auth.authenticatorHeader')['tokens'] ?? 'Authorization'),
+            'token' => $request->getHeaderLine(setting('AuthToken.authenticatorHeader')['tokens'] ?? 'Authorization'),
         ]);
 
         if (! $result->isOK() || (! empty($arguments) && $result->extraInfo()->tokenCant($arguments[0]))) {


### PR DESCRIPTION
**Description**
Mentioned in discussion https://github.com/codeigniter4/shield/discussions/1167
Fixes #1168

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
