### PR TITLE
lang: [sk] update Slovak translations for invalid email and token

### DIFF
--- a/src/Language/sk/Auth.php
+++ b/src/Language/sk/Auth.php
@@ -25,7 +25,7 @@ return [
     'badToken'              => 'Prístupový token je neplatný.',
     'oldToken'              => 'Platnosť prístupového tokenu vypršala.',
     'noUserEntity'          => 'Na overenie hesla je potrebné zadať entitu používateľa.',
-    'invalidEmail'          => 'Nie je možné overiť, že e-mailová adresa "{0}" sa zhoduje s e-mailom v databáze.',
+    'invalidEmail'          => 'Nie je možné overiť, či sa e-mailová adresa "{0}" zhoduje s e-mailom v databáze.',
     'unableSendEmailToUser' => 'Ľutujeme, pri odosielaní e-mailu sa vyskytol problém. Nepodarilo sa nám odoslať e-mail na adresu „{0}".',
     'throttled'             => 'Z tejto adresy IP bolo odoslaných príliš veľa žiadostí. Môžete to skúsiť znova o {0} sekúnd.',
     'notEnoughPrivilege'    => 'Nemáte potrebné povolenie na vykonanie požadovanej operácie.',

--- a/src/Language/sk/Auth.php
+++ b/src/Language/sk/Auth.php
@@ -25,7 +25,7 @@ return [
     'badToken'              => 'Prístupový token je neplatný.',
     'oldToken'              => 'Platnosť prístupového tokenu vypršala.',
     'noUserEntity'          => 'Na overenie hesla je potrebné zadať entitu používateľa.',
-    'invalidEmail'          => '(To be translated) Unable to verify the email address "{0}" matches the email on record.',
+    'invalidEmail'          => 'Nie je možné overiť, že e-mailová adresa "{0}" sa zhoduje s e-mailom v databáze.',
     'unableSendEmailToUser' => 'Ľutujeme, pri odosielaní e-mailu sa vyskytol problém. Nepodarilo sa nám odoslať e-mail na adresu „{0}".',
     'throttled'             => 'Z tejto adresy IP bolo odoslaných príliš veľa žiadostí. Môžete to skúsiť znova o {0} sekúnd.',
     'notEnoughPrivilege'    => 'Nemáte potrebné povolenie na vykonanie požadovanej operácie.',
@@ -39,7 +39,7 @@ return [
     'password'        => 'Heslo',
     'passwordConfirm' => 'Heslo (znova)',
     'haveAccount'     => 'Máte už účet?',
-    'token'           => '(To be translated) Token',
+    'token'           => 'Token',
 
     // Buttons
     'confirm' => 'Potvrdiť',

--- a/tests/Language/SlovakTranslationTest.php
+++ b/tests/Language/SlovakTranslationTest.php
@@ -18,4 +18,7 @@ namespace Tests\Language;
  */
 final class SlovakTranslationTest extends AbstractTranslationTestCase
 {
+    protected array $excludedLocaleKeyTranslations = [
+        'Auth.token',
+    ];
 }


### PR DESCRIPTION
**Description**

This PR completes the Slovak translation for the Auth.php language file by translating two remaining English strings:

1. `'invalidEmail'` - Translated from "Unable to verify the email address "{0}" matches the email on record." to "Nie je možné overiť, či sa e-mailová adresa "{0}" zhoduje s e-mailom v databáze."
2. `'token'` - Translated from "Token" to "Token" (keeping the same as it's a technical term commonly used in Slovak)

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
