### PR TITLE
fix: `strong_password` rule fails when the personal field contains an integer value.

### DIFF
--- a/src/Authentication/Passwords/NothingPersonalValidator.php
+++ b/src/Authentication/Passwords/NothingPersonalValidator.php
@@ -95,7 +95,7 @@ class NothingPersonalValidator extends BaseValidator implements ValidatorInterfa
 
             foreach ($personalFields as $value) {
                 if (! empty($user->{$value})) {
-                    $needles[] = strtolower($user->{$value});
+                    $needles[] = strtolower((string) $user->{$value});
                 }
             }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**

`strong_password` rule fails when the personal field contains an integer value. so, we must convert the personal field's data type to a string. See https://github.com/codeigniter4/shield/issues/1171#issuecomment-2309437552

<img width="1337" alt="Screenshot 2024-08-26 at 13 45 08" src="https://github.com/user-attachments/assets/a8d8d4bf-5662-4f41-b71d-96f2af180f9d">


**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
