### PR TITLE
feat: Add user relations loading methods for groups and permissions

### DIFF
--- a/docs/user_management/managing_users.md
+++ b/docs/user_management/managing_users.md
@@ -79,6 +79,40 @@ $user->fill([
 $users->save($user);
 ```
 
+### Listing Users
+
+When displaying a list of users - for example, in the admin panel - we typically use the standard `find*` methods. However, these methods only return basic user information.
+
+If you need additional details like email addresses, groups, or permissions, each piece of information will trigger a separate database query for every user. This happens because user entities lazy-load related data, which can quickly result in a large number of queries.
+
+To optimize this, you can use method scopes like `UserModel::withIdentities()`, `withGroups()`, and `withPermissions()`. These methods preload the related data in a single query (one per each method), drastically reducing the number of database queries and improving performance.
+
+```php
+// Get the User Provider (UserModel by default)
+$users = auth()->getProvider();
+
+$usersList = $users
+    ->withIdentities()
+    ->withGroups()
+    ->withPermissions()
+    ->findAll(10);
+
+// The below code would normally trigger
+// an additional DB queries, but now it won't
+
+// Because identities are preloaded
+echo $usersList[0]->email;
+
+// Because groups are preloaded
+$usersList[0]->inGroup('admin');
+
+// Because permissions are preloaded
+$usersList[0]->hasPermission('users.delete');
+
+// Because groups and permissions are preloaded
+$usersList[0]->can('users.delete');
+```
+
 ## Managing Users via CLI
 
 Shield has a CLI command to manage users. You can do the following actions:

--- a/docs/user_management/managing_users.md
+++ b/docs/user_management/managing_users.md
@@ -97,20 +97,22 @@ $usersList = $users
     ->withPermissions()
     ->findAll(10);
 
-// The below code would normally trigger
-// an additional DB queries, but now it won't
+// The below code would normally trigger an additional
+// DB queries, on every loop iteration, but now it won't
 
-// Because identities are preloaded
-echo $usersList[0]->email;
+foreach ($usersList as $u) {
+    // Because identities are preloaded
+    echo $u->email;
 
-// Because groups are preloaded
-$usersList[0]->inGroup('admin');
+    // Because groups are preloaded
+    $u->inGroup('admin');
 
-// Because permissions are preloaded
-$usersList[0]->hasPermission('users.delete');
+    // Because permissions are preloaded
+    $u->hasPermission('users.delete');
 
-// Because groups and permissions are preloaded
-$usersList[0]->can('users.delete');
+    // Because groups and permissions are preloaded
+    $u->can('users.delete');
+}
 ```
 
 ## Managing Users via CLI

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -411,6 +411,12 @@ The type \'basic\', \'md5\', and \'sha1\' are deprecated\\. They are not cryptog
 $ignoreErrors[] = [
 	'message' => '#^Call to function model with CodeIgniter\\\\Shield\\\\Models\\\\GroupModel\\:\\:class is discouraged\\.$#',
 	'identifier' => 'codeigniter.factoriesClassConstFetch',
+	'count' => 2,
+	'path' => __DIR__ . '/src/Models/UserModel.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to function model with CodeIgniter\\\\Shield\\\\Models\\\\PermissionModel\\:\\:class is discouraged\\.$#',
+	'identifier' => 'codeigniter.factoriesClassConstFetch',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Models/UserModel.php',
 ];
@@ -502,13 +508,19 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Call to an undefined method CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:getLastQuery\\(\\)\\.$#',
 	'identifier' => 'method.notFound',
-	'count' => 1,
+	'count' => 7,
 	'path' => __DIR__ . '/tests/Unit/UserTest.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with \'CodeIgniter\\\\\\\\Shield\\\\\\\\Entities\\\\\\\\UserIdentity\' and CodeIgniter\\\\Shield\\\\Entities\\\\UserIdentity will always evaluate to true\\.$#',
 	'identifier' => 'method.alreadyNarrowedType',
 	'count' => 1,
+	'path' => __DIR__ . '/tests/Unit/UserTest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Offset 1 does not exist on array\\{CodeIgniter\\\\Shield\\\\Entities\\\\User\\}\\.$#',
+	'identifier' => 'offsetAccess.notFound',
+	'count' => 5,
 	'path' => __DIR__ . '/tests/Unit/UserTest.php',
 ];
 

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -113,6 +113,22 @@ trait Authorizable
     }
 
     /**
+     * Set groups cache manually
+     */
+    public function setGroupsCache(array $groups): void
+    {
+        $this->groupCache = $groups === [] ? null : $groups;
+    }
+
+    /**
+     * Set permissions cache manually
+     */
+    public function setPermissionsCache(array $permissions): void
+    {
+        $this->permissionsCache = $permissions === [] ? null : $permissions;
+    }
+
+    /**
      * Returns all groups this user is a part of.
      */
     public function getGroups(): ?array

--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -82,4 +82,28 @@ class GroupModel extends BaseModel
 
         return in_array($group, $allowedGroups, true);
     }
+
+    /**
+     * @param list<int>|list<string> $userIds
+     *
+     * @return array<int, array>
+     */
+    public function getGroupsByUserIds(array $userIds): array
+    {
+        $groups = $this->builder()
+            ->select('user_id, group')
+            ->whereIn('user_id', $userIds)
+            ->orderBy($this->primaryKey)
+            ->get()
+            ->getResultArray();
+
+        return array_map(
+            'array_keys',
+            array_reduce($groups, static function ($carry, $item) {
+                $carry[$item['user_id']][$item['group']] = true;
+
+                return $carry;
+            }, []),
+        );
+    }
 }

--- a/src/Models/PermissionModel.php
+++ b/src/Models/PermissionModel.php
@@ -72,4 +72,28 @@ class PermissionModel extends BaseModel
 
         $this->checkQueryReturn($return);
     }
+
+    /**
+     * @param list<int>|list<string> $userIds
+     *
+     * @return array<int, array>
+     */
+    public function getPermissionsByUserIds(array $userIds): array
+    {
+        $permissions = $this->builder()
+            ->select('user_id, permission')
+            ->whereIn('user_id', $userIds)
+            ->orderBy($this->primaryKey)
+            ->get()
+            ->getResultArray();
+
+        return array_map(
+            'array_keys',
+            array_reduce($permissions, static function ($carry, $item) {
+                $carry[$item['user_id']][$item['permission']] = true;
+
+                return $carry;
+            }, []),
+        );
+    }
 }


### PR DESCRIPTION
**Description**
This PR enhances user queries by enabling the retrieval of related user data more efficiently.

It adds two new methods: `withGroups()` and `withPermissions()`, which loads user groups and permissions directly when fetching users. The existing `withIdentities()` method (previously undocumented) has also been included in the documentation.

With these methods, all necessary user information can be loaded in a single query (one per used method), reducing the number of additional queries and improving performance.

The problem this PR solves was described in the Bonfire2 repo: https://github.com/lonnieezell/Bonfire2/issues/558

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
