### PR TITLE
fix: Remember-me token refresh fails in loginView() - missing withCookies() on redirect

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -332,6 +332,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/tests/Controllers/ActionsTest.php',
 ];
 $ignoreErrors[] = [
+	'rawMessage' => 'Call to method setCookie() of internal class CodeIgniter\\Superglobals from outside its root namespace CodeIgniter.',
+	'identifier' => 'method.internalClass',
+	'count' => 1,
+	'path' => __DIR__ . '/tests/Controllers/LoginTest.php',
+];
+$ignoreErrors[] = [
 	'rawMessage' => 'Call to method setServer() of internal class CodeIgniter\\Superglobals from outside its root namespace CodeIgniter.',
 	'identifier' => 'method.internalClass',
 	'count' => 1,

--- a/src/Controllers/LoginController.php
+++ b/src/Controllers/LoginController.php
@@ -31,7 +31,7 @@ class LoginController extends BaseController
     public function loginView()
     {
         if (auth()->loggedIn()) {
-            return redirect()->to(config('Auth')->loginRedirect());
+            return redirect()->to(config('Auth')->loginRedirect())->withCookies();
         }
 
         /** @var Session $authenticator */

--- a/tests/Controllers/LoginTest.php
+++ b/tests/Controllers/LoginTest.php
@@ -17,6 +17,7 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Actions\Email2FA;
 use CodeIgniter\Shield\Config\Auth;
+use CodeIgniter\Shield\Models\RememberModel;
 use CodeIgniter\Shield\Models\UserIdentityModel;
 use CodeIgniter\Test\FeatureTestTrait;
 use CodeIgniter\Test\TestResponse;
@@ -167,6 +168,35 @@ final class LoginTest extends DatabaseTestCase
 
         $result = $this->get('/login');
         $result->assertRedirectTo(config('Auth')->loginRedirect());
+    }
+
+    public function testAfterLoggedInWithRememberCookieReturnsRefreshedCookie(): void
+    {
+        $this->user->createEmailIdentity([
+            'email'    => 'foo@example.com',
+            'password' => 'secret123',
+        ]);
+
+        $selector  = 'selector';
+        $validator = 'validator';
+        $expires   = Time::now()
+            ->addSeconds(setting('Auth.sessionConfig')['rememberLength'])
+            ->format('Y-m-d H:i:s');
+
+        model(RememberModel::class)->rememberUser(
+            $this->user,
+            $selector,
+            hash('sha256', $validator),
+            $expires,
+        );
+
+        $cookieName = setting('Auth.sessionConfig')['rememberCookieName'];
+        service('superglobals')->setCookie($cookieName, $selector . ':' . $validator);
+
+        $result = $this->get('/login');
+
+        $result->assertRedirectTo(config('Auth')->loginRedirect());
+        $result->assertCookie($cookieName);
     }
 
     public function testLoginActionUsernameSuccess(): void


### PR DESCRIPTION
When a user with a valid remember-me cookie accesses the login page, the loginView() method in LoginController redirects already-logged-in users without preserving cookies.

Bug Location:
vendor/codeigniter4/shield/src/Controllers/LoginController.php:34

Current Code:

```
  public function loginView()
  {
      if (auth()->loggedIn()) {
          return redirect()->to(config('Auth')->loginRedirect());  // ❌ Missing ->withCookies()
      }
      // ...
  }
```

Expected Code:

```
  public function loginView()
  {
      if (auth()->loggedIn()) {
          return redirect()->to(config('Auth')->loginRedirect())->withCookies();  // ✅ Fixed
      }
      // ...
  }
```

Impact:

When Session::checkRememberMe() validates a remember-me token, it calls refreshRememberMeToken() which:

Generates a new validator
Updates the hashed validator in database
Sends a new cookie via setRememberMeCookie()
However, the redirect at line 34 doesn't include ->withCookies(), so the new cookie is lost. The browser keeps the old cookie with the old validator, which no longer matches the updated hash in the database.

On the next visit, authentication fails with:
hash_equals($token->hashedValidator, $hashedValidator) === false // Session.php:631

Steps to Reproduce
Enable remember-me: $sessionConfig['allowRemembering'] = true
Login with remember-me checkbox checked
Wait for token refresh (or clear session to trigger remember-me authentication)
Access login page → redirect happens but new cookie is lost
Next visit → authentication fails because cookie validator doesn't match database hash
Expected Output
Expected Code:

```
  public function loginView()
  {
      if (auth()->loggedIn()) {
          return redirect()->to(config('Auth')->loginRedirect())->withCookies();  // ✅ Fixed
      }
      // ...
  }
```
=> The token will be refreshed in the cookie