### PR TITLE
chore: Bump to StructArmed 0.15 and enable MustBeFinalRule on tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "codeigniter4/settings": "^2.1"
     },
     "require-dev": {
-        "boundwize/structarmed": "0.14.16",
+        "boundwize/structarmed": "0.15.1",
         "codeigniter/phpstan-codeigniter": "^2.0",
         "codeigniter4/devkit": "^1.3",
         "codeigniter4/framework": ">=4.3.5 <4.5.0 || ^4.5.1",

--- a/structarmed.php
+++ b/structarmed.php
@@ -9,7 +9,7 @@ use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 return Architecture::define()
     ->rule(
-        'source.must_be_final',
+        'tests.must_be_final',
         new MustBeFinalRule(layer: 'tests'),
     )
     ->skip([

--- a/structarmed.php
+++ b/structarmed.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 use Boundwize\StructArmed\Architecture;
 use Boundwize\StructArmed\Preset\Preset;
 use Boundwize\StructArmed\Preset\Presets\Psr4Preset;
+use Boundwize\StructArmed\Rule\Rules\Class_\MustBeFinalRule;
 
 return Architecture::define()
+    ->rule(
+        'source.must_be_final',
+        new MustBeFinalRule(layer: 'tests'),
+    )
     ->skip([
         Psr4Preset::CLASSES_MUST_MATCH_COMPOSER => [
             __DIR__ . '/src/Database/Migrations',
@@ -14,6 +19,7 @@ return Architecture::define()
     ])
     ->cacheDirectory(is_dir('/tmp') ? '/tmp/structarmed' : null)
     ->withPreset(Preset::PSR4())
+    ->layer('tests', __DIR__ . '/tests')
     ->layerPattern('Model', '/^CodeIgniter\\\\Shield\\\\.*Model$/')
     ->layerPattern('Controller', '/^CodeIgniter\\\\Shield\\\\Controllers\\\\.*$/')
     ->layerPattern('Config', '/^CodeIgniter\\\\Shield\\\\Config\\\\.*$/', '/^.*Services$/')

--- a/tests/_support/Config/Registrar.php
+++ b/tests/_support/Config/Registrar.php
@@ -18,7 +18,7 @@ namespace Tests\Support\Config;
  *
  * Provides a basic registrar class for testing BaseConfig registration functions.
  */
-class Registrar
+final class Registrar
 {
     /**
      * DB config array for testing purposes.
@@ -27,7 +27,7 @@ class Registrar
      *
      * @psalm-suppress RedundantCondition
      */
-    protected static $dbConfig = [
+    private static $dbConfig = [
         'MySQLi' => [
             'DSN'      => '',
             'hostname' => '127.0.0.1',


### PR DESCRIPTION
**Description**

StructArmed 0.15.0 introduce `ExtendedClassAwareRuleInterface` that makes `MustBeFinalRule` safely be used to skip if there is class that extend target class.

This PR bump StructArmed to `0.15.1` and apply the `MustBeFinalRule` with single command to fix on `tests` directory.

```bash
vendor/bin/structarmed analyze --fix
```

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [x] Conforms to style guide
