### PR TITLE
docs: require `activator` in custom actions class name for `register`

### DIFF
--- a/docs/references/authentication/auth_actions.md
+++ b/docs/references/authentication/auth_actions.md
@@ -57,10 +57,12 @@ public $views = [
 ## Defining New Actions
 
 While the provided email-based activation and 2FA will work for many sites, others will have different
-needs, like using SMS to verify or something completely different. Actions have only one requirement:
-they must implement `CodeIgniter\Shield\Authentication\Actions\ActionInterface`.
+needs, like using SMS to verify or something completely different. Custom actions must adhere to the following requirements:
 
-The interface defines three methods for `ActionController`:
+1. The class name for a "register" action must end with the suffix `Activator` (e.g., `SMSActivator`) to ensure consistency.
+2. All custom actions must implement the `CodeIgniter\Shield\Authentication\Actions\ActionInterface`.
+
+The `ActionInterface` defines three required methods that must be implemented to ensure the action integrates properly with the `ActionController`.
 
 **show()** should display the initial page the user lands on immediately after the authentication task,
 like login. It will typically display instructions to the user and provide an action to take, like

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -95,6 +95,11 @@ class Auth extends BaseConfig
      * - register: \CodeIgniter\Shield\Authentication\Actions\EmailActivator::class
      * - login:    \CodeIgniter\Shield\Authentication\Actions\Email2FA::class
      *
+     * Custom Actions and Requirements:
+     *
+     * - All actions must implement \CodeIgniter\Shield\Authentication\Actions\ActionInterface.
+     * - Custom actions for "register" must have a class name that ends with the suffix "Activator" (e.g., `CustomSmsActivator`) ensure proper functionality.
+     *
      * @var array<string, class-string<ActionInterface>|null>
      */
     public array $actions = [


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
fix: #1249

In this implementation, since we cannot determine whether the user provides just the class name or the fully qualified namespace of the class, we are unable to directly verify the `ActionInterface` implementation. Therefore, we rely on the class name suffix ('Activator') as a consistent identifier for validation.

see:
https://github.com/codeigniter4/shield/blob/58d6d6f8820aa17016da4001d5da544ed13e8e75/src/Traits/Activatable.php#L63




**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
