### PR TITLE
docs: fix correct typo in `updateAcessTokenExpiration()`

### DIFF
--- a/docs/references/authentication/tokens.md
+++ b/docs/references/authentication/tokens.md
@@ -153,11 +153,11 @@ $token = $this->user->generateAccessToken('foo', ['foo.bar'], $expiresAt);
 
 // Expiration date = 2024-11-15 00:00:00
 $expiresAt = Time::parse('2024-11-15 00:00:00');
-$user->updateAcessTokenExpiration($token->id, $expiresAt);
+$user->updateAccessTokenExpiration($token->id, $expiresAt);
 
 // Or Expiration date = 1 month + 15 days into the future
 $expiresAt = Time::now()->addMonths(1)->addDays(15);
-$user->updateAcessTokenExpiration($token->id, $expiresAt);
+$user->updateAccessTokenExpiration($token->id, $expiresAt);
 
 // Remove the expiration date
 $user->removeAccessTokenExpiration($token->id);


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Renamed the method `updateAcessTokenExpiration()` to `updateAccessTokenExpiration()` to fix a spelling mistake in the method name.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [ ] Conforms to style guide
