### PR TITLE
fix: CSP error in debugbar

### DIFF
--- a/src/Collectors/Auth.php
+++ b/src/Collectors/Auth.php
@@ -83,7 +83,7 @@ class Auth extends BaseCollector
 
             $html = '<h3>Current User</h3>';
             $html .= '<table><tbody>';
-            $html .= "<tr><td style='width:150px;'>User ID</td><td>#{$user->id}</td></tr>";
+            $html .= "<tr><td width=\"150\">User ID</td><td>#{$user->id}</td></tr>";
             $html .= "<tr><td>Username</td><td>{$user->username}</td></tr>";
             $html .= "<tr><td>Email</td><td>{$user->email}</td></tr>";
             $html .= "<tr><td>Groups</td><td>{$groupsForUser}</td></tr>";


### PR DESCRIPTION
**Description**
Resolve an error when CSP is enabled and use debugbar in development environment, the style attribute in the table (from the collector) cause an error in browser console, changing the style attribute to a width attribute fix the issue.

```console
index.php?debugbar:46 Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self' 'nonce-98f45b1a6e3d510a2fe4474e'". Either the 'unsafe-inline' keyword, a hash ('sha256-AjG9eor6SyhAUzJE5wyV4y7++Gv+bkiPYFnboahgMlA='), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.
```
