### PR TITLE
fix: check for empty actionClass so that actions can be disabled via .env params

### DIFF
--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -195,7 +195,7 @@ class Session implements AuthenticatorInterface
     {
         $actionClass = setting('Auth.actions')[$type] ?? null;
 
-        if ($actionClass === null) {
+        if ($actionClass === null || $actionClass === '') {
             return false;
         }
 
@@ -473,7 +473,7 @@ class Session implements AuthenticatorInterface
         $authActions = setting('Auth.actions');
 
         foreach ($authActions as $actionClass) {
-            if ($actionClass === null) {
+            if ($actionClass === null || $actionClass === '') {
                 continue;
             }
 
@@ -517,7 +517,7 @@ class Session implements AuthenticatorInterface
         $types   = [];
 
         foreach ($actions as $actionClass) {
-            if ($actionClass === null) {
+            if ($actionClass === null || $actionClass === '') {
                 continue;
             }
 


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**

With current setup setting login or register action to empty string will trigger error.  Empty values should be allowed so that it is possible to disable the action from env file.

Example in env to disable TOTP in development environment

auth.actions.login = ''

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
