### PR TITLE
feat: add `UserModel::getReturnType()` and RegisterController::getUserEntity() uses it 

### DIFF
--- a/docs/customization/user_provider.md
+++ b/docs/customization/user_provider.md
@@ -55,10 +55,13 @@ class UserModel extends ShieldUserModel
 }
 ```
 
-## Using a custom ReturnType
-If you have set a custom `ReturnType` in your custom `UserModel`, you may retrieve the `ReturnTypt` using `UserModel::getReturnType()` and easily create a new `UserEntity` using your custom `ReturnType`:
+## Using a Custom User Entity
+
+If you have set a custom `$returnType` in your custom `UserModel`, you may
+retrieve the return type using the `UserModel::getReturnType()` method and
+easily create a new User Entity using it:
 
 ```php
 $userEntityClass = $userModel->getReturnType();
-$newUser = new $userEntityClass();
+$newUser         = new $userEntityClass();
 ```

--- a/docs/customization/user_provider.md
+++ b/docs/customization/user_provider.md
@@ -54,3 +54,11 @@ class UserModel extends ShieldUserModel
     }
 }
 ```
+
+## Using a custom ReturnType
+If you have set a custom `ReturnType` in your custom `UserModel`, you may retrieve the `ReturnTypt` using `UserModel::getReturnType()` and easily create a new `UserEntity` using your custom `ReturnType`:
+
+```php
+$userEntityClass = $userModel->getReturnType();
+$newUser = new $userEntityClass();
+```

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -19,7 +19,6 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
-use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\ValidationException;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Traits\Viewable;
@@ -163,7 +162,10 @@ class RegisterController extends BaseController
      */
     protected function getUserEntity(): User
     {
-        return new User();
+        $userProvider    = $this->getUserProvider();
+        $userEntityClass = $userProvider->getReturnType();
+
+        return new $userEntityClass();
     }
 
     /**

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -19,6 +19,7 @@ use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
+use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Exceptions\ValidationException;
 use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Shield\Traits\Viewable;

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -396,7 +396,12 @@ class UserModel extends BaseModel
         }
     }
 
-    public function getUserEntity(): User
+    /**
+     * Returns User Entity Type
+     *
+     * @return class-string<User>
+     */
+    public function getReturnType(): string
     {
         return $this->returnType;
     }

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -395,4 +395,9 @@ class UserModel extends BaseModel
             throw new LogicException('Return type must be a subclass of ' . User::class);
         }
     }
+
+    public function getUserEntity(): User
+    {
+        return $this->returnType;
+    }
 }


### PR DESCRIPTION
**Description**
See #1170
Refactor `RegisterController::getUserEntity` to use `UserModel::returnType` instead of the hard coded `new User()`. This allows for easy use of a custom User Entity without needing to extend the `RegisterController` and add the routes.

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
