### PR TITLE
feat: improve query performance for `find*()`

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,17 @@
 # Upgrade Guide
 
+## Version 1.1.0 to 1.1.1
+
+## Added Index to `deleted_at` Column
+
+In the new version, an `index` has been added to the **deleted_at** column in the **users** table. This change improves the performance of queries related to soft deletions.To apply the changes, execute the following command:
+
+```console
+php spark migrate
+```
+
+This will add the new index to your database and enhance query performance.
+
 ## Version 1.0.0-beta.8 to 1.0.0
 
 ## Removed Deprecated Items

--- a/src/Database/Migrations/2024-08-31-025704_AddIndexToDeletedAtInUsers.php
+++ b/src/Database/Migrations/2024-08-31-025704_AddIndexToDeletedAtInUsers.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Shield.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace CodeIgniter\Shield\Database\Migrations;
+
+use CodeIgniter\Database\Forge;
+use CodeIgniter\Database\Migration;
+use CodeIgniter\Shield\Config\Auth;
+
+class AddIndexToDeletedAtInUsers extends Migration
+{
+    /**
+     * Auth Table names
+     */
+    private array $tables;
+
+    public function __construct(?Forge $forge = null)
+    {
+        /** @var Auth $authConfig */
+        $authConfig = config('Auth');
+
+        if ($authConfig->DBGroup !== null) {
+            $this->DBGroup = $authConfig->DBGroup;
+        }
+
+        parent::__construct($forge);
+
+        $this->tables = $authConfig->tables;
+    }
+
+    /**
+     * Apply the migration.
+     *
+     * This method adds an index to the `deleted_at` column of the `users` table.
+     * It is called when running the `php spark migrate --all` command.
+     */
+    public function up(): void
+    {
+        $this->forge->addKey('deleted_at', false, false, 'deleted_at');
+        $this->forge->processIndexes($this->tables['users']);
+    }
+
+    /**
+     * Revert the migration.
+     *
+     * This method removes the index from the `deleted_at` column of the `users` table.
+     * It is called when rolling back the migration using the `php spark migrate:rollback AddIndexToDeletedAtInUsers` command.
+     */
+    public function down(): void
+    {
+        // Drop index from the `deleted_at` field
+        $this->forge->dropKey($this->tables['users'], 'deleted_at');
+    }
+}


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
This Pull Request introduces a database **migration** that adds an index to the **deleted_at** column in the **users table**. This change is intended to enhance the performance of queries that **filter based on the deleted_at** field, particularly for cases involving soft deletes.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
