### PR TITLE
chore: bump minimum PHP version to 8.2

### DIFF
--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           tools: composer, phive, phpunit
           extensions: intl, json, mbstring, gd, xdebug, xml, sqlite3
           coverage: xdebug

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "slack": "https://codeigniterchat.slack.com"
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "codeigniter4/settings": "^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
**Description**
This PR raises the minimum supported PHP version for the next release to 8.2.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
