### PR TITLE
fix: Bug in fetchIdentities when using first()

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -142,6 +142,10 @@ class UserModel extends BaseModel
 
         $mappedUsers = $this->assignIdentities($data, $identities);
 
+        if ($data['method'] === 'first') {
+            $data['id'] = $data['data']->id;
+        }
+
         $data['data'] = $data['singleton'] ? $mappedUsers[$data['id']] : $mappedUsers;
 
         return $data;

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -278,4 +278,49 @@ final class UserModelTest extends DatabaseTestCase
 
         $users->save(['id' => $user->id]);
     }
+
+    public function testGetFirstIdentity(): void
+    {
+        $errors = [];
+        $users  = $this->createUserModel();
+        $user   = $this->createNewUser();
+        $users->save($user);
+
+        // Custom error handler
+        set_error_handler(static function ($severity, $message, $file, $line) use (&$errors) {
+            $errors[] = [
+                'message'  => $message,
+                'severity' => $severity,
+                'file'     => $file,
+                'line'     => $line,
+            ];
+
+            // Return true so that the default handler is not executed
+            return true;
+        });
+
+        try {
+            $user = $users->withIdentities()->first();
+            $this->assertSame(
+                $user->getIdentity('all')->secret,
+                'foo@bar.com',
+                'Verify first() method retrieves user with identity',
+            );
+        } finally {
+            // restore handler
+            restore_error_handler();
+        }
+
+        if ($errors !== []) {
+            $errorMessages = array_map(static fn ($error) => sprintf(
+                '[%s] %s in %s:%s',
+                $error['severity'],
+                $error['message'],
+                $error['file'],
+                $error['line'],
+            ), $errors);
+
+            $this->fail("Errors found:\n" . implode("\n", $errorMessages));
+        }
+    }
 }


### PR DESCRIPTION
**Description**
This PR fixes a critical bug when using `withIdentities()->first()` and improves test reliability.

 **Fixed identity loading bug:**
   - Added missing ID population for `first()` method in `fetchIdentities`
   - Resolved "undefined array key id" error when calling `withIdentities()->first()`
   - Now correctly handles identity relationships for single results


**Checklist:**
- [ ] Securely signed commits
- [X] Component(s) with PHPDoc blocks, only if necessary or adds value
- [X] Unit testing, with >80% coverage
- [ ] User guide updated
- [X] Conforms to style guide
