### PR TITLE
lang: [nl] fix incorrect translation

### DIFF
--- a/src/Language/nl/Auth.php
+++ b/src/Language/nl/Auth.php
@@ -53,7 +53,7 @@ return [
     // Login
     'login'              => 'Inloggen',
     'needAccount'        => 'Heb je nog geen account?',
-    'rememberMe'         => 'Wachtwoord onthouden',
+    'rememberMe'         => 'Ingelogd blijven',
     'forgotPassword'     => 'Wachtwoord vergeten?',
     'useMagicLink'       => 'Gebruik een Login Link',
     'magicLinkSubject'   => 'Jou Login Link',


### PR DESCRIPTION
Key rememberMe currently is "Wachtwoord onthouden" but this translates to "Remember password". Better translation of "Remember me?" would be "Blijf ingelogd" (stay logged in).

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [X] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
