### PR TITLE
docs: fix typo and clarify JWS (Signed JWT) terminology

### DIFF
--- a/docs/addons/jwt.md
+++ b/docs/addons/jwt.md
@@ -2,7 +2,7 @@
 
 !!! note
 
-    Shield now supports only JWS (Singed JWT). JWE (Encrypted JWT) is not supported.
+    Shield now supports only JWS (Signed JWT). JWE (Encrypted JWT) is not supported.
 
 ## What is JWT?
 


### PR DESCRIPTION
**Description**
Typo fix: transposed letters; JWS appears as (Singed JWT), should be (Signed JWT).

**Checklist:**
- [x] Securely signed commits
- [x] User guide updated
- [x] Conforms to style guide
