### PR TITLE
fix: rector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -47,6 +47,8 @@ use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
 use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Rector\Set\ValueObject\LevelSetList;
@@ -139,6 +141,10 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/Authentication/JWT/JWSDecoder.php',
             __DIR__ . '/src/Authentication/JWTManager.php',
         ],
+
+        // Ignore some PHPUnit rules
+        AssertCountWithZeroToAssertEmptyRector::class,
+        AssertEmptyNullableObjectToAssertInstanceofRector::class,
     ]);
 
     // auto import fully qualified class names


### PR DESCRIPTION
**Description**
This PR ignores two Rector rules which were added in the latest versions.

I believe that the application of these rules will negatively affect the readability of our tests.

Here are the proposed changes in the codebase by Rector: https://github.com/codeigniter4/shield/actions/runs/13240274064/job/36953902890

I'm not super convinced about it - this was just my first impression.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
