### PR TITLE
refactor: [Authorizable Trait] move $matrix outside foreach loop

### DIFF
--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -250,6 +250,9 @@ trait Authorizable
         // Check the groups the user belongs to
         $this->populateGroups();
 
+        // Get the group matrix
+        $matrix = setting('AuthGroups.matrix');
+
         foreach ($permissions as $permission) {
             // Permission must contain a scope and action
             if (strpos($permission, '.') === false) {
@@ -269,8 +272,6 @@ trait Authorizable
             if (count($this->groupCache) === 0) {
                 return false;
             }
-
-            $matrix = setting('AuthGroups.matrix');
 
             foreach ($this->groupCache as $group) {
                 // Check exact match


### PR DESCRIPTION
**Description**
`$matrix = setting('AuthGroups.matrix');` can be moved out of the `foreach ($permissions as $permission)` loop since the value is the same for every iteration.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
