### PR TITLE
chore: make docs copyright year automatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ nb-configuration.xml
 /.phpunit.*.cache
 
 /.php-cs-fixer.php
+/docs/assets/__pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2020-2022 Lonnie Ezell
-Copyright (c) 2022-2025 CodeIgniter Foundation
+Copyright (c) 2022-present CodeIgniter Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/assets/hooks.py
+++ b/docs/assets/hooks.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+def on_config(config, **kwargs):
+    config.copyright = config.copyright.format(year=datetime.now().year)
+    return config

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,10 @@ extra:
 site_url: https://shield.codeigniter.com/
 repo_url: https://github.com/codeigniter4/shield
 edit_uri: edit/develop/docs/
-copyright: Copyright &copy; 2023-2025 CodeIgniter Foundation.
+copyright: Copyright &copy; 2022-{year} CodeIgniter Foundation.
+
+hooks:
+  - docs/assets/hooks.py
 
 markdown_extensions:
   - pymdownx.superfences


### PR DESCRIPTION
**Description**
This PR automates the copyright year in the documentation so it always reflects the current year during build.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
