### PR TITLE
fix: `withPermissions()` for users without permissions

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -502,7 +502,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'rawMessage' => 'Call to an undefined method CodeIgniter\\Shield\\Models\\UserModel::getLastQuery().',
 	'identifier' => 'method.notFound',
-	'count' => 7,
+	'count' => 9,
 	'path' => __DIR__ . '/tests/Unit/UserTest.php',
 ];
 $ignoreErrors[] = [

--- a/src/Authorization/Traits/Authorizable.php
+++ b/src/Authorization/Traits/Authorizable.php
@@ -117,7 +117,7 @@ trait Authorizable
      */
     public function setGroupsCache(array $groups): void
     {
-        $this->groupCache = $groups === [] ? null : $groups;
+        $this->groupCache = $groups;
     }
 
     /**
@@ -125,7 +125,7 @@ trait Authorizable
      */
     public function setPermissionsCache(array $permissions): void
     {
-        $this->permissionsCache = $permissions === [] ? null : $permissions;
+        $this->permissionsCache = $permissions;
     }
 
     /**

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -210,10 +210,6 @@ class UserModel extends BaseModel
         // Get our groups for all users
         $groups = $groupModel->getGroupsByUserIds($userIds);
 
-        if ($groups === []) {
-            return $data;
-        }
-
         $mappedUsers = $this->assignProperties($data, $groups, 'groups');
 
         $data['data'] = $data['singleton'] ? $mappedUsers[$data['id']] : $mappedUsers;
@@ -247,10 +243,6 @@ class UserModel extends BaseModel
 
         $permissions = $permissionModel->getPermissionsByUserIds($userIds);
 
-        if ($permissions === []) {
-            return $data;
-        }
-
         $mappedUsers = $this->assignProperties($data, $permissions, 'permissions');
 
         $data['data'] = $data['singleton'] ? $mappedUsers[$data['id']] : $mappedUsers;
@@ -281,9 +273,10 @@ class UserModel extends BaseModel
         // Build method name
         $method = 'set' . ucfirst($type) . 'Cache';
 
-        // Now assign the properties to the user
-        foreach ($properties as $userId => $propertyArray) {
-            $mappedUsers[$userId]->{$method}($propertyArray);
+        // Assign properties to all users (empty array if no properties found)
+        foreach ($mappedUsers as $userId => $user) {
+            $propertyArray = $properties[$userId] ?? [];
+            $user->{$method}($propertyArray);
         }
         unset($properties);
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -188,6 +188,26 @@ final class UserTest extends DatabaseTestCase
         );
     }
 
+    public function testModelFindByIdWithGroupsWhenUserHasNoGroups(): void
+    {
+        // User has no groups in the database
+        $user = model(UserModel::class)->where('active', 1)->withGroups()->findById(1);
+
+        $this->assertInstanceOf(User::class, $user);
+
+        // Verify groups cache is set to empty array (not null)
+        $this->assertSame([], $user->getGroups());
+        $this->assertFalse($user->inGroup('admin'));
+
+        // Verify the last query was the one with WHERE IN
+        $query = (string) model(UserModel::class)->getLastQuery();
+        $this->assertMatchesRegularExpression(
+            '/WHERE\s+.*\s+IN\s+\([^)]+\)/i',
+            $query,
+            'Groups were not obtained with the single query (missing "WHERE ... IN" condition)',
+        );
+    }
+
     public function testModelFindAllWithPermissionsUserNotExists(): void
     {
         $users = model(UserModel::class)->where('active', 0)->withPermissions()->findAll();
@@ -241,6 +261,28 @@ final class UserTest extends DatabaseTestCase
             '/WHERE\s+.*\s+IN\s+\([^)]+\)/i',
             $query,
             'Permissions were not obtained with the single query (missing "WHERE ... IN" condition)',
+        );
+    }
+
+    public function testModelFindByIdWithPermissionsWhenUserHasNoPermissions(): void
+    {
+        // Load both groups and permissions to ensure can() doesn't trigger queries
+        $user = model(UserModel::class)->where('active', 1)->withGroups()->withPermissions()->findById(1);
+
+        $this->assertInstanceOf(User::class, $user);
+
+        // Verify permissions cache is set to empty array (not null)
+        $this->assertSame([], $user->getPermissions());
+        $this->assertSame([], $user->getGroups());
+        $this->assertFalse($user->hasPermission('users.delete'));
+        $this->assertFalse($user->can('users.delete'));
+
+        // Verify the last query was the one with WHERE IN
+        $query = (string) model(UserModel::class)->getLastQuery();
+        $this->assertMatchesRegularExpression(
+            '/WHERE\s+.*\s+IN\s+\([^)]+\)/i',
+            $query,
+            'Groups and Permissions were not obtained with the single query (missing "WHERE ... IN" condition)',
         );
     }
 


### PR DESCRIPTION
**Description**
This PR fixes a bug affecting `UserModel::withPermissions()`, which caused users without permissions to trigger additional, unnecessary database queries. The same behavior was implemented for the `UserModel::withGroups()` for unification.

Bug reported here: https://github.com/codeigniter4/shield/pull/1257#issuecomment-3368990849

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
