### PR TITLE
fix: cannot override `emailer()` function

### DIFF
--- a/src/Helpers/email_helper.php
+++ b/src/Helpers/email_helper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 use CodeIgniter\Email\Email;
 
-if (! defined('emailer')) {
+if (! function_exists('emailer')) {
     /**
      * Provides convenient access to the CodeIgniter Email class.
      *


### PR DESCRIPTION
**Description**
Fixes #1173

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
