### PR TITLE
test: fix FirebaseAdapter encode test for unsupported algorithm

### DIFF
--- a/tests/Unit/Authentication/JWT/Adapters/FirebaseAdapaterTest.php
+++ b/tests/Unit/Authentication/JWT/Adapters/FirebaseAdapaterTest.php
@@ -141,7 +141,7 @@ final class FirebaseAdapaterTest extends TestCase
         // Set unsupported algorithm.
         /** @var AuthJWT $config */
         $config                            = config('AuthJWT');
-        $config->keys['default'][0]['alg'] = 'PS256';
+        $config->keys['default'][0]['alg'] = 'Unsupported';
 
         $adapter = new FirebaseAdapter();
 


### PR DESCRIPTION
**Description**
This PR fixes the `FirebaseAdapter` encode test, which broke because `firebase/php-jwt` now recognizes PS256 as supported (it just needs phpseclib).

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
