### PR TITLE
fix: add missing validation for group name to `shield:user addgroup`/`removegroup`

### DIFF
--- a/src/Commands/User.php
+++ b/src/Commands/User.php
@@ -603,6 +603,11 @@ class User extends BaseCommand
             $group = $this->prompt('Group', null, 'required');
         }
 
+        // Validate the group
+        if (! $this->validateGroup($group)) {
+            throw new CancelException('Invalid group: "' . $group . '"');
+        }
+
         $user = $this->findUser('Add user to group', $username, $email);
 
         $confirm = $this->prompt(
@@ -633,6 +638,11 @@ class User extends BaseCommand
     {
         if ($group === null) {
             $group = $this->prompt('Group', null, 'required');
+        }
+
+        // Validate the group
+        if (! $this->validateGroup($group)) {
+            throw new CancelException('Invalid group: "' . $group . '"');
         }
 
         $user = $this->findUser('Remove user from group', $username, $email);

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -595,6 +595,24 @@ final class UserTest extends DatabaseTestCase
         $this->assertTrue($user->inGroup('admin'));
     }
 
+    public function testAddgroupWithInvalidGroup(): void
+    {
+        $this->createUser([
+            'username' => 'user10',
+            'email'    => 'user10@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $this->setMockIo(['y']);
+
+        command('shield:user addgroup -n user10 -g invalid');
+
+        $this->assertStringContainsString(
+            'Invalid group: "invalid"',
+            $this->io->getLastOutput()
+        );
+    }
+
     public function testAddgroupCancel(): void
     {
         $this->createUser([
@@ -641,6 +659,32 @@ final class UserTest extends DatabaseTestCase
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user11@example.com']);
         $this->assertFalse($user->inGroup('admin'));
+    }
+
+    public function testRemovegroupWithInvalidGroup(): void
+    {
+        $this->createUser([
+            'username' => 'user11',
+            'email'    => 'user11@example.com',
+            'password' => 'secret123',
+        ]);
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $user->addGroup('admin');
+        $this->assertTrue($user->inGroup('admin'));
+
+        $this->setMockIo(['y']);
+
+        command('shield:user removegroup -n user11 -g invalid');
+
+        $this->assertStringContainsString(
+            'Invalid group: "invalid"',
+            $this->io->getLastOutput()
+        );
+
+        $users = model(UserModel::class);
+        $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $this->assertTrue($user->inGroup('admin'));
     }
 
     public function testRemovegroupCancel(): void


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/shield/pull/1164#discussion_r1722662886

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
