### PR TITLE
chore: fix code to comply with latest PHPStan, Rector and CS

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -166,15 +166,15 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Collectors/Auth.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot access property \\$id on array\\<string, string\\>\\|object\\.$#',
-	'identifier' => 'property.nonObject',
-	'count' => 9,
-	'path' => __DIR__ . '/src/Commands/Hmac.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$expires on array\\<string, string\\>\\|object\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 3,
+	'path' => __DIR__ . '/src/Commands/Hmac.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Cannot access property \\$id on array\\<string, string\\>\\|object\\.$#',
+	'identifier' => 'property.nonObject',
+	'count' => 9,
 	'path' => __DIR__ . '/src/Commands/Hmac.php',
 ];
 $ignoreErrors[] = [
@@ -491,6 +491,13 @@ $ignoreErrors[] = [
 	'identifier' => 'method.alreadyNarrowedType',
 	'count' => 6,
 	'path' => __DIR__ . '/tests/Unit/Authentication/JWT/JWTManagerTest.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Call to deprecated method __construct\\(\\) of class CodeIgniter\\\\HTTP\\\\Response\\:
+4\\.5\\.0 The param \\$config is no longer used\\.$#',
+	'identifier' => 'method.deprecated',
+	'count' => 3,
+	'path' => __DIR__ . '/tests/Unit/PwnedValidatorTest.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Call to an undefined method CodeIgniter\\\\Shield\\\\Models\\\\UserModel\\:\\:getLastQuery\\(\\)\\.$#',

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,3 +34,7 @@ parameters:
 		disallowedImplicitArrayCreation: true
 		disallowedShortTernary: true
 		matchingInheritedMethodNames: true
+	ignoreErrors:
+		- identifier: function.internal
+		- identifier: return.internalClass
+		- identifier: staticMethod.internal

--- a/rector.php
+++ b/rector.php
@@ -44,10 +44,8 @@ use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php73\Rector\FuncCall\StringifyStrNeedlesRector;
-use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\AnnotationWithValueToAttributeRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
-use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertCountWithZeroToAssertEmptyRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
@@ -135,15 +133,7 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/src/Commands/Setup.php',
         ],
 
-        // Ignore for some existing classes to prevent BC break
-        NewInInitializerRector::class => [
-            __DIR__ . '/src/Authentication/JWT/JWSEncoder.php',
-            __DIR__ . '/src/Authentication/JWT/JWSDecoder.php',
-            __DIR__ . '/src/Authentication/JWTManager.php',
-        ],
-
         // Ignore some PHPUnit rules
-        AssertCountWithZeroToAssertEmptyRector::class,
         AssertEmptyNullableObjectToAssertInstanceofRector::class,
     ]);
 

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -824,10 +824,9 @@ class Session implements AuthenticatorInterface
         /** @var \CodeIgniter\Session\Session $session */
         $session     = session();
         $sessionData = $session->get();
-        if (isset($sessionData)) {
-            foreach (array_keys($sessionData) as $key) {
-                $session->remove($key);
-            }
+
+        foreach (array_keys($sessionData) as $key) {
+            $session->remove($key);
         }
 
         // Regenerate the session ID for a touch of added safety.

--- a/src/Views/email_2fa_show.php
+++ b/src/Views/email_2fa_show.php
@@ -22,7 +22,6 @@
                 <div class="mb-2">
                     <input type="email" class="form-control" name="email"
                         inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>"
-                        <?php /** @var CodeIgniter\Shield\Entities\User $user */ ?>
                         value="<?= old('email', $user->email) ?>" required>
                 </div>
 

--- a/src/Views/email_2fa_show.php
+++ b/src/Views/email_2fa_show.php
@@ -1,3 +1,9 @@
+<?php
+
+use CodeIgniter\Shield\Entities\User;
+
+?>
+
 <?= $this->extend(config('Auth')->views['layout']) ?>
 
 <?= $this->section('title') ?><?= lang('Auth.email2FATitle') ?> <?= $this->endSection() ?>
@@ -22,6 +28,7 @@
                 <div class="mb-2">
                     <input type="email" class="form-control" name="email"
                         inputmode="email" autocomplete="email" placeholder="<?= lang('Auth.email') ?>"
+                        <?php /** @var User $user */ ?>
                         value="<?= old('email', $user->email) ?>" required>
                 </div>
 

--- a/tests/Commands/UserTest.php
+++ b/tests/Commands/UserTest.php
@@ -592,6 +592,7 @@ final class UserTest extends DatabaseTestCase
 
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user10@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $this->assertTrue($user->inGroup('admin'));
     }
 
@@ -632,6 +633,7 @@ final class UserTest extends DatabaseTestCase
 
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user10@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $this->assertFalse($user->inGroup('admin'));
     }
 
@@ -644,6 +646,7 @@ final class UserTest extends DatabaseTestCase
         ]);
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $user->addGroup('admin');
         $this->assertTrue($user->inGroup('admin'));
 
@@ -658,6 +661,7 @@ final class UserTest extends DatabaseTestCase
 
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $this->assertFalse($user->inGroup('admin'));
     }
 
@@ -670,6 +674,7 @@ final class UserTest extends DatabaseTestCase
         ]);
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $user->addGroup('admin');
         $this->assertTrue($user->inGroup('admin'));
 
@@ -684,6 +689,7 @@ final class UserTest extends DatabaseTestCase
 
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $this->assertTrue($user->inGroup('admin'));
     }
 
@@ -696,6 +702,7 @@ final class UserTest extends DatabaseTestCase
         ]);
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $user->addGroup('admin');
         $this->assertTrue($user->inGroup('admin'));
 
@@ -710,6 +717,7 @@ final class UserTest extends DatabaseTestCase
 
         $users = model(UserModel::class);
         $user  = $users->findByCredentials(['email' => 'user11@example.com']);
+        $this->assertInstanceOf(UserEntity::class, $user);
         $this->assertTrue($user->inGroup('admin'));
     }
 }

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -207,6 +207,8 @@ final class UserModelTest extends DatabaseTestCase
 
         $user = $users->findByCredentials(['email' => 'foo@bar.com']);
 
+        $this->assertInstanceOf(User::class, $user);
+
         $user->username = 'bar';
         $user->email    = 'bar@bar.com';
         $user->active   = true;


### PR DESCRIPTION
**Description**
This PR fixes all failing checks.

- ~**CS**  
  For some reason, [this line with a comment](https://github.com/codeigniter4/shield/blob/81b69bf9985f71f3a64d9274980acc85d0d0ceb7/src/Views/email_2fa_show.php#L25) was causing a [failure](https://github.com/michalsn/shield/actions/runs/16069502918/job/45376467406).  
  If anyone knows how to fix this, please share your thoughts or open a PR.~

- **PHPStan**  
  The main issue came from this PHPStan release: [v2.1.13](https://github.com/phpstan/phpstan/releases/tag/2.1.13)  
  > Report `@internal` symbols usage from outside their top namespace  
  
  Since we intentionally use `@internal` in some places, I decided to ignore these errors for now.   All other issues are listed [in this job run](https://github.com/codeigniter4/shield/actions/runs/14737650403/job/41367673100).

- **Rector**  
  I followed the suggested changes from Rector. If a rule was removed, Rector required it.  
  There were no side effects, so everything looks good.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
