### PR TITLE
chore: fix PHPStan, Rector and tests

### DIFF
--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   deptrac:
-    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/deptrac.yml@CI47

--- a/.github/workflows/phpcpd.yml
+++ b/.github/workflows/phpcpd.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   phpcpd:
-    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpcpd.yml@CI47
     with:
       dirs: "src/ tests/"
       options: "--exclude src/Database/Migrations/2020-12-28-223112_create_auth_tables.php --exclude src/Authentication/Authenticators/HmacSha256.php --exclude  tests/Authentication/Authenticators/AccessTokenAuthenticatorTest.php"

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   phpcsfixer:
-    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpcsfixer.yml@CI47

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpstan:
-    uses: codeigniter4/.github/.github/workflows/phpstan.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpstan.yml@CI47

--- a/.github/workflows/phpunit-lowest.yml
+++ b/.github/workflows/phpunit-lowest.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   phpunit:
-    uses: codeigniter4/.github/.github/workflows/phpunit-lowest.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpunit-lowest.yml@CI47

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -44,7 +44,7 @@ jobs:
             db-platform: OCI8
             mysql-version: '8.0'
 
-    uses: codeigniter4/.github/.github/workflows/phpunit.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/phpunit.yml@CI47
     with:
       php-version: ${{ matrix.php-version }}
       db-platform: ${{ matrix.db-platform }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,7 +22,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
         db-platform: ['MySQLi', 'SQLite3']
         mysql-version: ['8.0']
         dependencies: ['highest']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   psalm:
-    uses: codeigniter4/.github/.github/workflows/psalm.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/psalm.yml@CI47

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   rector:
-    uses: codeigniter4/.github/.github/workflows/rector.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/rector.yml@CI47

--- a/.github/workflows/unused.yml
+++ b/.github/workflows/unused.yml
@@ -18,4 +18,4 @@ on:
 
 jobs:
   unused:
-    uses: codeigniter4/.github/.github/workflows/unused.yml@CI46
+    uses: codeigniter4/.github/.github/workflows/unused.yml@CI47

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2,13 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-	'rawMessage' => 'Call to deprecated function random_string():
-The type \'basic\', \'md5\', and \'sha1\' are deprecated. They are not cryptographically secure.',
-	'identifier' => 'function.deprecated',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Authentication/Actions/Email2FA.php',
-];
-$ignoreErrors[] = [
 	'rawMessage' => 'Call to function model with CodeIgniter\\Shield\\Models\\UserIdentityModel::class is discouraged.',
 	'identifier' => 'codeigniter.factoriesClassConstFetch',
 	'count' => 2,
@@ -19,13 +12,6 @@ $ignoreErrors[] = [
 	'identifier' => 'empty.notAllowed',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Actions/Email2FA.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Call to deprecated function random_string():
-The type \'basic\', \'md5\', and \'sha1\' are deprecated. They are not cryptographically secure.',
-	'identifier' => 'function.deprecated',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Authentication/Actions/EmailActivator.php',
 ];
 $ignoreErrors[] = [
 	'rawMessage' => 'Call to function model with CodeIgniter\\Shield\\Models\\UserIdentityModel::class is discouraged.',
@@ -194,13 +180,6 @@ $ignoreErrors[] = [
 	'identifier' => 'codeigniter.factoriesClassConstFetch',
 	'count' => 9,
 	'path' => __DIR__ . '/src/Commands/User.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Call to deprecated function random_string():
-The type \'basic\', \'md5\', and \'sha1\' are deprecated. They are not cryptographically secure.',
-	'identifier' => 'function.deprecated',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Controllers/MagicLinkController.php',
 ];
 $ignoreErrors[] = [
 	'rawMessage' => 'Call to function model with CodeIgniter\\Shield\\Models\\LoginModel::class is discouraged.',
@@ -389,20 +368,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Filters/TokenAuth.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Call to deprecated function random_string():
-The type \'basic\', \'md5\', and \'sha1\' are deprecated. They are not cryptographically secure.',
-	'identifier' => 'function.deprecated',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Models/TokenLoginModel.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Call to deprecated function random_string():
-The type \'basic\', \'md5\', and \'sha1\' are deprecated. They are not cryptographically secure.',
-	'identifier' => 'function.deprecated',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Models/UserIdentityModel.php',
-];
-$ignoreErrors[] = [
 	'rawMessage' => 'Call to function model with CodeIgniter\\Shield\\Models\\GroupModel::class is discouraged.',
 	'identifier' => 'codeigniter.factoriesClassConstFetch',
 	'count' => 2,
@@ -461,6 +426,18 @@ $ignoreErrors[] = [
 	'identifier' => 'method.alreadyNarrowedType',
 	'count' => 8,
 	'path' => __DIR__ . '/tests/Authentication/Authenticators/SessionAuthenticatorTest.php',
+];
+$ignoreErrors[] = [
+	'rawMessage' => 'Parameter #1 $headers of method Tests\\Authentication\\Filters\\AbstractFilterTestCase::withHeaders() expects array<string, CodeIgniter\\HTTP\\Header|list<CodeIgniter\\HTTP\\Header>>, array{Authorization: non-falsy-string} given.',
+	'identifier' => 'argument.type',
+	'count' => 7,
+	'path' => __DIR__ . '/tests/Authentication/Filters/HmacFilterTest.php',
+];
+$ignoreErrors[] = [
+	'rawMessage' => 'Parameter #1 $headers of method Tests\\Authentication\\Filters\\JWTFilterTest::withHeaders() expects array<string, CodeIgniter\\HTTP\\Header|list<CodeIgniter\\HTTP\\Header>>, array{Authorization: non-falsy-string} given.',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/tests/Authentication/Filters/JWTFilterTest.php',
 ];
 $ignoreErrors[] = [
 	'rawMessage' => 'Implicit array creation is not allowed - variable $users might not exist.',

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -128,12 +128,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Authentication/Passwords/NothingPersonalValidator.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'PHPDoc tag @var with type string is not subtype of type uppercase-string.',
-	'identifier' => 'varTag.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Authentication/Passwords/PwnedValidator.php',
-];
-$ignoreErrors[] = [
 	'rawMessage' => 'Only booleans are allowed in &&, CodeIgniter\\Shield\\Entities\\User|null given on the right side.',
 	'identifier' => 'booleanAnd.rightNotBoolean',
 	'count' => 1,
@@ -425,6 +419,12 @@ $ignoreErrors[] = [
 	'rawMessage' => 'Call to method PHPUnit\\Framework\\Assert::assertInstanceOf() with \'CodeIgniter\\\\Shield\\\\Result\' and CodeIgniter\\Shield\\Result will always evaluate to true.',
 	'identifier' => 'method.alreadyNarrowedType',
 	'count' => 8,
+	'path' => __DIR__ . '/tests/Authentication/Authenticators/SessionAuthenticatorTest.php',
+];
+$ignoreErrors[] = [
+	'rawMessage' => 'Call to method setCookie() of internal class CodeIgniter\\Superglobals from outside its root namespace CodeIgniter.',
+	'identifier' => 'method.internalClass',
+	'count' => 1,
 	'path' => __DIR__ . '/tests/Authentication/Authenticators/SessionAuthenticatorTest.php',
 ];
 $ignoreErrors[] = [

--- a/rector.php
+++ b/rector.php
@@ -118,6 +118,7 @@ return static function (RectorConfig $rectorConfig): void {
         // Ignore tests that use CodeIgniter::CI_VERSION
         UnwrapFutureCompatibleIfPhpVersionRector::class => [
             __DIR__ . '/src/Test/MockInputOutput.php',
+            __DIR__ . '/tests/Authentication/Authenticators/SessionAuthenticatorTest.php',
             __DIR__ . '/tests/Commands/SetupTest.php',
             __DIR__ . '/tests/Commands/UserModelGeneratorTest.php',
             __DIR__ . '/tests/Controllers/LoginTest.php',

--- a/src/Authentication/Passwords/PwnedValidator.php
+++ b/src/Authentication/Passwords/PwnedValidator.php
@@ -44,8 +44,7 @@ class PwnedValidator extends BaseValidator implements ValidatorInterface
     {
         $hashedPword = strtoupper(sha1($password));
         $rangeHash   = substr($hashedPword, 0, 5);
-        /** @var string $searchHash */
-        $searchHash = substr($hashedPword, 5);
+        $searchHash  = substr($hashedPword, 5);
 
         try {
             $client = Services::curlrequest([

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace CodeIgniter\Shield\Models;
 
+use CodeIgniter\Database\RawSql;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Authenticators\AccessTokens;
 use CodeIgniter\Shield\Authentication\Authenticators\HmacSha256;
@@ -567,8 +568,8 @@ class UserIdentityModel extends BaseModel
      * Override the Model's `update()` method.
      * Throws an Exception when it fails.
      *
-     * @param array|int|string|null $id
-     * @param array|object|null     $row
+     * @param int|list<int|string>|RawSql|string|null $id
+     * @param array|object|null                       $row
      *
      * @return true if the update is successful
      *

--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace CodeIgniter\Shield\Models;
 
 use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Database\RawSql;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
@@ -416,8 +417,8 @@ class UserModel extends BaseModel
      * Override the BaseModel's `update()` method.
      * If you pass User object, also updates Email Identity.
      *
-     * @param array|int|string|null $id
-     * @param array|User            $row
+     * @param int|list<int|string>|RawSql|string|null $id
+     * @param array|User                              $row
      *
      * @return true if the update is successful
      *

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Authentication\Authenticators;
 
+use CodeIgniter\CodeIgniter;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Shield\Authentication\Authentication;
 use CodeIgniter\Shield\Authentication\AuthenticationException;
@@ -105,7 +106,11 @@ final class SessionAuthenticatorTest extends DatabaseTestCase
         // Set Cookie value for remember-me.
         $token      = $selector . ':' . $validator;
         $cookieName = $cookiePrefix . setting('Auth.sessionConfig')['rememberCookieName'];
-        service('superglobals')->setCookie($cookieName, $token);
+        if (version_compare(CodeIgniter::CI_VERSION, '4.7.0', '<')) {
+            $_COOKIE[$cookieName] = $token;
+        } else {
+            service('superglobals')->setCookie($cookieName, $token);
+        }
 
         $this->assertTrue($this->auth->loggedIn());
 

--- a/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
+++ b/tests/Authentication/Authenticators/SessionAuthenticatorTest.php
@@ -103,9 +103,9 @@ final class SessionAuthenticatorTest extends DatabaseTestCase
         $rememberModel->rememberUser($this->user, $selector, hash('sha256', $validator), $expires);
 
         // Set Cookie value for remember-me.
-        $token                = $selector . ':' . $validator;
-        $cookieName           = $cookiePrefix . setting('Auth.sessionConfig')['rememberCookieName'];
-        $_COOKIE[$cookieName] = $token;
+        $token      = $selector . ':' . $validator;
+        $cookieName = $cookiePrefix . setting('Auth.sessionConfig')['rememberCookieName'];
+        service('superglobals')->setCookie($cookieName, $token);
 
         $this->assertTrue($this->auth->loggedIn());
 

--- a/tests/Unit/UserModelTest.php
+++ b/tests/Unit/UserModelTest.php
@@ -154,6 +154,7 @@ final class UserModelTest extends DatabaseTestCase
         $user->username = 'bar';
         $user->email    = 'bar@bar.com';
         $user->active   = true;
+        $this->assertInstanceOf(User::class, $user);
 
         $users->save($user);
 
@@ -178,6 +179,7 @@ final class UserModelTest extends DatabaseTestCase
         $user->username = 'bar';
         $user->email    = 'bar@bar.com';
         $user->active   = true;
+        $this->assertInstanceOf(User::class, $user);
 
         $users->update($user->id, $user);
 
@@ -238,6 +240,7 @@ final class UserModelTest extends DatabaseTestCase
         $user = $users->findByCredentials(['email' => 'foo@bar.com']);
 
         $user->email = 'bar@bar.com';
+        $this->assertInstanceOf(User::class, $user);
 
         $users->save($user);
 
@@ -256,6 +259,7 @@ final class UserModelTest extends DatabaseTestCase
         $user = $users->findByCredentials(['email' => 'foo@bar.com']);
 
         $user->email = 'bar@bar.com';
+        $this->assertInstanceOf(User::class, $user);
 
         $users->update(null, $user);
 


### PR DESCRIPTION
This PR fixes PHPStan and Rector errors, resolves test-related issues with the `superglobals` service, and adds PHP 8.5 to the test suite.

PHPStan errors related to `withHeaders()` are temporary, and will be fixed in the upstream, see: https://github.com/codeigniter4/CodeIgniter4/pull/9932