### PR TITLE
chore(phpstan): restrict unsealed credential keys to string keys

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -68,13 +68,13 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Authentication/Authenticators/JWT.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{token?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
+	'rawMessage' => 'Parameter #1 $credentials (array{token?: string}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/JWT.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{token?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
+	'rawMessage' => 'Parameter #1 $credentials (array{token?: string}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\JWT::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/JWT.php',
@@ -110,13 +110,13 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Authentication/Authenticators/Session.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
+	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string, ...<string, string>}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::attempt() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::attempt()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/Session.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string, ...}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
+	'rawMessage' => 'Parameter #1 $credentials (array{email?: string, username?: string, password?: string, ...<string, string>}) of method CodeIgniter\\Shield\\Authentication\\Authenticators\\Session::check() should be contravariant with parameter $credentials (array) of method CodeIgniter\\Shield\\Authentication\\AuthenticatorInterface::check()',
 	'identifier' => 'method.childParameterType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Authentication/Authenticators/Session.php',

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -25,17 +25,17 @@ use InvalidArgumentException;
 /**
  * Facade for Authentication
  *
- * @method Result    attempt(array{email?: string, username?: string, password?: string, token?: string, ...} $credentials)
- * @method Result    check(array{email?: string, username?: string, password?: string, token?: string, ...} $credentials)
- * @method bool      checkAction(string $token, string $type)                                                               [Session]
- * @method void      forget(?User $user = null)                                                                             [Session]
+ * @method Result    attempt(array{email?: string, username?: string, password?: string, token?: string, ...<string, string>} $credentials)
+ * @method Result    check(array{email?: string, username?: string, password?: string, token?: string, ...<string, string>} $credentials)
+ * @method bool      checkAction(string $token, string $type)                                                                               [Session]
+ * @method void      forget(?User $user = null)                                                                                             [Session]
  * @method User|null getUser()
  * @method bool      loggedIn()
  * @method bool      login(User $user)
  * @method void      loginById($userId)
  * @method bool      logout()
  * @method void      recordActiveDate()
- * @method $this     remember(bool $shouldRemember = true)                                                                  [Session]
+ * @method $this     remember(bool $shouldRemember = true)                                                                                  [Session]
  */
 class Auth
 {

--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -64,7 +64,7 @@ class JWT implements AuthenticatorInterface
      * Attempts to authenticate a user with the given $credentials.
      * Logs the user in with a successful check.
      *
-     * @param array{token?: string, ...} $credentials
+     * @param array{token?: string} $credentials
      */
     public function attempt(array $credentials): Result
     {
@@ -141,7 +141,7 @@ class JWT implements AuthenticatorInterface
      * In this case, $credentials has only a single valid value: token,
      * which is the plain text token to return.
      *
-     * @param array{token?: string, ...} $credentials
+     * @param array{token?: string} $credentials
      */
     public function check(array $credentials): Result
     {

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -122,7 +122,7 @@ class Session implements AuthenticatorInterface
      * Attempts to authenticate a user with the given $credentials.
      * Logs the user in with a successful check.
      *
-     * @phpstan-param array{email?: string, username?: string, password?: string, ...} $credentials
+     * @phpstan-param array{email?: string, username?: string, password?: string, ...<string, string>} $credentials
      */
     public function attempt(array $credentials): Result
     {
@@ -315,7 +315,7 @@ class Session implements AuthenticatorInterface
      * Checks a user's $credentials to see if they match an
      * existing user.
      *
-     * @phpstan-param array{email?: string, username?: string, password?: string, ...} $credentials
+     * @phpstan-param array{email?: string, username?: string, password?: string, ...<string, string>} $credentials
      */
     public function check(array $credentials): Result
     {


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
This PR follows up on the previous change(PR #1330 ) that introduced PHPStan unsealed array shapes for authenticator credentials.

In the earlier PR, bare `...` was used in array shapes. However, in PHPStan this expands to `...<array-key, mixed>`, which allows both `string` and `int` keys. That is broader than intended for Shield credentials, because custom login fields are expected to be `string-keyed` fields.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
