### PR TITLE
feat: add `prefix` option for authentication routes

### DIFF
--- a/docs/customization/route_config.md
+++ b/docs/customization/route_config.md
@@ -31,10 +31,10 @@ This will generate the routes with the specified namespace instead of the defaul
 
 ## Change Prefix
 
-If you wish, you can prefix all defined authentication routes using the `prefix` option. This is particularly useful if you want all your routes to be under the same root (for example, `auth/login`, `auth/register`).
+If you wish, you can prefix all defined authentication routes using the `group` option. This is particularly useful if you want all your routes to be under the same root (for example, `auth/login`, `auth/register`).
 
 ```php
-service('auth')->routes($routes, ['prefix' => 'auth']);
+service('auth')->routes($routes, ['group' => 'auth']);
 ```
 
 This generates routes whose paths are all prefixed with `auth`.

--- a/docs/customization/route_config.md
+++ b/docs/customization/route_config.md
@@ -29,6 +29,16 @@ service('auth')->routes($routes, ['namespace' => '\App\Controllers\Auth']);
 
 This will generate the routes with the specified namespace instead of the default Shield namespace. This can be combined with any other options, like `except`.
 
+## Change Prefix
+
+If you wish, you can prefix all defined authentication routes using the `prefix` option. This is particularly useful if you want all your routes to be under the same root (for example, `auth/login`, `auth/register`).
+
+```php
+service('auth')->routes($routes, ['prefix' => 'auth']);
+```
+
+This generates routes whose paths are all prefixed with `auth`.
+
 ## Use Locale Routes
 
 You can use the `{locale}` placeholder in your routes

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -131,16 +131,16 @@ class Auth
      * Usage (in Config/Routes.php):
      *      - auth()->routes($routes);
      *      - auth()->routes($routes, ['except' => ['login', 'register']])
-     *      - auth()->routes($routes, ['prefix' => 'auth'])
+     *      - auth()->routes($routes, ['group' => 'auth'])
      */
     public function routes(RouteCollection &$routes, array $config = []): void
     {
         $authRoutes = config('AuthRoutes')->routes;
 
         $namespace = $config['namespace'] ?? 'CodeIgniter\Shield\Controllers';
-        $prefix    = $config['prefix'] ?? '/';
+        $group     = $config['group'] ?? '/';
 
-        $routes->group($prefix, ['namespace' => $namespace], static function (RouteCollection $routes) use ($authRoutes, $config): void {
+        $routes->group($group, ['namespace' => $namespace], static function (RouteCollection $routes) use ($authRoutes, $config): void {
             foreach ($authRoutes as $name => $row) {
                 if (! isset($config['except']) || ! in_array($name, $config['except'], true)) {
                     foreach ($row as $params) {

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -131,14 +131,16 @@ class Auth
      * Usage (in Config/Routes.php):
      *      - auth()->routes($routes);
      *      - auth()->routes($routes, ['except' => ['login', 'register']])
+     *      - auth()->routes($routes, ['prefix' => 'auth'])
      */
     public function routes(RouteCollection &$routes, array $config = []): void
     {
         $authRoutes = config('AuthRoutes')->routes;
 
         $namespace = $config['namespace'] ?? 'CodeIgniter\Shield\Controllers';
+        $prefix    = $config['prefix'] ?? '/';
 
-        $routes->group('/', ['namespace' => $namespace], static function (RouteCollection $routes) use ($authRoutes, $config): void {
+        $routes->group($prefix, ['namespace' => $namespace], static function (RouteCollection $routes) use ($authRoutes, $config): void {
             foreach ($authRoutes as $name => $row) {
                 if (! isset($config['except']) || ! in_array($name, $config['except'], true)) {
                     foreach ($row as $params) {

--- a/tests/Unit/AuthRoutesTest.php
+++ b/tests/Unit/AuthRoutesTest.php
@@ -86,7 +86,7 @@ final class AuthRoutesTest extends TestCase
         $collection = single_service('routes');
         $auth       = service('auth');
 
-        $auth->routes($collection, ['prefix' => 'auth']);
+        $auth->routes($collection, ['group' => 'auth']);
 
         if (version_compare(CodeIgniter::CI_VERSION, '4.5') >= 0) {
             $routes = $collection->getRoutes('GET');

--- a/tests/Unit/AuthRoutesTest.php
+++ b/tests/Unit/AuthRoutesTest.php
@@ -80,4 +80,24 @@ final class AuthRoutesTest extends TestCase
 
         $this->assertSame('\Auth\RegisterController::registerView', $routes['register']);
     }
+
+    public function testRoutesCustomPrefix(): void
+    {
+        $collection = single_service('routes');
+        $auth       = service('auth');
+
+        $auth->routes($collection, ['prefix' => 'auth']);
+
+        if (version_compare(CodeIgniter::CI_VERSION, '4.5') >= 0) {
+            $routes = $collection->getRoutes('GET');
+        } else {
+            $routes = $collection->getRoutes('get');
+        }
+
+        $this->assertArrayHasKey('auth/register', $routes);
+        $this->assertArrayHasKey('auth/login', $routes);
+        $this->assertArrayHasKey('auth/login/magic-link', $routes);
+        $this->assertArrayHasKey('auth/logout', $routes);
+        $this->assertArrayHasKey('auth/auth/a/show', $routes);
+    }
 }


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**

This pull request adds the ability to prefix all authentication route paths using a new `prefix` option in the `routes()` method.

- **New `prefix` option**: Allows you to define a common prefix for all authentication routes (default `/`)
- **Refactoring**: Replaces the hard-coded route group `‘/’` with a configurable `$prefix` variable

#### Benefits of this change

- **Increased flexibility** - Allows you to group auth routes under a single prefix (e.g., `auth/login`, `auth/register`)  
- **Better organization** - Facilitates the organization of routes in complex applications  
- **Consistency** - Complements the existing `namespace` and `except` options  
- **Backward compatible** - The default value `/` preserves the existing behavior  

#### Usage example

```php
// All routes will be prefixed with ‘auth’
service(‘auth’)->routes($routes, [‘prefix’ => ‘auth’]);

// Generates: auth/login, auth/register, auth/logout, etc.
```

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
