### PR TITLE
docs: typo fix in method name

### DIFF
--- a/docs/references/authentication/tokens.md
+++ b/docs/references/authentication/tokens.md
@@ -90,14 +90,14 @@ permissions the token grants to the user. Scopes are provided when the token is 
 cannot be modified afterword.
 
 ```php
-$token = $user->gererateAccessToken('Work Laptop', ['posts.manage', 'forums.manage']);
+$token = $user->generateAccessToken('Work Laptop', ['posts.manage', 'forums.manage']);
 ```
 
 By default a user is granted a wildcard scope which provides access to all scopes. This is the
 same as:
 
 ```php
-$token = $user->gererateAccessToken('Work Laptop', ['*']);
+$token = $user->generateAccessToken('Work Laptop', ['*']);
 ```
 
 During authentication, the token the user used is stored on the user. Once authenticated, you


### PR DESCRIPTION
**Description**
Typo in Token Authenticator doc, misspell of the generateAccessToken method.

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
- [x] Conforms to style guide
