### PR TITLE
feat: withIdentities/withGroups/withPermissions now work with first()

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -143,6 +143,10 @@ class UserModel extends BaseModel
 
         $mappedUsers = $this->assignIdentities($data, $identities);
 
+        if ($data['singleton'] && ! isset($data['id'])) {
+            $data['id'] = $data['data']->id;
+        }
+
         $data['data'] = $data['singleton'] ? $mappedUsers[$data['id']] : $mappedUsers;
 
         return $data;
@@ -213,6 +217,10 @@ class UserModel extends BaseModel
 
         $mappedUsers = $this->assignProperties($data, $groups, 'groups');
 
+        if ($data['singleton'] && ! isset($data['id'])) {
+            $data['id'] = $data['data']->id;
+        }
+
         $data['data'] = $data['singleton'] ? $mappedUsers[$data['id']] : $mappedUsers;
 
         return $data;
@@ -245,6 +253,10 @@ class UserModel extends BaseModel
         $permissions = $permissionModel->getPermissionsByUserIds($userIds);
 
         $mappedUsers = $this->assignProperties($data, $permissions, 'permissions');
+
+        if ($data['singleton'] && ! isset($data['id'])) {
+            $data['id'] = $data['data']->id;
+        }
 
         $data['data'] = $data['singleton'] ? $mappedUsers[$data['id']] : $mappedUsers;
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -332,6 +332,40 @@ final class UserTest extends DatabaseTestCase
         );
     }
 
+    public function testModelFirstWithIdentities(): void
+    {
+        fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'password']);
+        fake(UserIdentityModel::class, ['user_id' => $this->user->id, 'type' => 'access_token']);
+
+        $user = model(UserModel::class)->where('active', 1)->withIdentities()->first();
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertCount(2, $user->identities);
+    }
+
+    public function testModelFirstWithGroups(): void
+    {
+        fake(GroupModel::class, ['user_id' => $this->user->id, 'group' => 'superadmin']);
+        fake(GroupModel::class, ['user_id' => $this->user->id, 'group' => 'admin']);
+
+        $user = model(UserModel::class)->where('active', 1)->withGroups()->first();
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertTrue($user->inGroup('admin'));
+    }
+
+    public function testModelFirstWithPermissions(): void
+    {
+        fake(PermissionModel::class, ['user_id' => $this->user->id, 'permission' => 'users.edit']);
+        fake(PermissionModel::class, ['user_id' => $this->user->id, 'permission' => 'users.delete']);
+
+        $user = model(UserModel::class)->where('active', 1)->withPermissions()->first();
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertTrue($user->hasPermission('users.delete'));
+        $this->assertFalse($user->hasPermission('users.add'));
+    }
+
     public function testLastLogin(): void
     {
         fake(


### PR DESCRIPTION
**Description**
This PR allows `first()` to work correctly in cooperation with `withIdentities()`, `withGroups()`, and `withPermissions()`.

Closes #1283

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
