### PR TITLE
docs: correcting the typo in method name `generateHmacToken`

### DIFF
--- a/docs/references/authentication/hmac.md
+++ b/docs/references/authentication/hmac.md
@@ -119,14 +119,14 @@ permissions the token grants to the user. Scopes are provided when the token is 
 cannot be modified afterword.
 
 ```php
-$token = $user->gererateHmacToken('Work Laptop', ['posts.manage', 'forums.manage']);
+$token = $user->generateHmacToken('Work Laptop', ['posts.manage', 'forums.manage']);
 ```
 
 By default, a user is granted a wildcard scope which provides access to all scopes. This is the
 same as:
 
 ```php
-$token = $user->gererateHmacToken('Work Laptop', ['*']);
+$token = $user->generateHmacToken('Work Laptop', ['*']);
 ```
 
 During authentication, the HMAC Keys the user used is stored on the user. Once authenticated, you


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
fix #1237 

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
