### PR TITLE
chore(phpstan): use unsealed array shapes for credentials

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -68,13 +68,13 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Authentication/Authenticators/JWT.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{token?: string}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
+	'rawMessage' => 'Parameter #1 $credentials (array{token?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/JWT.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{token?: string}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
+	'rawMessage' => 'Parameter #1 $credentials (array{token?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/JWT.php',
@@ -110,13 +110,13 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Authentication/Authenticators/Session.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
+	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/Session.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
+	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/Session.php',

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -25,17 +25,17 @@ use InvalidArgumentException;
 /**
  * Facade for Authentication
  *
- * @method Result    attempt(array{email?: string, username?: string, password?: string, token?: string} $credentials)
- * @method Result    check(array{email?: string, username?: string, password?: string, token?: string} $credentials)
- * @method bool      checkAction(string $token, string $type)                                                          [Session]
- * @method void      forget(?User $user = null)                                                                        [Session]
+ * @method Result    attempt(array{email?: string, username?: string, password?: string, token?: string, ...} $credentials)
+ * @method Result    check(array{email?: string, username?: string, password?: string, token?: string, ...} $credentials)
+ * @method bool      checkAction(string $token, string $type)                                                               [Session]
+ * @method void      forget(?User $user = null)                                                                             [Session]
  * @method User|null getUser()
  * @method bool      loggedIn()
  * @method bool      login(User $user)
  * @method void      loginById($userId)
  * @method bool      logout()
  * @method void      recordActiveDate()
- * @method $this     remember(bool $shouldRemember = true)                                                             [Session]
+ * @method $this     remember(bool $shouldRemember = true)                                                                  [Session]
  */
 class Auth
 {

--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -64,7 +64,7 @@ class JWT implements AuthenticatorInterface
      * Attempts to authenticate a user with the given $credentials.
      * Logs the user in with a successful check.
      *
-     * @param array{token?: string} $credentials
+     * @param array{token?: string, ...} $credentials
      */
     public function attempt(array $credentials): Result
     {
@@ -141,7 +141,7 @@ class JWT implements AuthenticatorInterface
      * In this case, $credentials has only a single valid value: token,
      * which is the plain text token to return.
      *
-     * @param array{token?: string} $credentials
+     * @param array{token?: string, ...} $credentials
      */
     public function check(array $credentials): Result
     {

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -122,7 +122,7 @@ class Session implements AuthenticatorInterface
      * Attempts to authenticate a user with the given $credentials.
      * Logs the user in with a successful check.
      *
-     * @phpstan-param array{email?: string, username?: string, password?: string} $credentials
+     * @phpstan-param array{email?: string, username?: string, password?: string, ...} $credentials
      */
     public function attempt(array $credentials): Result
     {
@@ -315,7 +315,7 @@ class Session implements AuthenticatorInterface
      * Checks a user's $credentials to see if they match an
      * existing user.
      *
-     * @phpstan-param array{email?: string, username?: string, password?: string} $credentials
+     * @phpstan-param array{email?: string, username?: string, password?: string, ...} $credentials
      */
     public function check(array $credentials): Result
     {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
This PR fixes PHPStan errors related to extra keys being passed to the `$credentials` array in Authenticators.

```console
Error: Parameter #1 $credentials of method CodeIgniter\Shield\Authentication\Authenticators\Session::attempt() expects array{email?: string, username?: string, password?: string}, non-empty-array given.
Error: Parameter #1 $credentials of method CodeIgniter\Shield\Authentication\Authenticators\Session::attempt() expects array{email?: string, username?: string, password?: string}, array{status: 'abcde', password: 'secret123'} given.
Error: Parameter #1 $credentials of method CodeIgniter\Shield\Authentication\Authenticators\Session::attempt() expects array{email?: string, username?: string, password?: string}, array{status: '12345', password: 'secret123'} given.
 ------ ---------------------------------------------------------------------- 
  Line   src/Controllers/LoginController.php                                   
 ------ ---------------------------------------------------------------------- 
  71     Parameter #1 $credentials of method                                   
         CodeIgniter\Shield\Authentication\Authenticators\Session::attempt()   
         expects array{email?: string, username?: string, password?: string},  
         non-empty-array given.                                                
         🪪  argument.type                                                     
         💡  Sealed array shape can only accept a constant array. Extra keys   
         are not allowed.                                                      
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   tests/Authentication/Authenticators/SessionAuthenticatorTest.php       
 ------ ----------------------------------------------------------------------- 
  478    Parameter #1 $credentials of method                                    
         CodeIgniter\Shield\Authentication\Authenticators\Session::attempt()    
         expects array{email?: string, username?: string, password?: string},   
         array{status: 'abcde', password: 'secret123'} given.                   
         🪪  argument.type                                                      
         💡  Sealed array shape does not accept array with extra key 'status'.  
  482    Parameter #1 $credentials of method                                    
         CodeIgniter\Shield\Authentication\Authenticators\Session::attempt()    
         expects array{email?: string, username?: string, password?: string},   
         array{status: '12345', password: 'secret123'} given.                   
         🪪  argument.type                                                      
         💡  Sealed array shape does not accept array with extra key 'status'.  
 ------ ----------------------------------------------------------------------- 

Error:  [ERROR] Found 3 errors                                                         
```


Since Shield natively allows logging in with custom columns (via Auth.validFields) instead of just `email `or `username`, the strictly sealed array shapes in the DocBlocks were causing static analysis to fail when custom keys (like phone) were passed.

To solve this while preserving IDE autocomplete, I used PHPStan’s unsealed array shape feature by appending `... `to the array definitions. This tells PHPStan to expect the defined keys but also safely allow extra custom columns without throwing the Extra keys are not allowed error.

see : 
https://github.com/codeigniter4/shield/actions/runs/26674339169/job/78623302872
ref:
https://phpstan.org/blog/phpstan-2-2-unsealed-array-shapes-safer-array-keys

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
