### PR TITLE
refactor: Ensure `findById` returns `null` instead of an array when ID is null

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -182,7 +182,9 @@ class UserModel extends BaseModel
      */
     public function findById($id): ?User
     {
-        return $this->find($id);
+        $result = $this->find($id);
+        
+        return $result instanceof User ? $result : null;
     }
 
     /**


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Although the phpdocs states that the ID ($id) should not be `null`, in some cases, data may be retrieved from the database where the ID is set to `null`.

When `null` is passed to the `find($id)` method, instead of returning null or a User object, it returns an empty array ([]).

This leads to a type mismatch with the method signature, which expects a return type of `?User`, causing the error:


CodeIgniter\Shield\Models\UserModel::findById(): Return value must be of type ?CodeIgniter\Shield\Entities\User, array returned 

This change ensures that the method always adheres to the expected return type (?User), preventing unexpected runtime errors.

**Checklist:**
- [ ] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
