### PR TITLE
refactor: Move property to local variable on usage only in setUp() method in tests

### DIFF
--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -36,8 +36,6 @@ final class SessionAuthenticatorTest extends DatabaseTestCase
     use FakeUser;
 
     private Session $auth;
-    protected $namespace;
-    private MockEvents $events;
 
     protected function setUp(): void
     {
@@ -51,8 +49,8 @@ final class SessionAuthenticatorTest extends DatabaseTestCase
         $authenticator = $auth->factory('session');
         $this->auth    = $authenticator;
 
-        $this->events = new MockEvents();
-        Services::injectMock('events', $this->events);
+        $events = new MockEvents();
+        Services::injectMock('events', $events);
 
         $this->db->table($this->tables['identities'])->truncate();
     }

--- a/tests/Authentication/Filters/JWTFilterTest.php
+++ b/tests/Authentication/Filters/JWTFilterTest.php
@@ -31,8 +31,6 @@ final class JWTFilterTest extends DatabaseTestCase
 {
     use FeatureTestTrait;
 
-    protected $namespace;
-
     protected function setUp(): void
     {
         Services::reset(true);

--- a/tests/Authentication/MagicLinkTest.php
+++ b/tests/Authentication/MagicLinkTest.php
@@ -30,7 +30,6 @@ final class MagicLinkTest extends DatabaseTestCase
     use FeatureTestTrait;
 
     protected $refresh = true;
-    protected $namespace;
 
     protected function setUp(): void
     {

--- a/tests/Authorization/AuthorizableTest.php
+++ b/tests/Authorization/AuthorizableTest.php
@@ -29,7 +29,6 @@ final class AuthorizableTest extends DatabaseTestCase
     use FakeUser;
 
     protected $refresh = true;
-    protected $namespace;
 
     protected function setUp(): void
     {

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -31,8 +31,6 @@ final class LoginTest extends DatabaseTestCase
     use FeatureTestTrait;
     use FakeUser;
 
-    protected $namespace;
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Controllers/RegisterTest.php
+++ b/tests/Controllers/RegisterTest.php
@@ -33,8 +33,6 @@ final class RegisterTest extends DatabaseTestCase
     use FeatureTestTrait;
     use FakeUser;
 
-    protected $namespace;
-
     protected function setUp(): void
     {
         Services::reset(true);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Use local variable when only used on `setUp()` method.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
