### PR TITLE
fix: require login actions for magic links

### DIFF
--- a/docs/references/magic_link_login.md
+++ b/docs/references/magic_link_login.md
@@ -35,6 +35,8 @@ Some apps or devices may try to be "too helpful" by automatically visiting links
 
 Magic Link logins allow a user that has forgotten their password to have an email sent with a unique, one-time login link. Once they've logged in you can decide how to respond. In some cases, you might want to redirect them to a special page where they must choose a new password. In other cases, you might simply want to display a one-time message prompting them to go to their account page and choose a new password.
 
+If a login auth action is configured, such as Email-based Two Factor Authentication, the user must complete that action before the magic link login is finished.
+
 ### Session Notification
 
 You can detect if a user has finished the magic link login by checking for a session value, `magicLogin`. If they have recently completed the flow, it will exist and have a value of `true`.

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -57,6 +57,10 @@ class Session implements AuthenticatorInterface
     private const STATE_PENDING   = 2; // 2FA or Activation required.
     private const STATE_LOGGED_IN = 3;
 
+    // Magic-link session markers
+    private const MAGIC_LOGIN_TEMP_DATA    = 'magicLogin';
+    private const PENDING_MAGIC_LINK_LOGIN = 'auth_action_magic_login';
+
     /**
      * Authenticated or authenticating (pending login) User
      */
@@ -270,6 +274,29 @@ class Session implements AuthenticatorInterface
 
         // a successful login
         Events::trigger('login', $user);
+
+        // Complete the magic-link notification after any pending login action.
+        $this->completeMagicLinkLoginIfPending();
+    }
+
+    /**
+     * Marks the pending login action as originating from a magic-link login.
+     */
+    public function markPendingLoginAsMagicLink(): void
+    {
+        $this->setSessionUserKey(self::PENDING_MAGIC_LINK_LOGIN, self::MAGIC_LOGIN_TEMP_DATA);
+    }
+
+    private function completeMagicLinkLoginIfPending(): void
+    {
+        if ($this->getSessionUserKey(self::PENDING_MAGIC_LINK_LOGIN) !== self::MAGIC_LOGIN_TEMP_DATA) {
+            return;
+        }
+
+        $this->removeSessionUserKey(self::PENDING_MAGIC_LINK_LOGIN);
+        session()->setTempdata(self::MAGIC_LOGIN_TEMP_DATA, true);
+
+        Events::trigger('magicLogin');
     }
 
     /**

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -57,9 +57,9 @@ class Session implements AuthenticatorInterface
     private const STATE_PENDING   = 2; // 2FA or Activation required.
     private const STATE_LOGGED_IN = 3;
 
-    // Magic-link session markers
-    private const MAGIC_LOGIN_TEMP_DATA    = 'magicLogin';
-    private const PENDING_MAGIC_LINK_LOGIN = 'auth_action_magic_login';
+    // Passwordless login session markers
+    private const MAGIC_LOGIN_TEMP_DATA = 'magicLogin';
+    private const PENDING_LOGIN_METHOD  = 'auth_action_login_method';
 
     /**
      * Authenticated or authenticating (pending login) User
@@ -275,28 +275,33 @@ class Session implements AuthenticatorInterface
         // a successful login
         Events::trigger('login', $user);
 
-        // Complete the magic-link notification after any pending login action.
-        $this->completeMagicLinkLoginIfPending();
+        // Complete the passwordless login notification after any pending login action.
+        $this->completePendingLoginMethod();
     }
 
     /**
-     * Marks the pending login action as originating from a magic-link login.
+     * Marks the pending login action as originating from a passwordless login method.
      */
-    public function markPendingLoginAsMagicLink(): void
+    public function setPendingLoginMethod(string $method): void
     {
-        $this->setSessionUserKey(self::PENDING_MAGIC_LINK_LOGIN, self::MAGIC_LOGIN_TEMP_DATA);
+        $this->setSessionUserKey(self::PENDING_LOGIN_METHOD, $method);
     }
 
-    private function completeMagicLinkLoginIfPending(): void
+    private function completePendingLoginMethod(): void
     {
-        if ($this->getSessionUserKey(self::PENDING_MAGIC_LINK_LOGIN) !== self::MAGIC_LOGIN_TEMP_DATA) {
+        $method = $this->getSessionUserKey(self::PENDING_LOGIN_METHOD);
+
+        if ($method === null) {
             return;
         }
 
-        $this->removeSessionUserKey(self::PENDING_MAGIC_LINK_LOGIN);
-        session()->setTempdata(self::MAGIC_LOGIN_TEMP_DATA, true);
+        $this->removeSessionUserKey(self::PENDING_LOGIN_METHOD);
 
-        Events::trigger('magicLogin');
+        if ($method === self::ID_TYPE_MAGIC_LINK) {
+            session()->setTempdata(self::MAGIC_LOGIN_TEMP_DATA, true);
+
+            Events::trigger('magicLogin');
+        }
     }
 
     /**

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -20,6 +20,7 @@ use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\I18n\Time;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
+use CodeIgniter\Shield\Entities\User;
 use CodeIgniter\Shield\Models\LoginModel;
 use CodeIgniter\Shield\Models\UserIdentityModel;
 use CodeIgniter\Shield\Models\UserModel;
@@ -205,7 +206,17 @@ class MagicLinkController extends BaseController
             return redirect()->route('auth-action-show')->with('error', lang('Auth.needActivate'));
         }
 
-        // Log the user in
+        $user = $this->provider->findById($identity->user_id);
+
+        // Start any login action that has been defined.
+        if ($user instanceof User && $authenticator->startUpAction('login', $user) && $authenticator->hasAction($user->id)) {
+            $this->recordLoginAttempt($identifier, true, $user->id);
+            $authenticator->markPendingLoginAsMagicLink();
+
+            return redirect()->route('auth-action-show');
+        }
+
+        // Log the user in.
         $authenticator->loginById($identity->user_id);
 
         $user = $authenticator->getUser();

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -211,10 +211,12 @@ class MagicLinkController extends BaseController
         // Start any login action that has been defined.
         if ($user instanceof User && $authenticator->startUpAction('login', $user) && $authenticator->hasAction($user->id)) {
             $this->recordLoginAttempt($identifier, true, $user->id);
-            $authenticator->markPendingLoginAsMagicLink();
+            $authenticator->setPendingLoginMethod(Session::ID_TYPE_MAGIC_LINK);
 
             return redirect()->route('auth-action-show');
         }
+
+        $authenticator->setPendingLoginMethod(Session::ID_TYPE_MAGIC_LINK);
 
         // Log the user in.
         $authenticator->loginById($identity->user_id);
@@ -222,12 +224,6 @@ class MagicLinkController extends BaseController
         $user = $authenticator->getUser();
 
         $this->recordLoginAttempt($identifier, true, $user->id);
-
-        // Give the developer a way to know the user
-        // logged in via a magic link.
-        session()->setTempdata('magicLogin', true);
-
-        Events::trigger('magicLogin');
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());

--- a/tests/Controllers/MagicLinkTest.php
+++ b/tests/Controllers/MagicLinkTest.php
@@ -16,6 +16,7 @@ namespace Tests\Controllers;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\I18n\Time;
+use CodeIgniter\Shield\Authentication\Actions\Email2FA;
 use CodeIgniter\Shield\Authentication\Actions\EmailActivator;
 use CodeIgniter\Shield\Authentication\Authenticators\Session;
 use CodeIgniter\Shield\Entities\User;
@@ -24,6 +25,7 @@ use CodeIgniter\Shield\Models\UserModel;
 use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
 use Config\Services;
+use Tests\Support\AdminEmail2FA;
 use Tests\Support\AdminEmailActivator;
 use Tests\Support\FakeUser;
 use Tests\Support\TestCase;
@@ -175,6 +177,85 @@ final class MagicLinkTest extends TestCase
         $this->assertFalse(auth()->loggedIn());
     }
 
+    public function testMagicLinkVerifyStartsLoginAction(): void
+    {
+        setting('Auth.actions', ['login' => Email2FA::class, 'register' => null]);
+
+        /** @var User $user */
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+
+        $this->insertMagicLinkIdentity($user, 'validtoken123');
+
+        $result = $this->get(route_to('verify-magic-link') . '?token=validtoken123');
+
+        $result->assertRedirect();
+        $this->assertSame(site_url('/auth/a/show'), $result->getRedirectUrl());
+        $this->assertPendingLoginAction($user, Email2FA::class);
+        $this->seeInDatabase(config('Auth')->tables['identities'], [
+            'user_id' => $user->id,
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
+            'name'    => 'login',
+            'extra'   => lang('Auth.need2FA'),
+        ]);
+        $result->assertSessionMissing('magicLogin');
+        $this->assertFalse(auth()->loggedIn());
+
+        $identity = model(UserIdentityModel::class)->getIdentityByType($user, Session::ID_TYPE_EMAIL_2FA);
+        $this->assertNotNull($identity);
+
+        $result = $this->withSession()->post('/auth/a/verify', [
+            'token' => $identity->secret,
+        ]);
+
+        $result->assertRedirectTo(config('Auth')->loginRedirect());
+        $result->assertSessionHas('user', ['id' => $user->id]);
+        $result->assertSessionHas('magicLogin', true);
+        $this->assertTrue(auth()->loggedIn());
+    }
+
+    public function testMagicLinkVerifyStartsConditionalLoginActionWhenItApplies(): void
+    {
+        setting('Auth.actions', ['login' => AdminEmail2FA::class, 'register' => null]);
+
+        /** @var User $user */
+        $user = fake(UserModel::class);
+        $user->addGroup('admin');
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+
+        $this->insertMagicLinkIdentity($user, 'validtoken123');
+
+        $result = $this->get(route_to('verify-magic-link') . '?token=validtoken123');
+
+        $result->assertRedirect();
+        $this->assertSame(site_url('/auth/a/show'), $result->getRedirectUrl());
+        $this->assertPendingLoginAction($user, AdminEmail2FA::class);
+        $result->assertSessionMissing('magicLogin');
+        $this->assertFalse(auth()->loggedIn());
+    }
+
+    public function testMagicLinkVerifySkipsConditionalLoginActionWhenItDoesNotApply(): void
+    {
+        setting('Auth.actions', ['login' => AdminEmail2FA::class, 'register' => null]);
+
+        /** @var User $user */
+        $user = fake(UserModel::class);
+        $user->createEmailIdentity(['email' => 'foo@example.com', 'password' => 'secret123']);
+
+        $this->insertMagicLinkIdentity($user, 'validtoken123');
+
+        $result = $this->get(route_to('verify-magic-link') . '?token=validtoken123');
+
+        $result->assertRedirectTo(config('Auth')->loginRedirect());
+        $result->assertSessionHas('user', ['id' => $user->id]);
+        $result->assertSessionMissing('auth_action');
+        $this->assertTrue(auth()->loggedIn());
+        $this->dontSeeInDatabase(config('Auth')->tables['identities'], [
+            'user_id' => $user->id,
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
+        ]);
+    }
+
     public function testBackToLoginLinkOnPage(): void
     {
         $result = $this->get('/login/magic-link');
@@ -251,5 +332,27 @@ final class MagicLinkTest extends TestCase
         service('superglobals')->setServer('HTTP_USER_AGENT', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
 
         $this->get(route_to('verify-magic-link') . '?token=validtoken123');
+    }
+
+    private function insertMagicLinkIdentity(User $user, string $token): void
+    {
+        model(UserIdentityModel::class)->insert([
+            'user_id' => $user->id,
+            'type'    => Session::ID_TYPE_MAGIC_LINK,
+            'secret'  => $token,
+            'expires' => Time::now()->addMinutes(60),
+        ]);
+    }
+
+    /**
+     * @param class-string $action
+     */
+    private function assertPendingLoginAction(User $user, string $action): void
+    {
+        $sessionUser = session('user');
+        $this->assertIsArray($sessionUser);
+        $this->assertSame($user->id, $sessionUser['id'] ?? null);
+        $this->assertSame($action, $sessionUser['auth_action'] ?? null);
+        $this->assertSame(lang('Auth.need2FA'), $sessionUser['auth_action_message'] ?? null);
     }
 }

--- a/tests/Controllers/MagicLinkTest.php
+++ b/tests/Controllers/MagicLinkTest.php
@@ -196,7 +196,6 @@ final class MagicLinkTest extends TestCase
             'user_id' => $user->id,
             'type'    => Session::ID_TYPE_EMAIL_2FA,
             'name'    => 'login',
-            'extra'   => lang('Auth.need2FA'),
         ]);
         $result->assertSessionMissing('magicLogin');
         $this->assertFalse(auth()->loggedIn());


### PR DESCRIPTION
**Description**

This fixes a gap in the magic-link login flow.

Password login already respects configured login auth actions, such as Email-based 2FA. Magic-link login, however, could finish immediately after the token was verified. So an app could have 2FA enabled for normal login, but magic-link login would not go through that same action flow.

With this PR, magic-link login now starts the configured login action when one applies to the user. If an action is required, the user is sent to the normal auth-action screen first, and the magic-link login is only treated as complete after that action passes.

The existing `magicLogin` session value and `magicLogin` event still work. They are just delayed until the login action is completed, so they continue to mean "the user has finished logging in with a magic link".

I also added a short note to the docs, plus tests for normal and conditional login actions.

**Checklist:**

- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide