### PR TITLE
docs: fix trait's name typo in integrating custom view lib

### DIFF
--- a/docs/customization/integrating_custom_view_libs.md
+++ b/docs/customization/integrating_custom_view_libs.md
@@ -16,7 +16,7 @@ use CodeIgniter\Shield\Controllers\LoginController;
 
 class MyLoginController extends LoginController
 {
-    use Themable;
+    use Themeable;
 
     protected function view(string $view, array $data = [], array $options = []): string
     {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Typo in trait's name

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
