### PR TITLE
chore: add Pyrameter test-shape enforcement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@
 /phpstan-baseline.php   export-ignore
 /phpstan.neon.dist      export-ignore
 /phpunit.xml.dist       export-ignore
+/pyrameter.php          export-ignore
 /psalm_autoload.php     export-ignore
 /psalm-baseline.xml     export-ignore
 /psalm.xml              export-ignore

--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Test with PHPUnit
-        run: vendor/bin/phpunit --no-coverage --no-extensions --testsuite lang
+        run: PYRAMETER_DISABLED=1 vendor/bin/phpunit --no-coverage --testsuite lang
         env:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled

--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Test with PHPUnit
-        run: vendor/bin/phpunit --no-coverage --testsuite lang
+        run: vendor/bin/phpunit --no-coverage --testsuite --no-extensions lang
         env:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled

--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Test with PHPUnit
-        run: vendor/bin/phpunit --no-coverage --testsuite --no-extensions lang
+        run: vendor/bin/phpunit --no-coverage --no-extensions --testsuite lang
         env:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled

--- a/.github/workflows/phpunit-lang.yml
+++ b/.github/workflows/phpunit-lang.yml
@@ -59,7 +59,8 @@ jobs:
           fi
 
       - name: Test with PHPUnit
-        run: PYRAMETER_DISABLED=1 vendor/bin/phpunit --no-coverage --testsuite lang
+        run: vendor/bin/phpunit --no-coverage --testsuite lang
         env:
           TERM: xterm-256color
           TACHYCARDIA_MONITOR_GA: enabled
+          PYRAMETER_DISABLED: 1

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "codeigniter4/settings": "^2.1"
     },
     "require-dev": {
+        "boundwize/pyrameter": "^0.5",
         "boundwize/structarmed": "0.15.2",
         "codeigniter/phpstan-codeigniter": "^2.0",
         "codeigniter4/devkit": "^1.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,6 +34,7 @@
             <parameter name="report-count" value="30"/>
             <parameter name="format" value="table"/>
         </bootstrap>
+        <bootstrap class="Boundwize\Pyrameter\Extension"/>
     </extensions>
     <logging>
         <testdoxHtml outputFile="build/phpunit/testdox.html"/>

--- a/pyrameter.php
+++ b/pyrameter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of CodeIgniter Shield.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use Boundwize\Pyrameter\Config\PyrameterConfig;
+use Boundwize\Pyrameter\TestKind;
+use CodeIgniter\Test\FeatureTestTrait;
+use Tests\Support\DatabaseTestCase;
+
+return PyrameterConfig::defaults()
+    ->usesClass(
+        DatabaseTestCase::class,
+        TestKind::Integration,
+        unless: [FeatureTestTrait::class],
+    )
+    ->usesClass(
+        FeatureTestTrait::class,
+        TestKind::Functional,
+    )
+    ->targetShape(
+        unit: ['min' => 40],
+        functional: ['max' => 10],
+        integration: ['max' => 50],
+        e2e: ['max' => 0],
+    )
+    ->failOnViolation();

--- a/pyrameter.php
+++ b/pyrameter.php
@@ -13,23 +13,38 @@ declare(strict_types=1);
 
 use Boundwize\Pyrameter\Config\PyrameterConfig;
 use Boundwize\Pyrameter\TestKind;
+use CodeIgniter\Test\DatabaseTestTrait;
 use CodeIgniter\Test\FeatureTestTrait;
+use Tests\Authentication\Filters\AbstractFilterTestCase;
 use Tests\Support\DatabaseTestCase;
 
-return PyrameterConfig::defaults()
+return PyrameterConfig::create()
+    ->usesClass(
+        DatabaseTestTrait::class,
+        TestKind::Integration,
+        unless: [FeatureTestTrait::class, AbstractFilterTestCase::class],
+    )
     ->usesClass(
         DatabaseTestCase::class,
         TestKind::Integration,
-        unless: [FeatureTestTrait::class],
+        unless: [FeatureTestTrait::class, AbstractFilterTestCase::class],
     )
     ->usesClass(
         FeatureTestTrait::class,
         TestKind::Functional,
     )
-    ->targetShape(
-        unit: ['min' => 40],
-        functional: ['max' => 10],
-        integration: ['max' => 50],
-        e2e: ['max' => 0],
+    ->usesClass(
+        AbstractFilterTestCase::class,
+        TestKind::Functional,
     )
-    ->failOnViolation();
+    ->usesFunction('copy', TestKind::Integration)
+    ->usesFunction('file_get_contents', TestKind::Integration)
+    ->usesFunction('getcwd', TestKind::Integration)
+    ->usesFunction('is_file', TestKind::Integration)
+    ->usesFunction('unlink', TestKind::Integration)
+    ->targetShape(
+        unit: ['min' => 44],
+        functional: ['max' => 16],
+        integration: ['max' => 40],
+        e2e: ['max' => 0],
+    );

--- a/pyrameter.php
+++ b/pyrameter.php
@@ -43,8 +43,9 @@ return PyrameterConfig::create()
     ->usesFunction('is_file', TestKind::Integration)
     ->usesFunction('unlink', TestKind::Integration)
     ->targetShape(
-        unit: ['min' => 44],
-        functional: ['max' => 16],
-        integration: ['max' => 40],
+        unit: ['min' => 40],
+        functional: ['max' => 20],
+        integration: ['max' => 50],
         e2e: ['max' => 0],
-    );
+    )
+    ->failOnViolation();


### PR DESCRIPTION
<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**

This PR adds `Pyrameter` phpunit extension:

https://github.com/boundwize/pyrameter

Pyrameter classifies executed tests as unit, functional, integration, or e2e based on the code they use, then compares the totals with your target shape.

Per current tests, here the target limit defined:

Defines target limits:
  - Unit: minimum 40%
  - Functional: maximum 10%
  - Integration: maximum 50%
  - End-to-end: maximum 0%

and get output

```
=========
Pyrameter
=========

Shape:  Inverted Pyramid
Result: Passed ✓

        ▀▀▀▀▀▀▀▀▀▀▀▀▀  Integration  ✓
          ▀▀▀▀▀▀▀▀▀  Unit           ✓
            ▀▀▀▀▀  Functional       ✓
              ▼  E2E                ✓

+=============+=======+========+============+
|    KIND     | TESTS | ACTUAL |   TARGET   |
+=============+=======+========+============+
| Unit        |   277 |  44.8% | >= 40.0% ✓ |
+-------------+-------+--------+------------+
| Functional  |    38 |   6.2% | <= 10.0% ✓ |
+-------------+-------+--------+------------+
| Integration |   303 |  49.0% | <= 50.0% ✓ |
+-------------+-------+--------+------------+
| E2E         |     0 |   0.0% | <=  0.0% ✓ |
+-------------+-------+--------+------------+

Total: 618 tests

Your heavier tests outnumber your unit tests.
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
