### PR TITLE
test: set fixed time for time-dependent tests

### DIFF
--- a/tests/Authentication/HasAccessTokensTest.php
+++ b/tests/Authentication/HasAccessTokensTest.php
@@ -205,6 +205,8 @@ final class HasAccessTokensTest extends DatabaseTestCase
      */
     public function testTokenTimeToExpired(): void
     {
+        Time::setTestNow('2025-07-16 12:00:00');
+
         $tokenExpiration = Time::now()->addYears(1);
 
         $token = $this->user->generateAccessToken('foo', ['foo.bar'], $tokenExpiration);

--- a/tests/Authentication/HasAccessTokensTest.php
+++ b/tests/Authentication/HasAccessTokensTest.php
@@ -213,6 +213,8 @@ final class HasAccessTokensTest extends DatabaseTestCase
         $this->user->setAccessToken($token);
 
         $this->assertSame('in 1 year', $this->user->currentAccessToken()->expires->humanize());
+
+        Time::setTestNow();
     }
 
     /**

--- a/tests/Authentication/HasAccessTokensTest.php
+++ b/tests/Authentication/HasAccessTokensTest.php
@@ -35,6 +35,14 @@ final class HasAccessTokensTest extends DatabaseTestCase
         $this->db->table($this->tables['identities'])->truncate();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Reset the current time.
+        Time::setTestNow();
+    }
+
     public function testGenerateToken(): void
     {
         $token = $this->user->generateAccessToken('foo');
@@ -213,8 +221,6 @@ final class HasAccessTokensTest extends DatabaseTestCase
         $this->user->setAccessToken($token);
 
         $this->assertSame('in 1 year', $this->user->currentAccessToken()->expires->humanize());
-
-        Time::setTestNow();
     }
 
     /**

--- a/tests/Authentication/HasHmacTokensTest.php
+++ b/tests/Authentication/HasHmacTokensTest.php
@@ -35,6 +35,14 @@ final class HasHmacTokensTest extends DatabaseTestCase
         $this->db->table($this->tables['identities'])->truncate();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Reset the current time.
+        Time::setTestNow();
+    }
+
     public function testGenerateHmacToken(): void
     {
         $token = $this->user->generateHmacToken('foo');
@@ -222,8 +230,6 @@ final class HasHmacTokensTest extends DatabaseTestCase
         $token = $this->user->generateHmacToken('foo', ['foo.bar'], $tokenExpiration);
 
         $this->assertSame('in 1 year', $token->expires->humanize());
-
-        Time::setTestNow();
     }
 
     /**

--- a/tests/Authentication/HasHmacTokensTest.php
+++ b/tests/Authentication/HasHmacTokensTest.php
@@ -214,6 +214,8 @@ final class HasHmacTokensTest extends DatabaseTestCase
      */
     public function testHmacTokenTimeToExpired(): void
     {
+        Time::setTestNow('2025-07-16 12:00:00');
+
         $tokenExpiration = Time::now();
         $tokenExpiration = $tokenExpiration->addYears(1);
 

--- a/tests/Authentication/HasHmacTokensTest.php
+++ b/tests/Authentication/HasHmacTokensTest.php
@@ -222,6 +222,8 @@ final class HasHmacTokensTest extends DatabaseTestCase
         $token = $this->user->generateHmacToken('foo', ['foo.bar'], $tokenExpiration);
 
         $this->assertSame('in 1 year', $token->expires->humanize());
+
+        Time::setTestNow();
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR fixes two tests that were previously dependent on the current system time by setting a fixed time at the beginning of each test. This ensures consistent and deterministic test results.

Fixes #1280

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
