### PR TITLE
fix: multilevel permissions in can() method

### DIFF
--- a/.github/workflows/no-merge-commits.yml
+++ b/.github/workflows/no-merge-commits.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run test
-        uses: NexusPHP/no-merge-commits@v2.2.1
+        uses: NexusPHP/no-merge-commits@v2.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/customization/user_provider.md
+++ b/docs/customization/user_provider.md
@@ -54,17 +54,3 @@ class UserModel extends ShieldUserModel
     }
 }
 ```
-
-## Creating a Custom User Entity
-
-Starting from v1.2.0, `UserModel` in Shield has the `createNewUser()` method to
-create a new User Entity.
-
-```php
-$user = $userModel->createNewUser($data);
-```
-
-It takes an optional user data array as the first argument, and passes it to the
-constructor of the `$returnType` class.
-
-If your custom User entity cannot be instantiated in this way, override this method.

--- a/docs/references/authentication/hmac.md
+++ b/docs/references/authentication/hmac.md
@@ -119,14 +119,14 @@ permissions the token grants to the user. Scopes are provided when the token is 
 cannot be modified afterword.
 
 ```php
-$token = $user->generateHmacToken('Work Laptop', ['posts.manage', 'forums.manage']);
+$token = $user->gererateHmacToken('Work Laptop', ['posts.manage', 'forums.manage']);
 ```
 
 By default, a user is granted a wildcard scope which provides access to all scopes. This is the
 same as:
 
 ```php
-$token = $user->generateHmacToken('Work Laptop', ['*']);
+$token = $user->gererateHmacToken('Work Laptop', ['*']);
 ```
 
 During authentication, the HMAC Keys the user used is stored on the user. Once authenticated, you

--- a/docs/user_management/forcing_password_reset.md
+++ b/docs/user_management/forcing_password_reset.md
@@ -38,7 +38,7 @@ if ($user->requiresPasswordReset()) {
 
 !!! note
 
-    You can use the [force-reset](../references/controller_filters.md/#forcing-password-reset)
+    You can use the [force-reset](../references/controller_filters/#forcing-password-reset)
     filter to check.
 
 ### Force Password Reset On a User

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -258,7 +258,7 @@ trait Authorizable
             if (strpos($permission, '.') === false) {
                 throw new LogicException(
                     'A permission must be a string consisting of a scope and action, like `users.create`.'
-                    . ' Invalid permission: ' . $permission
+                        . ' Invalid permission: ' . $permission
                 );
             }
 
@@ -280,8 +280,14 @@ trait Authorizable
                 }
 
                 // Check wildcard match
-                $check = substr($permission, 0, strpos($permission, '.')) . '.*';
-                if (isset($matrix[$group]) && in_array($check, $matrix[$group], true)) {
+                $checks = [];
+                $parts  = explode('.', $permission);
+
+                for ($i = count($parts); $i > 0; $i--) {
+                    $check    = implode('.', array_slice($parts, 0, $i)) . '.*';
+                    $checks[] = $check;
+                }
+                if (isset($matrix[$group]) && array_intersect($checks, $matrix[$group])) {
                     return true;
                 }
             }

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -287,7 +287,7 @@ trait Authorizable
                     $check    = implode('.', array_slice($parts, 0, $i)) . '.*';
                     $checks[] = $check;
                 }
-                if (isset($matrix[$group]) && array_intersect($checks, $matrix[$group])) {
+                if (isset($matrix[$group]) && array_intersect($checks, $matrix[$group]) !== []) {
                     return true;
                 }
             }

--- a/src/Collectors/Auth.php
+++ b/src/Collectors/Auth.php
@@ -83,7 +83,7 @@ class Auth extends BaseCollector
 
             $html = '<h3>Current User</h3>';
             $html .= '<table><tbody>';
-            $html .= "<tr><td width=\"150\">User ID</td><td>#{$user->id}</td></tr>";
+            $html .= "<tr><td style='width:150px;'>User ID</td><td>#{$user->id}</td></tr>";
             $html .= "<tr><td>Username</td><td>{$user->username}</td></tr>";
             $html .= "<tr><td>Email</td><td>{$user->email}</td></tr>";
             $html .= "<tr><td>Groups</td><td>{$groupsForUser}</td></tr>";

--- a/src/Controllers/RegisterController.php
+++ b/src/Controllers/RegisterController.php
@@ -103,7 +103,8 @@ class RegisterController extends BaseController
 
         // Save the user
         $allowedPostFields = array_keys($rules);
-        $user              = $users->createNewUser($this->request->getPost($allowedPostFields));
+        $user              = $this->getUserEntity();
+        $user->fill($this->request->getPost($allowedPostFields));
 
         // Workaround for email only registration/login
         if ($user->username === null) {
@@ -159,14 +160,10 @@ class RegisterController extends BaseController
 
     /**
      * Returns the Entity class that should be used
-     *
-     * @deprecated 1.2.0 No longer used.
      */
     protected function getUserEntity(): User
     {
-        $userProvider = $this->getUserProvider();
-
-        return $userProvider->createNewUser();
+        return new User();
     }
 
     /**

--- a/src/Entities/Group.php
+++ b/src/Entities/Group.php
@@ -95,7 +95,7 @@ class Group extends Entity
 
         return $this->permissions !== null
             && $this->permissions !== []
-            && array_intersect($checks, $this->permissions);
+            && !empty(array_intersect($checks, $this->permissions));
     }
 
     /**

--- a/src/Entities/Group.php
+++ b/src/Entities/Group.php
@@ -95,7 +95,7 @@ class Group extends Entity
 
         return $this->permissions !== null
             && $this->permissions !== []
-            && !empty(array_intersect($checks, $this->permissions));
+            && ! empty(array_intersect($checks, $this->permissions));
     }
 
     /**

--- a/src/Entities/Group.php
+++ b/src/Entities/Group.php
@@ -85,9 +85,17 @@ class Group extends Entity
         }
 
         // Check wildcard match
-        $check = substr($permission, 0, strpos($permission, '.')) . '.*';
+        $checks = [];
+        $parts  = explode('.', $permission);
 
-        return $this->permissions !== null && $this->permissions !== [] && in_array($check, $this->permissions, true);
+        for ($i = count($parts); $i > 0; $i--) {
+            $check    = implode('.', array_slice($parts, 0, $i)) . '.*';
+            $checks[] = $check;
+        }
+
+        return $this->permissions !== null
+            && $this->permissions !== []
+            && array_intersect($checks, $this->permissions);
     }
 
     /**

--- a/src/Entities/Group.php
+++ b/src/Entities/Group.php
@@ -95,7 +95,7 @@ class Group extends Entity
 
         return $this->permissions !== null
             && $this->permissions !== []
-            && ! empty(array_intersect($checks, $this->permissions));
+            && array_intersect($checks, $this->permissions) !== [];
     }
 
     /**

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -397,14 +397,4 @@ class UserModel extends BaseModel
             throw new LogicException('Return type must be a subclass of ' . User::class);
         }
     }
-
-    /**
-     * Returns a new User Entity.
-     *
-     * @param array<string, array<array-key, mixed>|bool|float|int|object|string|null> $data (Optional) user data
-     */
-    public function createNewUser(array $data = []): User
-    {
-        return new $this->returnType($data);
-    }
 }

--- a/tests/Authorization/GroupTest.php
+++ b/tests/Authorization/GroupTest.php
@@ -87,4 +87,28 @@ final class GroupTest extends TestCase
         $this->assertTrue($group2->can('users.edit'));
         $this->assertFalse($group2->can('foo.bar'));
     }
+
+    public function testCanNestedPerms(): void
+    {
+        $group = $this->groups->info('user');
+
+        $group->addPermission('foo.bar.*');
+        $group->addPermission('foo.biz.buz.*');
+
+        $this->assertTrue($group->can('foo.bar'));
+        $this->assertTrue($group->can('foo.bar.*'));
+        $this->assertTrue($group->can('foo.bar.baz'));
+        $this->assertTrue($group->can('foo.bar.buz'));
+        $this->assertTrue($group->can('foo.bar.buz.biz'));
+        $this->assertTrue($group->can('foo.biz.buz'));
+        $this->assertTrue($group->can('foo.biz.buz.*'));
+        $this->assertTrue($group->can('foo.biz.buz.bar'));
+        $this->assertFalse($group->can('foo'));
+        $this->assertFalse($group->can('foo.*'));
+        $this->assertFalse($group->can('foo.biz'));
+        $this->assertFalse($group->can('foo.buz'));
+        $this->assertFalse($group->can('foo.biz.*'));
+        $this->assertFalse($group->can('foo.biz.bar'));
+        $this->assertFalse($group->can('foo.biz.bar.buz'));
+    }
 }


### PR DESCRIPTION
Refactor authorization checks to support nested permissions in can() method.
Fixes #1224 

**Description**

### Changes
- Enhanced permission wildcard matching to properly handle nested levels
- Ensure wildcard behavior to prevent unintended parent/sibling permission access

### Example
Given permission `admin.settings.theme.*`:
- ✅ WILL match: `admin.settings.theme`, `admin.settings.theme.color`, `admin.settings.theme.layout.dark`
- ❌ WON'T match: `admin.settings`, `admin.*`

### Benefits
- More granular permission control
- Prevents privilege escalation through parent levels
- Maintains backward compatibility with existing permission structure
- Better alignment with hierarchical permission management

### Testing
Added comprehensive test cases covering:
- Nested permission levels
- Parent/child permission relationships
- Cross-branch permission validation
- Edge cases and boundary scenarios

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
